### PR TITLE
Handle missing synthesizer

### DIFF
--- a/internal/controllers/synthesis/exec.go
+++ b/internal/controllers/synthesis/exec.go
@@ -78,7 +78,7 @@ func (c *execController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 	logger = logger.WithValues("synthesizerName", syn.Name)
 	ctx = logr.NewContext(ctx, logger)
 
-	if compGen < comp.Generation || (comp.Status.CurrentState != nil && comp.Status.CurrentState.Synthesized) {
+	if compGen < comp.Generation || (comp.Status.CurrentState != nil && comp.Status.CurrentState.Synthesized) || comp.DeletionTimestamp != nil {
 		return ctrl.Result{}, nil // old pod - don't bother synthesizing. The lifecycle controller will delete it
 	}
 
@@ -91,6 +91,10 @@ func (c *execController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("updating composition status: %w", err)
 	}
+
+	// Let the informers catch up
+	// Obviously this isn't ideal, consider a lamport clock in memory
+	time.Sleep(time.Millisecond * 100)
 
 	return ctrl.Result{}, nil
 }

--- a/internal/controllers/synthesis/exec.go
+++ b/internal/controllers/synthesis/exec.go
@@ -171,7 +171,6 @@ func buildResourceSlices(comp *apiv1.Composition, previous []*apiv1.ResourceSlic
 
 			// We don't need a tombstone once the deleted resource has been reconciled
 			if _, ok := refs[newResourceRef(obj)]; ok || ((res.Deleted || slice.DeletionTimestamp != nil) && slice.Status.Resources != nil && slice.Status.Resources[i].Reconciled) {
-				// TODO: Integration test this behavior with the reconciliation controllers
 				continue // still exists or has already been deleted
 			}
 

--- a/internal/controllers/synthesis/exec.go
+++ b/internal/controllers/synthesis/exec.go
@@ -78,7 +78,7 @@ func (c *execController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 	logger = logger.WithValues("synthesizerName", syn.Name)
 	ctx = logr.NewContext(ctx, logger)
 
-	if compGen < comp.Generation {
+	if compGen < comp.Generation || (comp.Status.CurrentState != nil && comp.Status.CurrentState.Synthesized) {
 		return ctrl.Result{}, nil // old pod - don't bother synthesizing. The lifecycle controller will delete it
 	}
 
@@ -111,7 +111,7 @@ func (c *execController) synthesize(ctx context.Context, syn *apiv1.Synthesizer,
 	if err != nil {
 		return nil, err
 	}
-	logger.V(1).Info("synthesizing is done", "latency", time.Since(start).Milliseconds())
+	logger.V(1).Info("synthesis is done", "latency", time.Since(start).Milliseconds())
 
 	return c.writeOutputToSlices(ctx, comp, stdout)
 }

--- a/internal/controllers/synthesis/integration_test.go
+++ b/internal/controllers/synthesis/integration_test.go
@@ -43,16 +43,9 @@ func TestControllerHappyPath(t *testing.T) {
 	require.NoError(t, cli.Create(ctx, comp))
 
 	t.Run("initial creation", func(t *testing.T) {
-		// It creates a pod to synthesize the composition
-		testutil.Eventually(t, func() bool {
-			list := &corev1.PodList{}
-			require.NoError(t, cli.List(ctx, list))
-			return len(list.Items) > 0
-		})
-
 		// The pod eventually performs the synthesis
 		testutil.Eventually(t, func() bool {
-			require.NoError(t, cli.Get(ctx, client.ObjectKeyFromObject(comp), comp))
+			require.NoError(t, client.IgnoreNotFound(cli.Get(ctx, client.ObjectKeyFromObject(comp), comp)))
 			return comp.Status.CurrentState != nil && comp.Status.CurrentState.Synthesized
 		})
 	})

--- a/internal/controllers/synthesis/lifecycle.go
+++ b/internal/controllers/synthesis/lifecycle.go
@@ -59,15 +59,6 @@ func (c *podLifecycleController) Reconcile(ctx context.Context, req ctrl.Request
 		return ctrl.Result{}, nil
 	}
 
-	syn := &apiv1.Synthesizer{}
-	syn.Name = comp.Spec.Synthesizer.Name
-	err = c.client.Get(ctx, client.ObjectKeyFromObject(syn), syn)
-	if err != nil {
-		// TODO: we should be able to tolerate a 404 here
-		return ctrl.Result{}, fmt.Errorf("getting synthesizer: %w", err)
-	}
-	logger = logger.WithValues("synthesizerName", syn.Name, "synthesizerGeneration", syn.Generation)
-
 	// Delete any unnecessary pods
 	pods := &corev1.PodList{}
 	err = c.client.List(ctx, pods, client.InNamespace(comp.Namespace), client.MatchingFields{
@@ -77,7 +68,7 @@ func (c *podLifecycleController) Reconcile(ctx context.Context, req ctrl.Request
 		return ctrl.Result{}, fmt.Errorf("listing pods: %w", err)
 	}
 
-	logger, toDelete, exists := c.shouldDeletePod(logger, comp, syn, pods)
+	logger, toDelete, exists := c.shouldDeletePod(logger, comp, pods)
 	if toDelete != nil {
 		if err := c.client.Delete(ctx, toDelete); err != nil {
 			return ctrl.Result{}, client.IgnoreNotFound(fmt.Errorf("deleting pod: %w", err))
@@ -138,7 +129,7 @@ func (c *podLifecycleController) Reconcile(ctx context.Context, req ctrl.Request
 
 	// Swap the state to prepare for resynthesis if needed
 	if comp.Status.CurrentState == nil || comp.Status.CurrentState.ObservedCompositionGeneration != comp.Generation {
-		swapStates(syn, comp)
+		swapStates(comp)
 		if err := c.client.Status().Update(ctx, comp); err != nil {
 			return ctrl.Result{}, fmt.Errorf("swapping compisition state: %w", err)
 		}
@@ -151,6 +142,14 @@ func (c *podLifecycleController) Reconcile(ctx context.Context, req ctrl.Request
 		return ctrl.Result{}, nil
 	}
 
+	syn := &apiv1.Synthesizer{}
+	syn.Name = comp.Spec.Synthesizer.Name
+	err = c.client.Get(ctx, client.ObjectKeyFromObject(syn), syn)
+	if err != nil {
+		return ctrl.Result{}, client.IgnoreNotFound(fmt.Errorf("getting synthesizer: %w", err))
+	}
+	logger = logger.WithValues("synthesizerName", syn.Name, "synthesizerGeneration", syn.Generation)
+
 	// If we made it this far it's safe to create a pod
 	pod := newPod(c.config, c.client.Scheme(), comp, syn)
 	err = c.client.Create(ctx, pod)
@@ -162,7 +161,7 @@ func (c *podLifecycleController) Reconcile(ctx context.Context, req ctrl.Request
 	return ctrl.Result{}, nil
 }
 
-func (c *podLifecycleController) shouldDeletePod(logger logr.Logger, comp *apiv1.Composition, syn *apiv1.Synthesizer, pods *corev1.PodList) (logr.Logger, *corev1.Pod /* exists */, bool) {
+func (c *podLifecycleController) shouldDeletePod(logger logr.Logger, comp *apiv1.Composition, pods *corev1.PodList) (logr.Logger, *corev1.Pod /* exists */, bool) {
 	if len(pods.Items) == 0 {
 		return logger, nil, false
 	}
@@ -212,7 +211,7 @@ func (c *podLifecycleController) shouldDeletePod(logger logr.Logger, comp *apiv1
 	return logger, nil, false
 }
 
-func swapStates(syn *apiv1.Synthesizer, comp *apiv1.Composition) {
+func swapStates(comp *apiv1.Composition) {
 	// If the previous state has been synthesized but not the current, keep the previous to avoid orphaning deleted resources
 	if comp.Status.CurrentState != nil && comp.Status.CurrentState.Synthesized {
 		comp.Status.PreviousState = comp.Status.CurrentState

--- a/internal/reconstitution/reconstituter.go
+++ b/internal/reconstitution/reconstituter.go
@@ -30,7 +30,6 @@ func newReconstituter(mgr ctrl.Manager) (*reconstituter, error) {
 		client: mgr.GetClient(),
 	}
 
-
 	return r, ctrl.NewControllerManagedBy(mgr).
 		Named("reconstituter").
 		For(&apiv1.Composition{}).

--- a/internal/reconstitution/writebuffer.go
+++ b/internal/reconstitution/writebuffer.go
@@ -121,8 +121,7 @@ func (w *writeBuffer) updateSlice(ctx context.Context, sliceNSN types.Namespaced
 	slice := &apiv1.ResourceSlice{}
 	err := w.client.Get(ctx, sliceNSN, slice)
 	if errors.IsNotFound(err) {
-		// TODO: I think this should cause the work queue to Forget this item?
-		logger.V(0).Info("slice has been deleted, skipping status update")
+		logger.V(0).Info("slice has been deleted - dropping status update")
 		return true
 	}
 	if err != nil {

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	goruntime "runtime"
 	"strconv"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -254,10 +255,13 @@ func AtLeastVersion(t *testing.T, minor int) bool {
 }
 
 type ExecConn struct {
-	Hook func(s *apiv1.Synthesizer) []client.Object
+	Hook  func(s *apiv1.Synthesizer) []client.Object
+	Calls atomic.Int64
 }
 
 func (e *ExecConn) Synthesize(ctx context.Context, syn *apiv1.Synthesizer, pod *corev1.Pod, inputsJson []byte) (io.Reader, error) {
+	defer e.Calls.Add(1)
+
 	objs := []client.Object{}
 	if e.Hook != nil {
 		objs = e.Hook(syn)


### PR DESCRIPTION
Currently a missing synthesizer will cause any pods derived from it to be deadlocked. Also includes a few other tiny bug fixes documented by PR comments.