### PR TITLE
Fix synthesis race condition

### DIFF
--- a/internal/controllers/synthesis/integration_test.go
+++ b/internal/controllers/synthesis/integration_test.go
@@ -185,27 +185,19 @@ func TestControllerSynthesizerRollout(t *testing.T) {
 	syn.Spec.Image = "test-syn-image"
 	require.NoError(t, cli.Create(ctx, syn))
 
-	comp1 := &apiv1.Composition{}
-	comp1.Name = "test-comp-1"
-	comp1.Namespace = "default"
-	comp1.Spec.Synthesizer.Name = syn.Name
-	require.NoError(t, cli.Create(ctx, comp1))
-
-	comp2 := &apiv1.Composition{}
-	comp2.Name = "test-comp-2"
-	comp2.Namespace = "default"
-	comp2.Spec.Synthesizer.Name = syn.Name
-	require.NoError(t, cli.Create(ctx, comp2))
+	comp := &apiv1.Composition{}
+	comp.Name = "test-comp"
+	comp.Namespace = "default"
+	comp.Spec.Synthesizer.Name = syn.Name
+	require.NoError(t, cli.Create(ctx, comp))
 
 	// Wait for initial sync
 	testutil.Eventually(t, func() bool {
-		require.NoError(t, client.IgnoreNotFound(cli.Get(ctx, client.ObjectKeyFromObject(comp1), comp1)))
-		require.NoError(t, client.IgnoreNotFound(cli.Get(ctx, client.ObjectKeyFromObject(comp2), comp2)))
-		inSync1 := comp1.Status.CurrentState != nil && comp1.Status.CurrentState.ObservedSynthesizerGeneration == syn.Generation
-		inSync2 := comp2.Status.CurrentState != nil && comp2.Status.CurrentState.ObservedSynthesizerGeneration == syn.Generation
-		return inSync1 && inSync2
+		require.NoError(t, client.IgnoreNotFound(cli.Get(ctx, client.ObjectKeyFromObject(comp), comp)))
+		return comp.Status.CurrentState != nil && comp.Status.CurrentState.ObservedSynthesizerGeneration == syn.Generation
 	})
 
+	// First synthesizer update
 	err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
 		if err := cli.Get(ctx, client.ObjectKeyFromObject(syn), syn); err != nil {
 			return err
@@ -215,21 +207,33 @@ func TestControllerSynthesizerRollout(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	// One of the compositions should be updated but not the other because we set a RolloutCooldown of 1hr
-	assertRolloutPending := func() {
-		testutil.Eventually(t, func() bool {
-			require.NoError(t, client.IgnoreNotFound(cli.Get(ctx, client.ObjectKeyFromObject(comp1), comp1)))
-			require.NoError(t, client.IgnoreNotFound(cli.Get(ctx, client.ObjectKeyFromObject(comp2), comp2)))
-			inSync1 := comp1.Status.CurrentState != nil && comp1.Status.CurrentState.ObservedSynthesizerGeneration == syn.Generation
-			inSync2 := comp2.Status.CurrentState != nil && comp2.Status.CurrentState.ObservedSynthesizerGeneration == syn.Generation
-			return (inSync1 && !inSync2) || (!inSync1 && inSync2)
-		})
-	}
+	// The first synthesizer update should be applied to the composition
+	testutil.Eventually(t, func() bool {
+		require.NoError(t, client.IgnoreNotFound(cli.Get(ctx, client.ObjectKeyFromObject(comp), comp)))
+		return comp.Status.CurrentState != nil && comp.Status.CurrentState.ObservedSynthesizerGeneration == syn.Generation
+	})
 
-	// Make sure the state persists
-	assertRolloutPending()
-	time.Sleep(time.Millisecond * 50)
-	assertRolloutPending()
+	// Wait for the informer cache to know about the last update
+	testutil.Eventually(t, func() bool {
+		require.NoError(t, client.IgnoreNotFound(cli.Get(ctx, client.ObjectKeyFromObject(syn), syn)))
+		return syn.Status.LastRolloutTime != nil
+	})
+
+	// Second synthesizer update
+	err = retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		if err := cli.Get(ctx, client.ObjectKeyFromObject(syn), syn); err != nil {
+			return err
+		}
+		syn.Spec.Image = "updated-image"
+		return cli.Update(ctx, syn)
+	})
+	require.NoError(t, err)
+
+	// The second synthesizer update should not be applied to the composition because we're within the update window
+	time.Sleep(time.Millisecond * 250)
+	original := comp.DeepCopy()
+	require.NoError(t, client.IgnoreNotFound(cli.Get(ctx, client.ObjectKeyFromObject(comp), comp)))
+	assert.Equal(t, original.Generation, comp.Generation, "spec hasn't been updated")
 }
 
 func TestControllerSwitchingSynthesizers(t *testing.T) {

--- a/internal/controllers/synthesis/rollout.go
+++ b/internal/controllers/synthesis/rollout.go
@@ -41,6 +41,7 @@ func (c *rolloutController) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	if err != nil {
 		return ctrl.Result{}, client.IgnoreNotFound(fmt.Errorf("gettting synthesizer: %w", err))
 	}
+	logger = logger.WithValues("synthesizerName", syn.Name, "synthesizerNamespace", syn.Namespace, "synthesizerGeneration", syn.Generation)
 
 	if syn.Status.LastRolloutTime != nil {
 		remainingCooldown := c.cooldown - time.Since(syn.Status.LastRolloutTime.Time)
@@ -65,7 +66,7 @@ func (c *rolloutController) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		comp := comp
 		logger := logger.WithValues("compositionName", comp.Name, "compositionNamespace", comp.Namespace, "compositionGeneration", comp.Generation)
 
-		if comp.Spec.Synthesizer.MinGeneration >= syn.Generation {
+		if comp.Spec.Synthesizer.MinGeneration >= syn.Generation || comp.Status.CurrentState == nil || comp.Status.CurrentState.ObservedSynthesizerGeneration >= syn.Generation {
 			continue
 		}
 


### PR DESCRIPTION
Fixes two race conditions: one in the test and one in the code.

The main race condition is reached when a composition has been created but not yet synthesized. It will be eligible for rollout, even though that doesn't make sense. We will always reach it on the next pass of the loop anyway.

The test race condition is simpler. It occurs because we use two separate test compositions in the test, and Kubernetes doesn't provide synchronization across resources. The same race isn't an issue in production because we don't care so much about ordering in within the eventually consistent system.