### PR TITLE
Remove swap logic (for now)

### DIFF
--- a/internal/controllers/synthesis/lifecycle.go
+++ b/internal/controllers/synthesis/lifecycle.go
@@ -94,7 +94,6 @@ func (c *podLifecycleController) Reconcile(ctx context.Context, req ctrl.Request
 
 	// No need to create a pod if everything is in sync
 	if comp.Status.CurrentState != nil && comp.Status.CurrentState.ResourceSliceCount != nil {
-		logger.V(1).Info("synthesis is complete - skipping creation")
 		return ctrl.Result{}, nil
 	}
 
@@ -186,12 +185,9 @@ func (c *podLifecycleController) podStatusTerminal(pod *corev1.Pod) (string, boo
 }
 
 func swapStates(syn *apiv1.Synthesizer, comp *apiv1.Composition) {
-	// Only swap current->previous when the current synthesis has completed
-	// This avoids losing the prior state during rapid updates to the composition
-	resourceSliceCountSet := comp.Status.CurrentState != nil && comp.Status.CurrentState.ResourceSliceCount != nil
-	if resourceSliceCountSet {
-		comp.Status.PreviousState = comp.Status.CurrentState
-	}
+	// TODO: Block swapping prev->current if the any resources present in prev but absent in current have not yet been reconciled
+	// This will ensure that we don't orphan resources
+	comp.Status.PreviousState = comp.Status.CurrentState
 	comp.Status.CurrentState = &apiv1.Synthesis{
 		ObservedCompositionGeneration: comp.Generation,
 	}

--- a/internal/controllers/synthesis/status.go
+++ b/internal/controllers/synthesis/status.go
@@ -78,7 +78,7 @@ func (c *statusController) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		if err := c.client.Status().Update(ctx, comp); err != nil {
 			return ctrl.Result{}, fmt.Errorf("updating composition status: %w", err)
 		}
-		logger.Info("populated synthesis status to reflect pod")
+		logger.V(1).Info("added synthesizer pod status to its composition resource")
 		return ctrl.Result{}, nil
 	}
 
@@ -87,7 +87,7 @@ func (c *statusController) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		if err := c.client.Update(ctx, pod); err != nil {
 			return ctrl.Result{}, fmt.Errorf("removing pod finalizer: %w", err)
 		}
-		logger.Info("removed pod finalizer")
+		logger.V(1).Info("removed pod finalizer")
 		return ctrl.Result{}, nil
 	}
 


### PR DESCRIPTION
Previously we planned to completely serialize synthesis and reconciliation per logical composition version. This is problematic if some resources cannot be applied due to validation errors, etc.

This removes the serialization logic and leaves a TODO re. a more robust/correct approach to be merged later.