### PR TITLE
Symphony status improvements

### DIFF
--- a/api/v1/config/crd/eno.azure.io_symphonies.yaml
+++ b/api/v1/config/crd/eno.azure.io_symphonies.yaml
@@ -82,6 +82,9 @@ spec:
             type: object
           status:
             properties:
+              observedGeneration:
+                format: int64
+                type: integer
               ready:
                 format: date-time
                 type: string

--- a/api/v1/symphony.go
+++ b/api/v1/symphony.go
@@ -28,10 +28,11 @@ type SymphonySpec struct {
 }
 
 type SymphonyStatus struct {
-	Synthesized  *metav1.Time     `json:"synthesized,omitempty"`
-	Reconciled   *metav1.Time     `json:"reconciled,omitempty"`
-	Ready        *metav1.Time     `json:"ready,omitempty"`
-	Synthesizers []SynthesizerRef `json:"synthesizers,omitempty"`
+	ObservedGeneration int64            `json:"observedGeneration,omitempty"`
+	Synthesized        *metav1.Time     `json:"synthesized,omitempty"`
+	Reconciled         *metav1.Time     `json:"reconciled,omitempty"`
+	Ready              *metav1.Time     `json:"ready,omitempty"`
+	Synthesizers       []SynthesizerRef `json:"synthesizers,omitempty"`
 }
 
 type Variation struct {

--- a/internal/controllers/aggregation/symphony.go
+++ b/internal/controllers/aggregation/symphony.go
@@ -59,7 +59,7 @@ func (c *symphonyController) Reconcile(ctx context.Context, req ctrl.Request) (c
 }
 
 func (c *symphonyController) buildStatus(symph *apiv1.Symphony, comps *apiv1.CompositionList) (apiv1.SymphonyStatus, bool) {
-	newStatus := apiv1.SymphonyStatus{Synthesizers: symph.Status.Synthesizers}
+	newStatus := apiv1.SymphonyStatus{ObservedGeneration: symph.Generation, Synthesizers: symph.Status.Synthesizers}
 
 	synthMap := map[string]struct{}{}
 	for _, comp := range comps.Items {

--- a/internal/controllers/aggregation/symphony.go
+++ b/internal/controllers/aggregation/symphony.go
@@ -64,7 +64,7 @@ func (c *symphonyController) buildStatus(symph *apiv1.Symphony, comps *apiv1.Com
 	synthMap := map[string]struct{}{}
 	for _, comp := range comps.Items {
 		synthMap[comp.Spec.Synthesizer.Name] = struct{}{}
-		if comp.Status.CurrentSynthesis == nil {
+		if comp.Status.CurrentSynthesis == nil || comp.Status.CurrentSynthesis.ObservedCompositionGeneration != comp.Generation || comp.DeletionTimestamp != nil {
 			return newStatus, false
 		}
 

--- a/internal/controllers/aggregation/symphony_test.go
+++ b/internal/controllers/aggregation/symphony_test.go
@@ -15,6 +15,7 @@ func TestBuildSymphonyStatusHappyPath(t *testing.T) {
 	now := metav1.Now()
 
 	symph := &apiv1.Symphony{}
+	symph.Generation = 123
 	symph.Spec.Variations = []apiv1.Variation{{Synthesizer: apiv1.SynthesizerRef{Name: "synth1"}}, {Synthesizer: apiv1.SynthesizerRef{Name: "synth2"}}}
 
 	comp1 := apiv1.Composition{}
@@ -42,9 +43,10 @@ func TestBuildSymphonyStatusHappyPath(t *testing.T) {
 	status, changed := c.buildStatus(symph, comps)
 	require.True(t, changed)
 	assert.Equal(t, apiv1.SymphonyStatus{
-		Synthesized: ptr.To(metav1.NewTime(now.Add(time.Minute))),
-		Reconciled:  ptr.To(metav1.NewTime(now.Add(time.Minute + time.Second))),
-		Ready:       ptr.To(metav1.NewTime(now.Add(time.Minute + (time.Second * 2)))),
+		ObservedGeneration: 123,
+		Synthesized:        ptr.To(metav1.NewTime(now.Add(time.Minute))),
+		Reconciled:         ptr.To(metav1.NewTime(now.Add(time.Minute + time.Second))),
+		Ready:              ptr.To(metav1.NewTime(now.Add(time.Minute + (time.Second * 2)))),
 	}, status)
 
 	// It should not update the status when it already matches

--- a/internal/controllers/reconciliation/symphony_test.go
+++ b/internal/controllers/reconciliation/symphony_test.go
@@ -66,7 +66,7 @@ func TestSymphonyIntegration(t *testing.T) {
 
 	testutil.Eventually(t, func() bool {
 		upstream.Get(ctx, client.ObjectKeyFromObject(symph), symph)
-		return symph.Status.Reconciled != nil
+		return symph.Status.Reconciled != nil && symph.Status.ObservedGeneration == symph.Generation
 	})
 
 	// Deletion

--- a/internal/controllers/replication/symphony.go
+++ b/internal/controllers/replication/symphony.go
@@ -114,8 +114,11 @@ func (c *symphonyController) reconcileReverse(ctx context.Context, symph *apiv1.
 		comp := comp
 		existingBySynthName[comp.Spec.Synthesizer.Name] = append(existingBySynthName[comp.Spec.Synthesizer.Name], &comp)
 
-		if _, ok := expectedSynths[comp.Spec.Synthesizer.Name]; (ok || comp.DeletionTimestamp == nil) && symph.DeletionTimestamp == nil {
-			continue // should still exist, or already deleting
+		if _, ok := expectedSynths[comp.Spec.Synthesizer.Name]; ok && symph.DeletionTimestamp == nil {
+			continue // should still exist
+		}
+		if comp.DeletionTimestamp != nil {
+			continue // already deleting
 		}
 
 		err := c.client.Delete(ctx, &comp)

--- a/internal/controllers/replication/symphony_test.go
+++ b/internal/controllers/replication/symphony_test.go
@@ -146,10 +146,12 @@ func TestSymphonyDuplicateCleanup(t *testing.T) {
 	now := metav1.Now()
 	comp.CreationTimestamp = metav1.NewTime(now.Add(time.Second))
 	comp.Name = "foo"
+	comp.Spec.Synthesizer.Name = "foo"
 
 	comp2 := apiv1.Composition{}
 	comp2.CreationTimestamp = now
 	comp2.Name = "bar"
+	comp2.Spec.Synthesizer.Name = "foo"
 
 	comps := &apiv1.CompositionList{Items: []apiv1.Composition{comp, comp2}}
 	_, _, err := s.reconcileReverse(ctx, sym, comps)


### PR DESCRIPTION
Adds an observed generation property and counts deletion against composition status. The idea is that callers should be able to trust that when `observedGeneration == generation` all compositions are in the state reflected by the status.