### PR TITLE
Limit concurrency of terminating pods

### DIFF
--- a/api/v1/config/crd/eno.azure.io_synthesizers.yaml
+++ b/api/v1/config/crd/eno.azure.io_synthesizers.yaml
@@ -57,6 +57,9 @@ spec:
                   Eno will wait between each composition update.
                 type: string
             type: object
+            x-kubernetes-validations:
+            - message: podTimeout must be greater than execTimeout
+              rule: duration(self.execTimeout) <= duration(self.podTimeout)
           status:
             properties:
               currentGeneration:

--- a/api/v1/synthesizer.go
+++ b/api/v1/synthesizer.go
@@ -22,6 +22,7 @@ type Synthesizer struct {
 	Status SynthesizerStatus `json:"status,omitempty"`
 }
 
+// +kubebuilder:validation:XValidation:rule="duration(self.execTimeout) <= duration(self.podTimeout)",message="podTimeout must be greater than execTimeout"
 type SynthesizerSpec struct {
 	// +required
 	Image string `json:"image,omitempty"`

--- a/internal/controllers/synthesis/connection.go
+++ b/internal/controllers/synthesis/connection.go
@@ -71,12 +71,7 @@ func (s *SynthesizerPodConnection) Synthesize(ctx context.Context, syn *apiv1.Sy
 		return nil, fmt.Errorf("creating remote command executor: %w", err)
 	}
 
-	// Execs will in most cases block pod termination, so use the min of the exec and pod lifespan timeouts
-	timeout := syn.Spec.ExecTimeout.Duration
-	if pt := syn.Spec.PodTimeout.Duration; pt < timeout {
-		timeout = pt
-	}
-	streamCtx, cancel := context.WithTimeout(ctx, timeout)
+	streamCtx, cancel := context.WithTimeout(ctx, syn.Spec.ExecTimeout.Duration)
 	defer cancel()
 
 	stderr := &bytes.Buffer{}

--- a/internal/controllers/synthesis/connection.go
+++ b/internal/controllers/synthesis/connection.go
@@ -71,7 +71,12 @@ func (s *SynthesizerPodConnection) Synthesize(ctx context.Context, syn *apiv1.Sy
 		return nil, fmt.Errorf("creating remote command executor: %w", err)
 	}
 
-	streamCtx, cancel := context.WithTimeout(ctx, syn.Spec.ExecTimeout.Duration)
+	// Execs will in most cases block pod termination, so use the min of the exec and pod lifespan timeouts
+	timeout := syn.Spec.ExecTimeout.Duration
+	if pt := syn.Spec.PodTimeout.Duration; pt < timeout {
+		timeout = pt
+	}
+	streamCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
 	stderr := &bytes.Buffer{}

--- a/internal/controllers/synthesis/exec.go
+++ b/internal/controllers/synthesis/exec.go
@@ -54,7 +54,7 @@ func (c *execController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 		// This shouldn't be common as the informer watch filters on Eno-managed pods using a selector
 		return ctrl.Result{}, nil
 	}
-	if len(pod.Status.ContainerStatuses) == 0 || pod.Status.ContainerStatuses[0].State.Running == nil {
+	if len(pod.Status.ContainerStatuses) == 0 || pod.Status.ContainerStatuses[0].State.Running == nil || pod.DeletionTimestamp != nil {
 		return ctrl.Result{}, nil // pod isn't ready for exec
 	}
 	compGen, _ := strconv.ParseInt(pod.Annotations["eno.azure.io/composition-generation"], 10, 0)

--- a/internal/controllers/synthesis/lifecycle.go
+++ b/internal/controllers/synthesis/lifecycle.go
@@ -168,6 +168,7 @@ func shouldDeletePod(logger logr.Logger, comp *apiv1.Composition, syn *apiv1.Syn
 	// Only create pods when the previous one is deleting or non-existant
 	var onePodDeleting bool
 	for _, pod := range pods.Items {
+		pod := pod
 		if comp.DeletionTimestamp != nil {
 			logger = logger.WithValues("reason", "CompositionDeleted")
 			return logger, &pod, true
@@ -176,7 +177,6 @@ func shouldDeletePod(logger logr.Logger, comp *apiv1.Composition, syn *apiv1.Syn
 		// Allow a single extra pod to be created while the previous one is terminating
 		// in order to break potential deadlocks while avoiding a thundering herd of pods
 		// TODO: e2e test for this
-		pod := pod
 		if pod.DeletionTimestamp != nil {
 			if onePodDeleting {
 				return logger, nil, true

--- a/internal/controllers/synthesis/lifecycle_test.go
+++ b/internal/controllers/synthesis/lifecycle_test.go
@@ -4,13 +4,17 @@ import (
 	"testing"
 	"time"
 
-	apiv1 "github.com/Azure/eno/api/v1"
-	"github.com/Azure/eno/internal/testutil"
+	"github.com/go-logr/logr/testr"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	apiv1 "github.com/Azure/eno/api/v1"
+	"github.com/Azure/eno/internal/testutil"
 )
 
 func TestCompositionDeletion(t *testing.T) {
@@ -90,4 +94,264 @@ func TestCompositionDeletion(t *testing.T) {
 	testutil.Eventually(t, func() bool {
 		return errors.IsNotFound(cli.Get(ctx, client.ObjectKeyFromObject(comp), comp))
 	})
+}
+
+var shouldDeletePodTests = []struct {
+	Name               string
+	Pods               []corev1.Pod
+	Composition        *apiv1.Composition
+	Synth              *apiv1.Synthesizer
+	PodShouldExist     bool
+	PodShouldBeDeleted bool
+}{
+	{
+		Name:               "no-pods",
+		Pods:               []corev1.Pod{},
+		Composition:        &apiv1.Composition{},
+		Synth:              &apiv1.Synthesizer{},
+		PodShouldExist:     false,
+		PodShouldBeDeleted: false,
+	},
+	{
+		Name: "still-in-use",
+		Pods: []corev1.Pod{{
+			ObjectMeta: metav1.ObjectMeta{
+				CreationTimestamp: metav1.Now(),
+				Annotations: map[string]string{
+					"eno.azure.io/composition-generation": "2",
+				},
+			},
+		}},
+		Composition: &apiv1.Composition{
+			ObjectMeta: metav1.ObjectMeta{
+				Generation: 2,
+			},
+		},
+		Synth: &apiv1.Synthesizer{
+			Spec: apiv1.SynthesizerSpec{
+				PodTimeout: metav1.Duration{Duration: time.Hour},
+			},
+		},
+		PodShouldExist:     true,
+		PodShouldBeDeleted: false,
+	},
+	{
+		Name: "success",
+		Pods: []corev1.Pod{{
+			ObjectMeta: metav1.ObjectMeta{
+				CreationTimestamp: metav1.Now(),
+				Annotations: map[string]string{
+					"eno.azure.io/composition-generation": "2",
+				},
+			},
+		}},
+		Composition: &apiv1.Composition{
+			ObjectMeta: metav1.ObjectMeta{
+				Generation: 2,
+			},
+			Status: apiv1.CompositionStatus{
+				CurrentState: &apiv1.Synthesis{
+					Synthesized: true,
+				},
+			},
+		},
+		Synth: &apiv1.Synthesizer{
+			Spec: apiv1.SynthesizerSpec{
+				PodTimeout: metav1.Duration{Duration: time.Hour},
+			},
+		},
+		PodShouldExist:     true,
+		PodShouldBeDeleted: true,
+	},
+	{
+		Name: "success-and-wrong-gen",
+		Pods: []corev1.Pod{{
+			ObjectMeta: metav1.ObjectMeta{
+				CreationTimestamp: metav1.Now(),
+				Annotations: map[string]string{
+					"eno.azure.io/composition-generation": "1",
+				},
+			},
+		}},
+		Composition: &apiv1.Composition{
+			ObjectMeta: metav1.ObjectMeta{
+				Generation: 2,
+			},
+			Status: apiv1.CompositionStatus{
+				CurrentState: &apiv1.Synthesis{
+					Synthesized: true,
+				},
+			},
+		},
+		Synth: &apiv1.Synthesizer{
+			Spec: apiv1.SynthesizerSpec{
+				PodTimeout: metav1.Duration{Duration: time.Hour},
+			},
+		},
+		PodShouldExist:     true,
+		PodShouldBeDeleted: true,
+	},
+	{
+		Name: "pod-timeout",
+		Pods: []corev1.Pod{{
+			ObjectMeta: metav1.ObjectMeta{
+				CreationTimestamp: metav1.NewTime(time.Now().Add(-time.Minute * 2)),
+				Annotations: map[string]string{
+					"eno.azure.io/composition-generation": "2",
+				},
+			},
+		}},
+		Composition: &apiv1.Composition{
+			ObjectMeta: metav1.ObjectMeta{
+				Generation: 2,
+			},
+		},
+		Synth: &apiv1.Synthesizer{
+			Spec: apiv1.SynthesizerSpec{
+				PodTimeout: metav1.Duration{Duration: time.Minute},
+			},
+		},
+		PodShouldExist:     true,
+		PodShouldBeDeleted: true,
+	},
+	{
+		Name: "composition-deleted",
+		Pods: []corev1.Pod{{
+			ObjectMeta: metav1.ObjectMeta{
+				CreationTimestamp: metav1.Now(),
+				Annotations: map[string]string{
+					"eno.azure.io/composition-generation": "2",
+				},
+			},
+		}},
+		Composition: &apiv1.Composition{
+			ObjectMeta: metav1.ObjectMeta{
+				DeletionTimestamp: &metav1.Time{Time: time.Now()},
+				Generation:        2,
+			},
+		},
+		Synth: &apiv1.Synthesizer{
+			Spec: apiv1.SynthesizerSpec{
+				PodTimeout: metav1.Duration{Duration: time.Hour},
+			},
+		},
+		PodShouldExist:     true,
+		PodShouldBeDeleted: true,
+	},
+	{
+		Name: "one-pod-deleting",
+		Pods: []corev1.Pod{{
+			ObjectMeta: metav1.ObjectMeta{
+				CreationTimestamp: metav1.Now(),
+				DeletionTimestamp: &metav1.Time{Time: time.Now()},
+				Annotations: map[string]string{
+					"eno.azure.io/composition-generation": "2",
+				},
+			},
+		}},
+		Composition: &apiv1.Composition{
+			ObjectMeta: metav1.ObjectMeta{
+				Generation: 2,
+			},
+		},
+		Synth: &apiv1.Synthesizer{
+			Spec: apiv1.SynthesizerSpec{
+				PodTimeout: metav1.Duration{Duration: time.Hour},
+			},
+		},
+		PodShouldExist:     false,
+		PodShouldBeDeleted: false,
+	},
+	{
+		Name: "two-pods-deleting",
+		Pods: []corev1.Pod{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					CreationTimestamp: metav1.Now(),
+					DeletionTimestamp: &metav1.Time{Time: time.Now()},
+					Annotations: map[string]string{
+						"eno.azure.io/composition-generation": "2",
+					},
+				},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					CreationTimestamp: metav1.Now(),
+					DeletionTimestamp: &metav1.Time{Time: time.Now()},
+					Annotations: map[string]string{
+						"eno.azure.io/composition-generation": "2",
+					},
+				},
+			},
+		},
+		Composition: &apiv1.Composition{
+			ObjectMeta: metav1.ObjectMeta{
+				Generation: 2,
+			},
+		},
+		Synth: &apiv1.Synthesizer{
+			Spec: apiv1.SynthesizerSpec{
+				PodTimeout: metav1.Duration{Duration: time.Hour},
+			},
+		},
+		PodShouldExist:     true,
+		PodShouldBeDeleted: false,
+	},
+	{
+		Name: "three-pods-deleting",
+		Pods: []corev1.Pod{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					CreationTimestamp: metav1.Now(),
+					DeletionTimestamp: &metav1.Time{Time: time.Now()},
+					Annotations: map[string]string{
+						"eno.azure.io/composition-generation": "2",
+					},
+				},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					CreationTimestamp: metav1.Now(),
+					DeletionTimestamp: &metav1.Time{Time: time.Now()},
+					Annotations: map[string]string{
+						"eno.azure.io/composition-generation": "2",
+					},
+				},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					CreationTimestamp: metav1.Now(),
+					DeletionTimestamp: &metav1.Time{Time: time.Now()},
+					Annotations: map[string]string{
+						"eno.azure.io/composition-generation": "2",
+					},
+				},
+			},
+		},
+		Composition: &apiv1.Composition{
+			ObjectMeta: metav1.ObjectMeta{
+				Generation: 2,
+			},
+		},
+		Synth: &apiv1.Synthesizer{
+			Spec: apiv1.SynthesizerSpec{
+				PodTimeout: metav1.Duration{Duration: time.Hour},
+			},
+		},
+		PodShouldExist:     true,
+		PodShouldBeDeleted: false,
+	},
+}
+
+func TestShouldDeletePod(t *testing.T) {
+	logger := testr.New(t)
+
+	for _, tc := range shouldDeletePodTests {
+		t.Run(tc.Name, func(t *testing.T) {
+			logger, pod, exists := shouldDeletePod(logger, tc.Composition, tc.Synth, &corev1.PodList{Items: tc.Pods})
+			assert.Equal(t, tc.PodShouldExist, exists)
+			assert.Equal(t, tc.PodShouldBeDeleted, pod != nil)
+			logger.Info("logging to see the appended fields for debugging purposes")
+		})
+	}
 }


### PR DESCRIPTION
Currently Eno will keep recreating pods as the current ones are superseded. Naturally this is dangerous since it's possible to end up with an unbounded number of synthesizer pods per composition.

This PR reduces the total max pod concurrency of each composition to 2 - surging by one pod allows fast retries with limited risk.

Also fixes a couple of bugs related to pod lifecycle: corrects the timeout when PodTimeout < ExecTimeout, and avoids exec'ing into deleted pods.