### PR TITLE
Limit the scope of configured selectors

### DIFF
--- a/cmd/eno-controller/main.go
+++ b/cmd/eno-controller/main.go
@@ -9,6 +9,7 @@ import (
 	"github.com/go-logr/zapr"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
+	"k8s.io/apimachinery/pkg/labels"
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	"github.com/Azure/eno/internal/controllers/synthesis"
@@ -26,9 +27,11 @@ func main() {
 func run() error {
 	ctx := ctrl.SetupSignalHandler()
 	var (
-		debugLogging  bool
-		watchdogThres time.Duration
-		synconf       = &synthesis.Config{}
+		debugLogging         bool
+		watchdogThres        time.Duration
+		compositionSelector  string
+		compositionNamespace string
+		synconf              = &synthesis.Config{}
 
 		mgrOpts = &manager.Options{
 			Rest: ctrl.GetConfigOrDie(),
@@ -39,6 +42,8 @@ func run() error {
 	flag.StringVar(&synconf.PodServiceAccount, "synthesizer-pod-service-account", "", "Service account name to be assigned to synthesizer Pods.")
 	flag.BoolVar(&debugLogging, "debug", true, "Enable debug logging")
 	flag.DurationVar(&watchdogThres, "watchdog-threshold", time.Minute*5, "How long before the watchdog considers a mid-transition resource to be stuck")
+	flag.StringVar(&compositionSelector, "composition-label-selector", "", "Optional label selector for compositions to be reconciled")
+	flag.StringVar(&compositionNamespace, "composition-namespace", "", "Optional namespace to limit compositions that will be reconciled")
 	mgrOpts.Bind(flag.CommandLine)
 	flag.Parse()
 
@@ -46,6 +51,17 @@ func run() error {
 		return fmt.Errorf("a value is required in --synthesizer-pod-namespace or POD_NAMESPACE")
 	}
 	mgrOpts.SynthesizerPodNamespace = synconf.PodNamespace
+	mgrOpts.CompositionNamespace = compositionNamespace
+
+	if compositionSelector != "" {
+		var err error
+		mgrOpts.CompositionSelector, err = labels.Parse(compositionSelector)
+		if err != nil {
+			return fmt.Errorf("invalid composition label selector: %w", err)
+		}
+	} else {
+		mgrOpts.CompositionSelector = labels.Everything()
+	}
 
 	zapCfg := zap.NewProductionConfig()
 	if debugLogging {

--- a/cmd/eno-reconciler/main.go
+++ b/cmd/eno-reconciler/main.go
@@ -9,6 +9,7 @@ import (
 	"github.com/go-logr/zapr"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	ctrl "sigs.k8s.io/controller-runtime"
 
@@ -50,8 +51,8 @@ func run() error {
 	flag.StringVar(&remoteKubeconfigFile, "remote-kubeconfig", "", "Path to the kubeconfig of the apiserver where the resources will be reconciled. The config from the environment is used if this is not provided")
 	flag.Float64Var(&remoteQPS, "remote-qps", 0, "Max requests per second to the remote apiserver")
 	flag.DurationVar(&readinessPollInterval, "readiness-poll-interval", time.Second*5, "Interval at which non-ready resources will be checked for readiness")
-	flag.StringVar(&compositionSelector, "composition-label-selector", "", "Optional label selector for compositions to be reconciled")
-	flag.StringVar(&compositionNamespace, "composition-namespace", "", "Optional namespace to limit compositions that will be reconciled")
+	flag.StringVar(&compositionSelector, "composition-label-selector", labels.Everything().String(), "Optional label selector for compositions to be reconciled")
+	flag.StringVar(&compositionNamespace, "composition-namespace", metav1.NamespaceAll, "Optional namespace to limit compositions that will be reconciled")
 	mgrOpts.Bind(flag.CommandLine)
 	flag.Parse()
 

--- a/internal/manager/options.go
+++ b/internal/manager/options.go
@@ -2,9 +2,7 @@ package manager
 
 import (
 	"flag"
-	"fmt"
 
-	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/leaderelection"
@@ -13,12 +11,14 @@ import (
 type Options struct {
 	leaderelection.Options
 	Rest                    *rest.Config
-	FieldSelector           string
-	LabelSelector           string
 	HealthProbeAddr         string
 	MetricsAddr             string
 	SynthesizerPodNamespace string  // set in cmd from synthesis config
 	qps                     float64 // flags don't support float32, bind to this value and copy over to Rest.QPS during initialization
+
+	// Only set by cmd in reconciler process
+	CompositionNamespace string
+	CompositionSelector  labels.Selector
 }
 
 func (o *Options) Bind(set *flag.FlagSet) {
@@ -26,32 +26,8 @@ func (o *Options) Bind(set *flag.FlagSet) {
 	set.StringVar(&o.MetricsAddr, "metrics-addr", ":8080", "Address to serve Prometheus metrics on")
 	set.IntVar(&o.Rest.Burst, "burst", 50, "apiserver client rate limiter burst configuration")
 	set.Float64Var(&o.qps, "qps", 20, "Max requests per second to apiserver")
-	set.StringVar(&o.FieldSelector, "watch-field-selector", "", "Only reconcile resources that match the given field selector")
-	set.StringVar(&o.LabelSelector, "watch-label-selector", "", "Only reconcile resiurces that match the given label selector")
 	set.BoolVar(&o.LeaderElection, "leader-election", false, "Enable leader election")
 	set.StringVar(&o.LeaderElectionNamespace, "leader-election-namespace", "", "Determines the namespace in which the leader election resource will be created")
 	set.StringVar(&o.LeaderElectionResourceLock, "leader-election-resource-lock", "", "Determines which resource lock to use for leader election")
 	set.StringVar(&o.LeaderElectionID, "leader-election-id", "", "Determines the name of the resource that leader election will use for holding the leader lock")
-}
-
-func (o *Options) getDefaultLabelSelector() (labels.Selector, error) {
-	if o.LabelSelector == "" {
-		return labels.Everything(), nil
-	}
-	s, err := labels.Parse(o.LabelSelector)
-	if err != nil {
-		return nil, fmt.Errorf("could not parse watch-label-selector flag: %w", err)
-	}
-	return s, nil
-}
-
-func (o *Options) getDefaultFieldSelector() (fields.Selector, error) {
-	if o.FieldSelector == "" {
-		return fields.Everything(), nil
-	}
-	f, err := fields.ParseSelector(o.FieldSelector)
-	if err != nil {
-		return nil, fmt.Errorf("could not parse watch-field-selector flag: %w", err)
-	}
-	return f, nil
 }


### PR DESCRIPTION
Currently we allow users to set default label/field selectors, but that can exposes a pretty significant space of impossible configurations, since one could set a label selector that matches a composition but not its resource slices, synthesis pods, etc.

So let's scope down those configurations: only allow setting a namespace and label selector _on compositions_ from only the reconciler. The controller can't really support selectors easily, and doesn't benefit much from them either.
