### PR TITLE
3 tiny test fixes

### DIFF
--- a/examples/loadtest.yaml
+++ b/examples/loadtest.yaml
@@ -62,9 +62,9 @@ spec:
         - |
           n=0
           while true; do
-            timeout="10s"
+            timeout="61s"
             if [[ $(($n % 2)) == 1 ]]; then
-              timeout="11s"
+              timeout="60s"
             fi
 
             kubectl patch synthesizers load-test-synth --type=merge --patch "{\"spec\":{\"timeout\": \"$timeout\"}}"

--- a/internal/controllers/reconciliation/status_test.go
+++ b/internal/controllers/reconciliation/status_test.go
@@ -107,16 +107,6 @@ func TestResourceReadiness(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	// It should eventually be marked as ready
-	testutil.Eventually(t, func() bool {
-		slices, err := mgr.GetCurrentResourceSlices(ctx)
-		if err != nil {
-			t.Log(err)
-			return false
-		}
-		return len(slices[0].Status.Resources) > 0 && isReady(slices[0].Status.Resources[0])
-	})
-
 	// The composition should also be updated
 	testutil.Eventually(t, func() bool {
 		err = upstream.Get(ctx, client.ObjectKeyFromObject(comp), comp)

--- a/internal/controllers/synthesis/backoff_test.go
+++ b/internal/controllers/synthesis/backoff_test.go
@@ -43,8 +43,8 @@ func TestControllerBackoff(t *testing.T) {
 			return comp.Status.CurrentSynthesis != nil && comp.Status.CurrentSynthesis.Attempts >= 3
 		})
 
-		// It shouldn't be possible to try three times within 1s
-		assert.Greater(t, int(time.Since(start).Milliseconds()), 1000)
+		// It shouldn't be possible to try three times within 250ms
+		assert.Greater(t, int(time.Since(start).Milliseconds()), 250)
 	})
 }
 


### PR DESCRIPTION
- Removes a flaky assertion that isn't useful anyway
- Extends the load test's synthesizer timeout
- Greatly reduces the risk of flakes in another time-based test (I've only seen this one flake once anyway)
