### PR TITLE
Fix symphony test flake

### DIFF
--- a/internal/controllers/reconciliation/symphony_test.go
+++ b/internal/controllers/reconciliation/symphony_test.go
@@ -103,7 +103,7 @@ func TestSymphonyIntegration(t *testing.T) {
 	testutil.Eventually(t, func() bool {
 		current := &apiv1.Symphony{} // invalidate cache
 		upstream.Get(ctx, client.ObjectKeyFromObject(symph), current)
-		return symph.Status.Reconciled != nil && current.Status.ObservedGeneration == symph.Generation && len(current.Status.Synthesizers) == 1
+		return current.Status.Reconciled != nil && current.Status.ObservedGeneration == current.Generation && len(current.Status.Synthesizers) == 1
 	})
 
 	comps := &apiv1.CompositionList{}


### PR DESCRIPTION
There's kind of a typo here that uses a potentially stale struct instead of the fresh one.