### PR TITLE
More symphony-related improvements

### DIFF
--- a/internal/controllers/synthesis/lifecycle_test.go
+++ b/internal/controllers/synthesis/lifecycle_test.go
@@ -294,6 +294,31 @@ var shouldDeletePodTests = []struct {
 		PodShouldBeDeleted: true,
 	},
 	{
+		Name: "composition-and-pod-deleted",
+		Pods: []corev1.Pod{{
+			ObjectMeta: metav1.ObjectMeta{
+				CreationTimestamp: metav1.Now(),
+				DeletionTimestamp: ptr.To(metav1.Now()),
+				Annotations: map[string]string{
+					"eno.azure.io/composition-generation": "2",
+				},
+			},
+		}},
+		Composition: &apiv1.Composition{
+			ObjectMeta: metav1.ObjectMeta{
+				DeletionTimestamp: &metav1.Time{Time: time.Now()},
+				Generation:        2,
+			},
+		},
+		Synth: &apiv1.Synthesizer{
+			Spec: apiv1.SynthesizerSpec{
+				PodTimeout: ptr.To(metav1.Duration{Duration: time.Hour}),
+			},
+		},
+		PodShouldExist:     false,
+		PodShouldBeDeleted: false,
+	},
+	{
 		Name: "one-pod-deleting",
 		Pods: []corev1.Pod{{
 			ObjectMeta: metav1.ObjectMeta{

--- a/internal/controllers/synthesis/slicecleanup.go
+++ b/internal/controllers/synthesis/slicecleanup.go
@@ -51,7 +51,7 @@ func (c *sliceCleanupController) Reconcile(ctx context.Context, req ctrl.Request
 		err = c.client.Get(ctx, client.ObjectKeyFromObject(comp), comp)
 		if errors.IsNotFound(err) && time.Since(slice.CreationTimestamp.Time) < time.Minute {
 			logger.V(1).Info("didn't find a composition for this resource slice - ignoring because resource slice is new so informer may just be stale")
-			return ctrl.Result{}, nil
+			return ctrl.Result{RequeueAfter: time.Minute}, nil
 		}
 		if client.IgnoreNotFound(err) != nil {
 			return ctrl.Result{}, fmt.Errorf("getting composition: %w", err)

--- a/internal/controllers/synthesis/status.go
+++ b/internal/controllers/synthesis/status.go
@@ -53,6 +53,9 @@ func (c *statusController) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	comp.Namespace = pod.GetLabels()[manager.CompositionNamespaceLabelKey]
 	err = c.client.Get(ctx, client.ObjectKeyFromObject(comp), comp)
 	if errors.IsNotFound(err) {
+		if pod.DeletionTimestamp != nil {
+			return ctrl.Result{}, nil // nothing to do
+		}
 		logger.V(0).Info("composition was deleted unexpectedly - releasing synthesizer pod")
 		return c.removeFinalizer(ctx, pod)
 	}


### PR DESCRIPTION
- Terminating pods shouldn't block composition deletion
- Symphony status fields should be nil if _any_ of the compositions have not reached that state. Currently it takes the max value.
- Don't re-delete resources in a couple of obscure cases
- Retry stale cache errors

That last one is tricky. When reading compositions from the resource slice status controller we error on 404s within 1min of resource slice creation. This is an excessively long time for informers to be sync'd, typically another event is received within a couple of ms. But there is one case in which this code can be reached legitimately: compositions that were deleted during synthesis. A resource slice may have already been written before deletion, so it will (rightly) not hold the composition finalizer. It's fine to defer GC'ing that slice for 1min but currently we never retry, so it will be blocked until resync.