### PR TITLE
Block composition deletion while pods or resource slices exist

### DIFF
--- a/internal/controllers/synthesis/lifecycle_test.go
+++ b/internal/controllers/synthesis/lifecycle_test.go
@@ -1,0 +1,73 @@
+package synthesis
+
+import (
+	"testing"
+	"time"
+
+	apiv1 "github.com/Azure/eno/api/v1"
+	"github.com/Azure/eno/internal/testutil"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func TestCompositionDeletion(t *testing.T) {
+	ctx := testutil.NewContext(t)
+	mgr := testutil.NewManager(t)
+	cli := mgr.GetClient()
+
+	require.NoError(t, NewExecController(mgr.Manager, time.Second, &testutil.ExecConn{
+		Hook: func(s *apiv1.Synthesizer) []client.Object {
+			cm := &corev1.ConfigMap{}
+			cm.APIVersion = "v1"
+			cm.Kind = "ConfigMap"
+			cm.Name = "test"
+			cm.Namespace = "default"
+			return []client.Object{cm}
+		},
+	}))
+
+	require.NoError(t, NewPodLifecycleController(mgr.Manager, minimalTestConfig))
+	require.NoError(t, NewStatusController(mgr.Manager))
+	mgr.Start(t)
+
+	syn := &apiv1.Synthesizer{}
+	syn.Name = "test-syn-1"
+	syn.Spec.Image = "initial-image"
+	require.NoError(t, cli.Create(ctx, syn))
+
+	comp := &apiv1.Composition{}
+	comp.Name = "test-comp"
+	comp.Namespace = "default"
+	comp.Spec.Synthesizer.Name = syn.Name
+	require.NoError(t, cli.Create(ctx, comp))
+
+	// Create the composition's resource slice
+	testutil.Eventually(t, func() bool {
+		require.NoError(t, client.IgnoreNotFound(cli.Get(ctx, client.ObjectKeyFromObject(comp), comp)))
+		return comp.Status.CurrentState != nil && len(comp.Status.CurrentState.ResourceSlices) > 0
+	})
+
+	// Delete the composition
+	require.NoError(t, cli.Delete(ctx, comp))
+	deleteGen := comp.Generation
+
+	// The generation should be updated
+	testutil.Eventually(t, func() bool {
+		require.NoError(t, client.IgnoreNotFound(cli.Get(ctx, client.ObjectKeyFromObject(comp), comp)))
+		return comp.Status.CurrentState != nil && comp.Status.CurrentState.ObservedCompositionGeneration >= deleteGen
+	})
+
+	// Delete the resource slice(s)
+	slices := &apiv1.ResourceSliceList{}
+	require.NoError(t, cli.List(ctx, slices))
+	for _, slice := range slices.Items {
+		require.NoError(t, cli.Delete(ctx, &slice))
+	}
+
+	// The composition should eventually be released
+	testutil.Eventually(t, func() bool {
+		return errors.IsNotFound(cli.Get(ctx, client.ObjectKeyFromObject(comp), comp))
+	})
+}


### PR DESCRIPTION
Because reconciling resources requires both the composition and resource slices, we can't let the composition disappear before the resource slices have been deleted.

This implements half of the cleanup story, I'll open another PR for the remaining bits soon.