### PR TITLE
Add watchdog controller

### DIFF
--- a/internal/controllers/watchdog/controller.go
+++ b/internal/controllers/watchdog/controller.go
@@ -1,0 +1,71 @@
+package watchdog
+
+import (
+	"context"
+	"time"
+
+	apiv1 "github.com/Azure/eno/api/v1"
+	"github.com/Azure/eno/internal/manager"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// watchdogController exposes metrics that track the states of Eno resources relative to the current time.
+// The idea is to identify deadlock states so they can be alerted on.
+type watchdogController struct {
+	client    client.Client
+	threshold time.Duration
+}
+
+func NewController(mgr ctrl.Manager, threshold time.Duration) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&apiv1.Composition{}).
+		WithLogConstructor(manager.NewLogConstructor(mgr, "watchdogController")).
+		Complete(&watchdogController{
+			client:    mgr.GetClient(),
+			threshold: threshold,
+		})
+}
+
+func (c *watchdogController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	list := &apiv1.CompositionList{}
+	err := c.client.List(ctx, list)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	var unrecd int
+	var unready int
+	for _, comp := range list.Items {
+		if c.pendingReconciliation(&comp) {
+			unrecd++
+		}
+		if c.pendingReadiness(&comp) {
+			unready++
+		}
+	}
+
+	pendingReconciliation.Set(float64(unrecd))
+	pendingReadiness.Set(float64(unready))
+
+	return ctrl.Result{}, nil
+}
+
+func (c *watchdogController) pendingReconciliation(comp *apiv1.Composition) bool {
+	return !synthesisHasReconciled(comp.Status.CurrentSynthesis) &&
+		!synthesisHasReconciled(comp.Status.PreviousSynthesis) &&
+		time.Since(comp.CreationTimestamp.Time) > c.threshold
+}
+
+func (c *watchdogController) pendingReadiness(comp *apiv1.Composition) bool {
+	return !synthesisIsReady(comp.Status.CurrentSynthesis) &&
+		!synthesisIsReady(comp.Status.PreviousSynthesis) &&
+		c.timeSinceReconcilePastThreshold(comp)
+}
+
+func (c *watchdogController) timeSinceReconcilePastThreshold(comp *apiv1.Composition) bool {
+	return comp.Status.CurrentSynthesis != nil && comp.Status.CurrentSynthesis.Reconciled != nil && time.Since(comp.Status.CurrentSynthesis.Reconciled.Time) > c.threshold
+}
+
+func synthesisHasReconciled(syn *apiv1.Synthesis) bool { return syn != nil && syn.Reconciled != nil }
+func synthesisIsReady(syn *apiv1.Synthesis) bool       { return syn != nil && syn.Ready != nil }

--- a/internal/controllers/watchdog/controller_test.go
+++ b/internal/controllers/watchdog/controller_test.go
@@ -1,0 +1,98 @@
+package watchdog
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+
+	apiv1 "github.com/Azure/eno/api/v1"
+)
+
+var controllerLogicTests = []struct {
+	Name                        string
+	Composition                 *apiv1.Composition
+	ExpectPendingReconciliation bool
+	ExpectPendingReadiness      bool
+}{
+	{
+		Name: "ready",
+		Composition: &apiv1.Composition{
+			Status: apiv1.CompositionStatus{
+				CurrentSynthesis: &apiv1.Synthesis{
+					Reconciled: &metav1.Time{},
+					Ready:      &metav1.Time{},
+				},
+			},
+		},
+	},
+	{
+		Name: "previously ready",
+		Composition: &apiv1.Composition{
+			Status: apiv1.CompositionStatus{
+				PreviousSynthesis: &apiv1.Synthesis{
+					Reconciled: &metav1.Time{},
+					Ready:      &metav1.Time{},
+				},
+			},
+		},
+	},
+	{
+		Name: "within threshold",
+		Composition: &apiv1.Composition{
+			ObjectMeta: metav1.ObjectMeta{
+				CreationTimestamp: metav1.Now(),
+			},
+			Status: apiv1.CompositionStatus{},
+		},
+	},
+	{
+		Name: "reconciliation outside of threshold",
+		Composition: &apiv1.Composition{
+			ObjectMeta: metav1.ObjectMeta{
+				CreationTimestamp: metav1.NewTime(time.Now().Add(-time.Minute * 3)),
+			},
+			Status: apiv1.CompositionStatus{},
+		},
+		ExpectPendingReconciliation: true,
+		// readiness isn't firing yet, since we haven't finished reconciliation
+	},
+	{
+		Name: "readiness outside of threshold",
+		Composition: &apiv1.Composition{
+			Status: apiv1.CompositionStatus{
+				CurrentSynthesis: &apiv1.Synthesis{
+					Reconciled: ptr.To(metav1.NewTime(time.Now().Add(-time.Minute * 3))),
+				},
+			},
+		},
+		ExpectPendingReadiness: true,
+	},
+	{
+		Name: "readiness within threshold",
+		Composition: &apiv1.Composition{
+			ObjectMeta: metav1.ObjectMeta{
+				CreationTimestamp: metav1.NewTime(time.Now().Add(-time.Minute * 3)),
+			},
+			Status: apiv1.CompositionStatus{
+				CurrentSynthesis: &apiv1.Synthesis{
+					Reconciled: ptr.To(metav1.NewTime(time.Now().Add(-time.Second))),
+				},
+			},
+		},
+	},
+}
+
+func TestControllerLogic(t *testing.T) {
+	for _, tc := range controllerLogicTests {
+		t.Run(tc.Name, func(t *testing.T) {
+			c := &watchdogController{threshold: time.Minute}
+			unrecd := c.pendingReconciliation(tc.Composition)
+			unready := c.pendingReadiness(tc.Composition)
+			assert.Equal(t, tc.ExpectPendingReconciliation, unrecd, "Reconciliation")
+			assert.Equal(t, tc.ExpectPendingReadiness, unready, "Readiness")
+		})
+	}
+}

--- a/internal/controllers/watchdog/metrics.go
+++ b/internal/controllers/watchdog/metrics.go
@@ -1,0 +1,26 @@
+package watchdog
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+var (
+	pendingReconciliation = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "eno_compositions_stuck_reconciling_total",
+			Help: "Number of compositions that have not been reconciled since a period after their creation",
+		},
+	)
+
+	pendingReadiness = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "eno_compositions_nonready_total",
+			Help: "Number of compositions that have not become ready since a period after their reconciliation",
+		},
+	)
+)
+
+func init() {
+	metrics.Registry.MustRegister(pendingReconciliation, pendingReadiness)
+}


### PR DESCRIPTION
kube-state-metrics can't compare timestamps against the current time so we need to implement that monitoring logic within Eno.
