### PR TITLE
Patch the resource slice status instead of updating

### DIFF
--- a/internal/reconstitution/api.go
+++ b/internal/reconstitution/api.go
@@ -21,11 +21,10 @@ type Reconciler interface {
 // Client provides read/write access to a collection of reconstituted resources.
 type Client interface {
 	Get(ctx context.Context, comp *CompositionRef, res *ResourceRef) (*Resource, bool)
-	PatchStatusAsync(ctx context.Context, req *ManifestRef, checkFn CheckPatchFn, patchFn StatusPatchFn)
+	PatchStatusAsync(ctx context.Context, req *ManifestRef, patchFn StatusPatchFn)
 }
 
-type StatusPatchFn func(*apiv1.ResourceState)
-type CheckPatchFn func(*apiv1.ResourceState) bool
+type StatusPatchFn func(*apiv1.ResourceState) *apiv1.ResourceState
 
 // ManifestRef references a particular resource manifest within a resource slice.
 type ManifestRef struct {

--- a/internal/reconstitution/writebuffer.go
+++ b/internal/reconstitution/writebuffer.go
@@ -131,8 +131,9 @@ func (w *writeBuffer) updateSlice(ctx context.Context, sliceNSN types.Namespaced
 	// It's easier to pre-allocate the entire status slice before sending patches
 	// since the "replace" op requires an existing item.
 	if len(slice.Status.Resources) == 0 {
-		slice.Status.Resources = make([]apiv1.ResourceState, len(slice.Spec.Resources))
-		err = w.client.Status().Update(ctx, slice)
+		copy := slice.DeepCopy()
+		copy.Status.Resources = make([]apiv1.ResourceState, len(slice.Spec.Resources))
+		err = w.client.Status().Update(ctx, copy)
 		if err != nil {
 			logger.Error(err, "unable to update resource slice")
 			return false

--- a/internal/reconstitution/writebuffer.go
+++ b/internal/reconstitution/writebuffer.go
@@ -138,6 +138,7 @@ func (w *writeBuffer) updateSlice(ctx context.Context, sliceNSN types.Namespaced
 			logger.Error(err, "unable to update resource slice")
 			return false
 		}
+		slice = copy
 	}
 
 	// Transform the set of patch funcs into a set of jsonpatch objects

--- a/internal/reconstitution/writebuffer.go
+++ b/internal/reconstitution/writebuffer.go
@@ -2,6 +2,7 @@ package reconstitution
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"sync"
 	"time"
@@ -19,7 +20,6 @@ import (
 type asyncStatusUpdate struct {
 	SlicedResource *ManifestRef
 	PatchFn        StatusPatchFn
-	CheckFn        CheckPatchFn
 }
 
 // writeBuffer reduces load on etcd/apiserver by collecting resource slice status
@@ -46,7 +46,7 @@ func newWriteBuffer(cli client.Client, batchInterval time.Duration, burst int) *
 	}
 }
 
-func (w *writeBuffer) PatchStatusAsync(ctx context.Context, ref *ManifestRef, checkFn CheckPatchFn, patchFn StatusPatchFn) {
+func (w *writeBuffer) PatchStatusAsync(ctx context.Context, ref *ManifestRef, patchFn StatusPatchFn) {
 	w.mut.Lock()
 	defer w.mut.Unlock()
 	logger := logr.FromContextOrDiscard(ctx)
@@ -63,7 +63,6 @@ func (w *writeBuffer) PatchStatusAsync(ctx context.Context, ref *ManifestRef, ch
 	w.state[key] = append(currentSlice, &asyncStatusUpdate{
 		SlicedResource: ref,
 		PatchFn:        patchFn,
-		CheckFn:        checkFn,
 	})
 	w.queue.Add(key)
 }
@@ -129,44 +128,44 @@ func (w *writeBuffer) updateSlice(ctx context.Context, sliceNSN types.Namespaced
 		return false
 	}
 
-	// Allocate the status slice if needed
-	var status *apiv1.ResourceSliceStatus
-	var dirty bool
-	if len(slice.Status.Resources) != len(slice.Spec.Resources) {
-		dirty = true
-		status = slice.Status.DeepCopy()
-		status.Resources = make([]apiv1.ResourceState, len(slice.Spec.Resources))
+	// It's easier to pre-allocate the entire status slice before sending patches
+	// since the "replace" op requires an existing item.
+	if len(slice.Status.Resources) == 0 {
+		slice.Status.Resources = make([]apiv1.ResourceState, len(slice.Spec.Resources))
+		err = w.client.Status().Update(ctx, slice)
+		if err != nil {
+			logger.Error(err, "unable to update resource slice")
+			return false
+		}
 	}
 
-	// Use the newly allocated slice (if allocated), otherwise use the already allocated one
+	// Transform the set of patch funcs into a set of jsonpatch objects
 	unsafeSlice := slice.Status.Resources
-	if unsafeSlice == nil {
-		unsafeSlice = status.Resources
-	}
-
-	// The resource slice informer doesn't DeepCopy automatically for perf reasons.
-	// So we can apply the CheckFn to status pointers but not PatchFn.
-	// We'll deep copy the status here only when it needs to change.
+	var patches []*jsonPatch
 	for _, update := range updates {
 		unsafeStatusPtr := &unsafeSlice[update.SlicedResource.Index]
-		if update.CheckFn(unsafeStatusPtr) {
+		patch := update.PatchFn(unsafeStatusPtr)
+		if patch == nil {
 			continue
 		}
 
-		if status == nil {
-			status = slice.Status.DeepCopy()
-		}
-
-		dirty = true
-		update.PatchFn(&status.Resources[update.SlicedResource.Index])
+		patches = append(patches, &jsonPatch{
+			Op:    "replace",
+			Path:  fmt.Sprintf("/status/resources/%d", update.SlicedResource.Index),
+			Value: patch,
+		})
 	}
-	if !dirty {
-		return true
+	if len(patches) == 0 {
+		return true // nothing to do!
 	}
 
-	copy := &apiv1.ResourceSlice{Status: *status}
-	slice.ObjectMeta.DeepCopyInto(&copy.ObjectMeta)
-	err = w.client.Status().Update(ctx, copy)
+	// Encode/apply the patch(es)
+	patchJson, err := json.Marshal(&patches)
+	if err != nil {
+		logger.Error(err, "unable to encode patch")
+		return false
+	}
+	err = w.client.Status().Patch(ctx, slice, client.RawPatch(types.JSONPatchType, patchJson))
 	if err != nil {
 		logger.Error(err, "unable to update resource slice")
 		return false
@@ -174,4 +173,10 @@ func (w *writeBuffer) updateSlice(ctx context.Context, sliceNSN types.Namespaced
 
 	logger.V(0).Info(fmt.Sprintf("updated the status of %d resources in slice", len(updates)))
 	return true
+}
+
+type jsonPatch struct {
+	Op    string `json:"op"`
+	Path  string `json:"path"`
+	Value any    `json:"value"`
 }


### PR DESCRIPTION
We can avoid the overhead of deep copying the entire resource slice by using jsonpatch to update only the modified items. This approach also naturally simplifies the signature of the write buffer since the same func can be used for checking the current state and building the patch.

The perf overhead of full updates isn't a big deal now, but will be once we start updating it 2-3x more often (status updates).