### PR TITLE
Fix slice cleanup at scale

### DIFF
--- a/dev/deploy.yaml
+++ b/dev/deploy.yaml
@@ -17,6 +17,11 @@ spec:
       containers:
       - name: eno-controller
         image: $REGISTRY/eno-controller:$TAG
+        args:
+        - --rollout-cooldown=1s
+        env:
+          - name: PPROF_ADDR
+            value: ":8888"
 
 ---
 

--- a/examples/loadtest.yaml
+++ b/examples/loadtest.yaml
@@ -15,7 +15,7 @@ spec:
           \"apiVersion\": \"v1\",
           \"kind\": \"ConfigMap\",
           \"metadata\": { \"name\": \"test-cm-${i}\", \"namespace\": \"default\", \"annotations\": { \"eno.azure.io/reconcile-interval\": \"30s\" } },
-          \"data\": { \"foo\": \"bar\" }
+          \"data\": { \"foo\": \"$(tr -dc A-Za-z0-9 </dev/urandom | head -c 4096; echo)\" }
         }"
         if [[ $i == $n ]]; then
           echo "]}"
@@ -67,5 +67,5 @@ spec:
 
             kubectl patch synthesizers load-test-synth --type=merge --patch "{\"spec\":{\"timeout\": \"$timeout\"}}"
             n=$(($n + 1))
-            sleep 120
+            sleep 10
           done

--- a/internal/controllers/synthesis/integration_test.go
+++ b/internal/controllers/synthesis/integration_test.go
@@ -72,14 +72,17 @@ func TestControllerHappyPath(t *testing.T) {
 		}
 	})
 
-	// The pod eventually completes and is deleted
+	// The synthesizer is eventually executed a second time
+	testutil.Eventually(t, func() bool {
+		return conn.Calls.Load() == 2
+	})
+
+	// The pod is deleted
 	testutil.Eventually(t, func() bool {
 		list := &corev1.PodList{}
 		require.NoError(t, cli.List(ctx, list))
 		return len(list.Items) == 0
 	})
-
-	assert.Equal(t, int64(2), conn.Calls.Load())
 }
 
 func TestControllerFastCompositionUpdates(t *testing.T) {

--- a/internal/controllers/synthesis/lifecycle.go
+++ b/internal/controllers/synthesis/lifecycle.go
@@ -154,6 +154,8 @@ func (c *podLifecycleController) Reconcile(ctx context.Context, req ctrl.Request
 	}
 	logger.Info("created synthesizer pod", "podName", pod.Name)
 
+	time.Sleep(time.Millisecond * 100) // avoid creating extra pods when informers are stale
+
 	return ctrl.Result{}, nil
 }
 

--- a/internal/controllers/synthesis/lifecycle.go
+++ b/internal/controllers/synthesis/lifecycle.go
@@ -154,8 +154,6 @@ func (c *podLifecycleController) Reconcile(ctx context.Context, req ctrl.Request
 	}
 	logger.Info("created synthesizer pod", "podName", pod.Name)
 
-	time.Sleep(time.Millisecond * 100) // avoid creating extra pods when informers are stale
-
 	return ctrl.Result{}, nil
 }
 

--- a/internal/controllers/synthesis/slicecleanup.go
+++ b/internal/controllers/synthesis/slicecleanup.go
@@ -92,8 +92,7 @@ func shouldDelete(comp *apiv1.Composition, slice *apiv1.ResourceSlice) bool {
 		return false // stale informer
 	}
 	isReferenced := synthesisReferencesSlice(comp.Status.CurrentState, slice) || synthesisReferencesSlice(comp.Status.PreviousState, slice)
-	isSynthesizing := comp.Status.CurrentState == nil || !comp.Status.CurrentState.Synthesized || (comp.Status.PreviousState != nil && !comp.Status.PreviousState.Synthesized)
-	return comp.DeletionTimestamp != nil || (!isSynthesizing && !isReferenced)
+	return comp.DeletionTimestamp != nil || (!isReferenced && slice.Spec.CompositionGeneration < comp.Generation)
 }
 
 func shouldReleaseFinalizer(comp *apiv1.Composition, slice *apiv1.ResourceSlice) bool {

--- a/internal/controllers/synthesis/status.go
+++ b/internal/controllers/synthesis/status.go
@@ -66,7 +66,7 @@ func (c *statusController) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		synGen, _  = strconv.ParseInt(pod.Annotations["eno.azure.io/synthesizer-generation"], 10, 0)
 	)
 	logger.WithValues("synthesizerGeneration", synGen, "compositionGeneration", compGen)
-	if shouldWriteStatus(comp, compGen, synGen) {
+	if shouldWriteStatus(comp, compGen) {
 		if comp.Status.CurrentState == nil {
 			comp.Status.CurrentState = &apiv1.Synthesis{}
 		}
@@ -97,7 +97,7 @@ func (c *statusController) removeFinalizer(ctx context.Context, pod *corev1.Pod)
 	return ctrl.Result{Requeue: true}, nil
 }
 
-func shouldWriteStatus(comp *apiv1.Composition, podCompGen, podSynGen int64) bool {
+func shouldWriteStatus(comp *apiv1.Composition, podCompGen int64) bool {
 	current := comp.Status.CurrentState
 	return current == nil || (current.ObservedCompositionGeneration == podCompGen && (current.PodCreation == nil || current.ObservedSynthesizerGeneration == 0))
 }


### PR DESCRIPTION
It's currently possible to outpace the slice cleanup since it's blocked by _any_ in-flight syntheses - even for slices that have long expired.