### PR TITLE
Reduce memory consumption

### DIFF
--- a/cmd/eno-controller/main.go
+++ b/cmd/eno-controller/main.go
@@ -80,10 +80,5 @@ func run() error {
 		return fmt.Errorf("constructing pod lifecycle controller: %w", err)
 	}
 
-	err = synthesis.NewSliceCleanupController(mgr)
-	if err != nil {
-		return fmt.Errorf("constructing resource slice cleanup controller: %w", err)
-	}
-
 	return mgr.Start(ctx)
 }

--- a/cmd/eno-reconciler/main.go
+++ b/cmd/eno-reconciler/main.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/Azure/eno/internal/controllers/aggregation"
 	"github.com/Azure/eno/internal/controllers/reconciliation"
+	"github.com/Azure/eno/internal/controllers/synthesis"
 	"github.com/Azure/eno/internal/k8s"
 	"github.com/Azure/eno/internal/manager"
 	"github.com/Azure/eno/internal/reconstitution"
@@ -72,6 +73,11 @@ func run() error {
 	err = aggregation.NewStatusController(mgr)
 	if err != nil {
 		return fmt.Errorf("constructing status aggregation controller: %w", err)
+	}
+
+	err = synthesis.NewSliceCleanupController(mgr)
+	if err != nil {
+		return fmt.Errorf("constructing resource slice cleanup controller: %w", err)
 	}
 
 	remoteConfig := mgr.GetConfig()

--- a/examples/loadtest.yaml
+++ b/examples/loadtest.yaml
@@ -4,18 +4,20 @@ metadata:
   name: load-test-synth
 spec:
   image: docker.io/ubuntu:latest
+  execTimeout: 1m
   command:
   - /bin/bash
   - -c
   - |
       n=3000
+      tr -dc A-Za-z0-9 </dev/urandom | head -c 4096 > rando
       echo -n "{\"apiVersion\":\"config.kubernetes.io/v1\",\"kind\":\"ResourceList\",\"items\":["
       for i in $(seq $n); do
         echo -n "{
           \"apiVersion\": \"v1\",
           \"kind\": \"ConfigMap\",
           \"metadata\": { \"name\": \"test-cm-${i}\", \"namespace\": \"default\", \"annotations\": { \"eno.azure.io/reconcile-interval\": \"30s\" } },
-          \"data\": { \"foo\": \"$(tr -dc A-Za-z0-9 </dev/urandom | head -c 4096; echo)\" }
+          \"data\": { \"foo\": \"$(cat rando)\" }
         }"
         if [[ $i == $n ]]; then
           echo "]}"

--- a/internal/controllers/aggregation/status.go
+++ b/internal/controllers/aggregation/status.go
@@ -63,7 +63,7 @@ func (s *statusController) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 			}
 
 			// Readiness
-			if ready && (state.Ready == nil || !*state.Ready) {
+			if state.Ready == nil || !*state.Ready {
 				ready = false
 			}
 		}

--- a/internal/controllers/aggregation/status.go
+++ b/internal/controllers/aggregation/status.go
@@ -63,7 +63,7 @@ func (s *statusController) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 			}
 
 			// Readiness
-			if state.Ready == nil || !*state.Ready {
+			if ready && (state.Ready == nil || !*state.Ready) {
 				ready = false
 			}
 		}

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -94,7 +94,7 @@ func NewManager(t *testing.T) *Manager {
 	cfg, err := env.Start()
 	require.NoError(t, err)
 
-	mgr, err := manager.New(logr.FromContextOrDiscard(NewContext(t)), &manager.Options{
+	mgr, err := manager.NewTest(logr.FromContextOrDiscard(NewContext(t)), &manager.Options{
 		Rest:            cfg,
 		HealthProbeAddr: "127.0.0.1:0",
 		MetricsAddr:     "127.0.0.1:0",


### PR DESCRIPTION
Compositions can contain a ton of resources, which are currently cached in the controller's informers, the reconciler's informers, and the reconciler's reconstitution cache. This change reduces the number of in-memory copies to 1: the reconstitution cache.

- Moves slice cleanup controller to reconciler so the controller no longer starts up a resource slice informer
- Strips the `manifest` property out of resource slices in the reconciler informers
- Gets the full resource slice from a non-caching client when filling the reconstitution cache