### PR TITLE
Reconstitution deep copy fix

### DIFF
--- a/internal/reconstitution/api.go
+++ b/internal/reconstitution/api.go
@@ -37,12 +37,7 @@ type Resource struct {
 
 	Manifest          string
 	ReconcileInterval time.Duration
-	object            *unstructured.Unstructured
-}
-
-func (r *Resource) Object() *unstructured.Unstructured {
-	// don't allow callers to mutate the original
-	return r.object.DeepCopy()
+	Object            *unstructured.Unstructured
 }
 
 // ResourceRef refers to a specific synthesized resource.

--- a/internal/reconstitution/cache_test.go
+++ b/internal/reconstitution/cache_test.go
@@ -44,8 +44,8 @@ func TestCacheBasics(t *testing.T) {
 		resource, exists := c.Get(ctx, &expectedReqs[0].ResourceRef, synth.ObservedCompositionGeneration)
 		require.True(t, exists)
 		assert.NotEmpty(t, resource.Manifest)
-		assert.Equal(t, "ConfigMap", resource.Object().GetKind())
-		assert.Equal(t, "slice-0-resource-0", resource.Object().GetName())
+		assert.Equal(t, "ConfigMap", resource.Object.GetKind())
+		assert.Equal(t, "slice-0-resource-0", resource.Object.GetName())
 
 		// negative
 		_, exists = c.Get(ctx, &expectedReqs[0].ResourceRef, 123)
@@ -106,8 +106,8 @@ func TestCacheSecret(t *testing.T) {
 	resource, exists := c.Get(ctx, &expectedReqs[0].ResourceRef, synth.ObservedCompositionGeneration)
 	require.True(t, exists)
 	assert.NotEmpty(t, resource.Manifest)
-	assert.Equal(t, "ConfigMap", resource.Object().GetKind())
-	assert.Equal(t, "slice-0-resource-0", resource.Object().GetName())
+	assert.Equal(t, "ConfigMap", resource.Object.GetKind())
+	assert.Equal(t, "slice-0-resource-0", resource.Object.GetName())
 }
 
 func TestCacheInvalidManifest(t *testing.T) {

--- a/internal/reconstitution/manager_test.go
+++ b/internal/reconstitution/manager_test.go
@@ -57,7 +57,7 @@ func TestManagerBasics(t *testing.T) {
 }
 
 type testReconciler struct {
-	mgr          Manager
+	mgr          *Manager
 	lastResource atomic.Pointer[Resource]
 }
 


### PR DESCRIPTION
This PR prevents mutation of objects in the reconstitution cache and makes a few small refactors.