### PR TITLE
Add separate rate limit for resource slice creation

### DIFF
--- a/cmd/eno-controller/main.go
+++ b/cmd/eno-controller/main.go
@@ -33,6 +33,7 @@ func run() error {
 		synconf          = &synthesis.Config{}
 	)
 	flag.DurationVar(&synconf.Timeout, "synthesis-pod-timeout", time.Minute, "Maximum lifespan of synthesizer pods")
+	flag.Float64Var(&synconf.SliceCreationQPS, "slice-creation-qps", 5, "Max QPS for writing synthesized resources into resource slices")
 	flag.DurationVar(&synthesisTimeout, "synthesis-timeout", time.Second*30, "Timeout when executing synthesizer binaries")
 	flag.DurationVar(&rolloutCooldown, "rollout-cooldown", time.Second*30, "Minimum period of time between each ensuing composition update after a synthesizer is updated")
 	flag.BoolVar(&debugLogging, "debug", true, "Enable debug logging")
@@ -60,7 +61,7 @@ func run() error {
 		return fmt.Errorf("constructing synthesizer connection: %w", err)
 	}
 
-	err = synthesis.NewExecController(mgr, synthesisTimeout, synconn)
+	err = synthesis.NewExecController(mgr, synconf, synconn)
 	if err != nil {
 		return fmt.Errorf("constructing execution controller: %w", err)
 	}

--- a/internal/controllers/reconciliation/integration_test.go
+++ b/internal/controllers/reconciliation/integration_test.go
@@ -29,6 +29,11 @@ func init() {
 	insecureLogPatch = true
 }
 
+var defaultConf = &synthesis.Config{
+	Timeout:          time.Second * 5,
+	SliceCreationQPS: 20,
+}
+
 type crudTestCase struct {
 	Name                         string
 	Empty, Initial, Updated      client.Object
@@ -151,10 +156,8 @@ func TestCRUD(t *testing.T) {
 			require.NoError(t, err)
 			require.NoError(t, synthesis.NewRolloutController(mgr.Manager, time.Millisecond))
 			require.NoError(t, synthesis.NewStatusController(mgr.Manager))
-			require.NoError(t, synthesis.NewPodLifecycleController(mgr.Manager, &synthesis.Config{
-				Timeout: time.Second * 5,
-			}))
-			require.NoError(t, synthesis.NewExecController(mgr.Manager, time.Second, &testutil.ExecConn{Hook: newSliceBuilder(t, scheme, &test)}))
+			require.NoError(t, synthesis.NewPodLifecycleController(mgr.Manager, defaultConf))
+			require.NoError(t, synthesis.NewExecController(mgr.Manager, defaultConf, &testutil.ExecConn{Hook: newSliceBuilder(t, scheme, &test)}))
 
 			// Test subject
 			// Only enable rediscoverWhenNotFound on k8s versions that can support it.
@@ -312,10 +315,8 @@ func TestReconcileInterval(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, synthesis.NewRolloutController(mgr.Manager, time.Millisecond))
 	require.NoError(t, synthesis.NewStatusController(mgr.Manager))
-	require.NoError(t, synthesis.NewPodLifecycleController(mgr.Manager, &synthesis.Config{
-		Timeout: time.Second * 5,
-	}))
-	require.NoError(t, synthesis.NewExecController(mgr.Manager, time.Second, &testutil.ExecConn{Hook: func(s *apiv1.Synthesizer) []client.Object {
+	require.NoError(t, synthesis.NewPodLifecycleController(mgr.Manager, defaultConf))
+	require.NoError(t, synthesis.NewExecController(mgr.Manager, defaultConf, &testutil.ExecConn{Hook: func(s *apiv1.Synthesizer) []client.Object {
 		obj := &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test-obj",
@@ -387,11 +388,9 @@ func TestReconcileCacheRace(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, synthesis.NewRolloutController(mgr.Manager, time.Microsecond))
 	require.NoError(t, synthesis.NewStatusController(mgr.Manager))
-	require.NoError(t, synthesis.NewPodLifecycleController(mgr.Manager, &synthesis.Config{
-		Timeout: time.Second * 5,
-	}))
+	require.NoError(t, synthesis.NewPodLifecycleController(mgr.Manager, defaultConf))
 	renderN := 0
-	require.NoError(t, synthesis.NewExecController(mgr.Manager, time.Second, &testutil.ExecConn{Hook: func(s *apiv1.Synthesizer) []client.Object {
+	require.NoError(t, synthesis.NewExecController(mgr.Manager, defaultConf, &testutil.ExecConn{Hook: func(s *apiv1.Synthesizer) []client.Object {
 		renderN++
 		obj := &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
@@ -512,10 +511,8 @@ func TestCompositionDeletionOrdering(t *testing.T) {
 	require.NoError(t, synthesis.NewRolloutController(mgr.Manager, time.Millisecond))
 	require.NoError(t, synthesis.NewStatusController(mgr.Manager))
 	require.NoError(t, synthesis.NewSliceCleanupController(mgr.Manager))
-	require.NoError(t, synthesis.NewPodLifecycleController(mgr.Manager, &synthesis.Config{
-		Timeout: time.Second * 5,
-	}))
-	require.NoError(t, synthesis.NewExecController(mgr.Manager, time.Second, &testutil.ExecConn{Hook: func(s *apiv1.Synthesizer) []client.Object {
+	require.NoError(t, synthesis.NewPodLifecycleController(mgr.Manager, defaultConf))
+	require.NoError(t, synthesis.NewExecController(mgr.Manager, defaultConf, &testutil.ExecConn{Hook: func(s *apiv1.Synthesizer) []client.Object {
 		obj := &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test-obj",

--- a/internal/controllers/synthesis/exec_integration_test.go
+++ b/internal/controllers/synthesis/exec_integration_test.go
@@ -36,7 +36,7 @@ func TestExecIntegrationHappyPath(t *testing.T) {
 	require.NoError(t, NewPodLifecycleController(mgr, minimalTestConfig))
 	require.NoError(t, NewStatusController(mgr))
 	require.NoError(t, NewRolloutController(mgr, time.Millisecond*10))
-	require.NoError(t, NewExecController(mgr, time.Second, conn))
+	require.NoError(t, NewExecController(mgr, minimalTestConfig, conn))
 	go mgr.Start(ctx)
 
 	syn := &apiv1.Synthesizer{}

--- a/internal/controllers/synthesis/lifecycle_test.go
+++ b/internal/controllers/synthesis/lifecycle_test.go
@@ -18,7 +18,7 @@ func TestCompositionDeletion(t *testing.T) {
 	mgr := testutil.NewManager(t)
 	cli := mgr.GetClient()
 
-	require.NoError(t, NewExecController(mgr.Manager, time.Second, &testutil.ExecConn{
+	require.NoError(t, NewExecController(mgr.Manager, minimalTestConfig, &testutil.ExecConn{
 		Hook: func(s *apiv1.Synthesizer) []client.Object {
 			cm := &corev1.ConfigMap{}
 			cm.APIVersion = "v1"


### PR DESCRIPTION
Resource slices can be close to 1mb, so writing a lot of them in a short period is dangerous for apiserver and etcd.

This adds a separate rate limit such that slice creation can be throttled separately from the other, less expensive calls.