### PR TITLE
Fix patch idempotence

### DIFF
--- a/internal/controllers/reconciliation/controller.go
+++ b/internal/controllers/reconciliation/controller.go
@@ -174,13 +174,13 @@ func (c *Controller) reconcileResource(ctx context.Context, prev, resource *reco
 	if err != nil {
 		return false, fmt.Errorf("building patch: %w", err)
 	}
-	if string(patch) == "{}" {
-		logger.V(1).Info("skipping empty patch")
-		return false, nil
-	}
 	patch, err = mungePatch(patch, current.GetResourceVersion())
 	if err != nil {
 		return false, fmt.Errorf("adding resource version: %w", err)
+	}
+	if len(patch) == 0 {
+		logger.V(1).Info("skipping empty patch")
+		return false, nil
 	}
 	if insecureLogPatch {
 		logger.V(1).Info("INSECURE logging patch", "patch", string(patch))
@@ -262,6 +262,7 @@ func mungePatch(patch []byte, rv string) ([]byte, error) {
 	if err != nil {
 		return nil, reconcile.TerminalError(err)
 	}
+
 	u := unstructured.Unstructured{Object: patchMap}
 	a, err := meta.Accessor(&u)
 	if err != nil {
@@ -269,6 +270,10 @@ func mungePatch(patch []byte, rv string) ([]byte, error) {
 	}
 	a.SetResourceVersion(rv)
 	a.SetCreationTimestamp(metav1.Time{})
+
+	if len(patchMap) <= 1 {
+		return nil, nil // resource version only == empty patch
+	}
 
 	return json.Marshal(patchMap)
 }

--- a/internal/controllers/reconciliation/controller_test.go
+++ b/internal/controllers/reconciliation/controller_test.go
@@ -1,0 +1,20 @@
+package reconciliation
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMungePatch(t *testing.T) {
+	patch, err := mungePatch([]byte(`{"metadata":{"creationTimestamp":"2024-03-05T00:45:27Z"}, "foo":"bar"}`), "test-rv")
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"metadata":{"resourceVersion":"test-rv"},"foo":"bar"}`, string(patch))
+}
+
+func TestMungePatchEmpty(t *testing.T) {
+	patch, err := mungePatch([]byte(`{"metadata":{"creationTimestamp":"2024-03-05T00:45:27Z"}}`), "test-rv")
+	require.NoError(t, err)
+	assert.Nil(t, patch)
+}


### PR DESCRIPTION
The reconciliation controller isn't actually idempotent currently, although the impact is hidden by the resource version cache.

e.g. if a resource's version hasn't changed, we won't even attempt to build a patch for it. But when we do, we always send it to the server.