### PR TITLE
Refactor reconstitution code

### DIFF
--- a/internal/reconstitution/api.go
+++ b/internal/reconstitution/api.go
@@ -18,7 +18,7 @@ type Reconciler interface {
 
 // Client provides read/write access to a collection of reconstituted resources.
 type Client interface {
-	Get(ctx context.Context, ref *ResourceRef, gen int64) (*Resource, bool)
+	Get(ctx context.Context, comp *CompositionRef, res *ResourceRef) (*Resource, bool)
 	PatchStatusAsync(ctx context.Context, req *ManifestRef, patchFn StatusPatchFn)
 }
 
@@ -40,13 +40,27 @@ type Resource struct {
 
 // ResourceRef refers to a specific synthesized resource.
 type ResourceRef struct {
-	Composition           types.NamespacedName
 	Name, Namespace, Kind string
+}
+
+// CompositionRef refers to a specific generation of a composition.
+type CompositionRef struct {
+	Name, Namespace string
+	Generation      int64
+}
+
+func NewCompositionRef(comp *apiv1.Composition) *CompositionRef {
+	c := &CompositionRef{Name: comp.Name, Namespace: comp.Namespace}
+	if comp.Status.CurrentState != nil {
+		c.Generation = comp.Status.CurrentState.ObservedCompositionGeneration
+	}
+	return c
 }
 
 // Request is like controller-runtime reconcile.Request but for reconstituted resources.
 // https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/reconcile#Request
 type Request struct {
-	ResourceRef
-	Manifest ManifestRef
+	Resource    ResourceRef
+	Manifest    ManifestRef
+	Composition CompositionRef
 }

--- a/internal/reconstitution/cache.go
+++ b/internal/reconstitution/cache.go
@@ -18,30 +18,28 @@ type cache struct {
 	client client.Client
 
 	mut                    sync.Mutex
-	resources              map[synthesisKey]map[resourceKey]*Resource
+	resources              map[CompositionRef]map[ResourceRef]*Resource
 	synthesesByComposition map[types.NamespacedName][]int64
 }
 
 func newCache(client client.Client) *cache {
 	return &cache{
 		client:                 client,
-		resources:              make(map[synthesisKey]map[resourceKey]*Resource),
+		resources:              make(map[CompositionRef]map[ResourceRef]*Resource),
 		synthesesByComposition: make(map[types.NamespacedName][]int64),
 	}
 }
 
-func (c *cache) Get(ctx context.Context, ref *ResourceRef, gen int64) (*Resource, bool) {
+func (c *cache) Get(ctx context.Context, comp *CompositionRef, ref *ResourceRef) (*Resource, bool) {
 	c.mut.Lock()
 	defer c.mut.Unlock()
 
-	synKey := synthesisKey{Composition: ref.Composition, Generation: gen}
-	resources, ok := c.resources[synKey]
+	resources, ok := c.resources[*comp]
 	if !ok {
 		return nil, false
 	}
 
-	resKey := resourceKey{Kind: ref.Kind, Namespace: ref.Namespace, Name: ref.Name}
-	res, ok := resources[resKey]
+	res, ok := resources[*ref]
 	if !ok {
 		return nil, false
 	}
@@ -57,10 +55,11 @@ func (c *cache) Get(ctx context.Context, ref *ResourceRef, gen int64) (*Resource
 
 // HasSynthesis returns true when the cache contains the resulting resources of the given synthesis.
 // This should be called before Fill to determine if filling is necessary.
-func (c *cache) HasSynthesis(ctx context.Context, comp types.NamespacedName, synthesis *apiv1.Synthesis) bool {
-	key := synthesisKey{
-		Composition: comp,
-		Generation:  synthesis.ObservedCompositionGeneration,
+func (c *cache) HasSynthesis(ctx context.Context, comp *apiv1.Composition, synthesis *apiv1.Synthesis) bool {
+	key := CompositionRef{
+		Name:       comp.Name,
+		Namespace:  comp.Namespace,
+		Generation: synthesis.ObservedCompositionGeneration,
 	}
 
 	c.mut.Lock()
@@ -71,7 +70,7 @@ func (c *cache) HasSynthesis(ctx context.Context, comp types.NamespacedName, syn
 
 // Fill populates the cache with all (or no) resources that are part of the given synthesis.
 // Requests to be enqueued are returned. Although this arguably violates separation of concerns, it's convenient and efficient.
-func (c *cache) Fill(ctx context.Context, comp types.NamespacedName, synthesis *apiv1.Synthesis, items []apiv1.ResourceSlice) ([]*Request, error) {
+func (c *cache) Fill(ctx context.Context, comp *apiv1.Composition, synthesis *apiv1.Synthesis, items []apiv1.ResourceSlice) ([]*Request, error) {
 	logger := logr.FromContextOrDiscard(ctx)
 
 	// Building resources can be expensive (json parsing, etc.) so don't hold the lock during this call
@@ -83,16 +82,18 @@ func (c *cache) Fill(ctx context.Context, comp types.NamespacedName, synthesis *
 	c.mut.Lock()
 	defer c.mut.Unlock()
 
-	synKey := synthesisKey{Composition: comp, Generation: synthesis.ObservedCompositionGeneration}
+	synKey := CompositionRef{Name: comp.Name, Namespace: comp.Namespace, Generation: synthesis.ObservedCompositionGeneration}
 	c.resources[synKey] = resources
-	c.synthesesByComposition[comp] = append(c.synthesesByComposition[comp], synKey.Generation)
+
+	compNSN := types.NamespacedName{Name: comp.Name, Namespace: comp.Namespace}
+	c.synthesesByComposition[compNSN] = append(c.synthesesByComposition[compNSN], synKey.Generation)
 
 	logger.Info("cache filled")
 	return requests, nil
 }
 
-func (c *cache) buildResources(ctx context.Context, comp types.NamespacedName, items []apiv1.ResourceSlice) (map[resourceKey]*Resource, []*Request, error) {
-	resources := map[resourceKey]*Resource{}
+func (c *cache) buildResources(ctx context.Context, comp *apiv1.Composition, items []apiv1.ResourceSlice) (map[ResourceRef]*Resource, []*Request, error) {
+	resources := map[ResourceRef]*Resource{}
 	requests := []*Request{}
 	for _, slice := range items {
 		slice := slice
@@ -101,14 +102,19 @@ func (c *cache) buildResources(ctx context.Context, comp types.NamespacedName, i
 
 		for i, resource := range slice.Spec.Resources {
 			resource := resource
+
+			// Delete the resource if the composition is being deleted
+			if comp.DeletionTimestamp != nil {
+				resource.Deleted = true
+			}
+
 			res, err := c.buildResource(ctx, comp, &slice, &resource)
 			if err != nil {
 				return nil, nil, fmt.Errorf("building resource at index %d of slice %s: %w", i, slice.Name, err)
 			}
-			key := resourceKey{Kind: res.Ref.Kind, Namespace: res.Ref.Namespace, Name: res.Ref.Name}
-			resources[key] = res
+			resources[*res.Ref] = res
 			requests = append(requests, &Request{
-				ResourceRef: *res.Ref,
+				Resource: *res.Ref,
 				Manifest: ManifestRef{
 					Slice: types.NamespacedName{
 						Namespace: slice.Namespace,
@@ -116,6 +122,7 @@ func (c *cache) buildResources(ctx context.Context, comp types.NamespacedName, i
 					},
 					Index: i,
 				},
+				Composition: *NewCompositionRef(comp),
 			})
 		}
 	}
@@ -123,7 +130,7 @@ func (c *cache) buildResources(ctx context.Context, comp types.NamespacedName, i
 	return resources, requests, nil
 }
 
-func (c *cache) buildResource(ctx context.Context, comp types.NamespacedName, slice *apiv1.ResourceSlice, resource *apiv1.Manifest) (*Resource, error) {
+func (c *cache) buildResource(ctx context.Context, comp *apiv1.Composition, slice *apiv1.ResourceSlice, resource *apiv1.Manifest) (*Resource, error) {
 	manifest := resource.Manifest
 	parsed := &unstructured.Unstructured{}
 	err := parsed.UnmarshalJSON([]byte(manifest))
@@ -133,10 +140,9 @@ func (c *cache) buildResource(ctx context.Context, comp types.NamespacedName, sl
 
 	res := &Resource{
 		Ref: &ResourceRef{
-			Composition: comp,
-			Namespace:   parsed.GetNamespace(),
-			Name:        parsed.GetName(),
-			Kind:        parsed.GetKind(),
+			Namespace: parsed.GetNamespace(),
+			Name:      parsed.GetName(),
+			Kind:      parsed.GetKind(),
 		},
 		Manifest: resource,
 		Object:   parsed,
@@ -162,19 +168,11 @@ func (c *cache) Purge(ctx context.Context, compNSN types.NamespacedName, comp *a
 			remainingSyns = append(remainingSyns, syn)
 			continue // still referenced by the Generation
 		}
-		delete(c.resources, synthesisKey{
-			Composition: compNSN,
-			Generation:  syn,
+		delete(c.resources, CompositionRef{
+			Name:       compNSN.Name,
+			Namespace:  compNSN.Namespace,
+			Generation: syn,
 		})
 	}
 	c.synthesesByComposition[compNSN] = remainingSyns
-}
-
-type synthesisKey struct {
-	Composition types.NamespacedName
-	Generation  int64
-}
-
-type resourceKey struct {
-	Kind, Namespace, Name string
 }

--- a/internal/reconstitution/manager.go
+++ b/internal/reconstitution/manager.go
@@ -17,7 +17,7 @@ func New(mgr ctrl.Manager, writeBatchInterval time.Duration) (*Manager, error) {
 		Manager: mgr,
 	}
 	m.writeBuffer = newWriteBuffer(mgr.GetClient(), writeBatchInterval, 2)
-	mgr.Add(m.writeBuffer)
+	mgr.Add(m.writeBuffer) // TODO: No logger is in the context here
 
 	var err error
 	m.reconstituter, err = newReconstituter(mgr)
@@ -83,7 +83,7 @@ func (q *queueProcessor) processQueueItem(ctx context.Context) bool {
 		return false
 	}
 
-	logger := q.Logger.WithValues("compositionName", req.Composition.Name, "compositionNamespace", req.Composition.Namespace, "resourceKind", req.ResourceRef.Kind, "resourceName", req.ResourceRef.Name, "resourceNamespace", req.ResourceRef.Namespace)
+	logger := q.Logger.WithValues("compositionName", req.Composition.Name, "compositionNamespace", req.Composition.Namespace, "compositionGeneration", req.Composition.Generation, "resourceKind", req.Resource.Kind, "resourceName", req.Resource.Name, "resourceNamespace", req.Resource.Namespace)
 	ctx = logr.NewContext(ctx, logger)
 
 	result, err := q.Handler.Reconcile(ctx, req)

--- a/internal/reconstitution/manager_test.go
+++ b/internal/reconstitution/manager_test.go
@@ -38,6 +38,7 @@ func TestManagerBasics(t *testing.T) {
 		Synthesized:                   true,
 	}
 	require.NoError(t, client.Status().Update(ctx, comp))
+	tr.comp = NewCompositionRef(comp)
 
 	slice := &apiv1.ResourceSlice{}
 	slice.Name = "test-slice"
@@ -57,13 +58,14 @@ func TestManagerBasics(t *testing.T) {
 
 type testReconciler struct {
 	mgr          *Manager
+	comp         *CompositionRef
 	lastResource atomic.Pointer[Resource]
 }
 
 func (t *testReconciler) Name() string { return "testReconciler" }
 
 func (t *testReconciler) Reconcile(ctx context.Context, req *Request) (ctrl.Result, error) {
-	resource, exists := t.mgr.GetClient().Get(ctx, &req.ResourceRef, 1)
+	resource, exists := t.mgr.GetClient().Get(ctx, t.comp, &req.Resource)
 	if !exists {
 		panic("resource should exist in cache")
 	}

--- a/internal/reconstitution/reconstituter.go
+++ b/internal/reconstitution/reconstituter.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/go-logr/logr"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/workqueue"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -86,11 +85,10 @@ func (r *reconstituter) populateCache(ctx context.Context, comp *apiv1.Compositi
 		// synthesis is still in progress
 		return nil, nil
 	}
-	compNSN := types.NamespacedName{Namespace: comp.Namespace, Name: comp.Name}
 
 	logger = logger.WithValues("synthesisCompositionGeneration", synthesis.ObservedCompositionGeneration)
 	ctx = logr.NewContext(ctx, logger)
-	if r.cache.HasSynthesis(ctx, compNSN, synthesis) {
+	if r.cache.HasSynthesis(ctx, comp, synthesis) {
 		return nil, nil
 	}
 
@@ -106,5 +104,5 @@ func (r *reconstituter) populateCache(ctx context.Context, comp *apiv1.Compositi
 		slices[i] = slice
 	}
 
-	return r.cache.Fill(ctx, compNSN, synthesis, slices)
+	return r.cache.Fill(ctx, comp, synthesis, slices)
 }


### PR DESCRIPTION
Restructures a few things to enable the next feature (resource slice cleanup), and generally improve ergonomics.

There are essentially two major changes:

- The structure of the various reference types has changed such that they are now less nested, and (I think) much clearer
- Resources are marked as Deleted when a composition is being deleted