### PR TITLE
Track resource deletion

### DIFF
--- a/api/v1/config/crd/eno.azure.io_resourceslices.yaml
+++ b/api/v1/config/crd/eno.azure.io_resourceslices.yaml
@@ -56,6 +56,11 @@ spec:
                   spec.resources at the observed generation.
                 items:
                   properties:
+                    deleted:
+                      description: Deleted is true when the resource has been cleaned
+                        up, either because spec.deleted == true or the parent composition
+                        has been deleted.
+                      type: boolean
                     ready:
                       description: nil if Eno is unable to determine the readiness
                         of this resource. Otherwise it is true when the resource is

--- a/api/v1/resourceslice.go
+++ b/api/v1/resourceslice.go
@@ -48,6 +48,9 @@ type ResourceState struct {
 	// Otherwise it is true when the resource is ready, false otherwise.
 	// Like Reconciled, it latches and will never transition from true->false.
 	Ready *bool `json:"ready,omitempty"`
+
+	// Deleted is true when the resource has been cleaned up, either because spec.deleted == true or the parent composition has been deleted.
+	Deleted bool `json:"deleted,omitempty"`
 }
 
 type ResourceSliceRef struct {

--- a/internal/controllers/reconciliation/controller.go
+++ b/internal/controllers/reconciliation/controller.go
@@ -117,12 +117,16 @@ func (c *Controller) Reconcile(ctx context.Context, req *reconstitution.Request)
 		return ctrl.Result{}, err
 	}
 
-	c.resourceClient.PatchStatusAsync(ctx, &req.Manifest, func(rs *apiv1.ResourceState) bool {
-		if rs.Reconciled {
-			return false // already in sync
+	c.resourceClient.PatchStatusAsync(ctx, &req.Manifest, func(rs *apiv1.ResourceState) (modified bool) {
+		if resource.Manifest.Deleted && !rs.Deleted {
+			rs.Deleted = true
+			modified = true
 		}
-		rs.Reconciled = true
-		return true
+		if !rs.Reconciled {
+			rs.Reconciled = true
+			modified = true
+		}
+		return
 	})
 
 	if resource != nil && resource.Manifest.ReconcileInterval != nil {


### PR DESCRIPTION
We need a way to block composition deletion until all related resources have also been deleted, since deleting them requires the composition.