### PR TITLE
Allow labels to be set on synthesizer pods

### DIFF
--- a/cmd/eno-controller/main_test.go
+++ b/cmd/eno-controller/main_test.go
@@ -1,0 +1,14 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseMapString(t *testing.T) {
+	assert.Equal(t, map[string]string{
+		"foo": "bar",
+		"baz": "a=string=with=equals",
+	}, parseMapString("foo=bar,baz=a=string=with=equals,another"))
+}

--- a/internal/controllers/synthesis/lifecycle.go
+++ b/internal/controllers/synthesis/lifecycle.go
@@ -23,6 +23,7 @@ type Config struct {
 	SliceCreationQPS  float64
 	PodNamespace      string
 	PodServiceAccount string
+	PodLabels         map[string]string
 }
 
 type podLifecycleController struct {

--- a/internal/controllers/synthesis/pod.go
+++ b/internal/controllers/synthesis/pod.go
@@ -14,12 +14,14 @@ func newPod(cfg *Config, comp *apiv1.Composition, syn *apiv1.Synthesizer) *corev
 	pod.GenerateName = "synthesis-"
 	pod.Namespace = cfg.PodNamespace
 	pod.Finalizers = []string{"eno.azure.io/cleanup"}
-	pod.Labels = map[string]string{
-		manager.CompositionNameLabelKey:      comp.Name,
-		manager.CompositionNamespaceLabelKey: comp.Namespace,
-		manager.ManagerLabelKey:              manager.ManagerLabelValue,
-		"eno.azure.io/synthesis-uuid":        comp.Status.CurrentSynthesis.UUID,
+	pod.Labels = map[string]string{}
+	if cfg.PodLabels != nil {
+		pod.Labels = cfg.PodLabels
 	}
+	pod.Labels[manager.CompositionNameLabelKey] = comp.Name
+	pod.Labels[manager.CompositionNamespaceLabelKey] = comp.Namespace
+	pod.Labels[manager.ManagerLabelKey] = manager.ManagerLabelValue
+	pod.Labels["eno.azure.io/synthesis-uuid"] = comp.Status.CurrentSynthesis.UUID
 	pod.Annotations = map[string]string{
 		"eno.azure.io/composition-generation": strconv.FormatInt(comp.Generation, 10),
 		"eno.azure.io/synthesizer-generation": strconv.FormatInt(syn.Generation, 10),
@@ -39,24 +41,6 @@ func newPod(cfg *Config, comp *apiv1.Composition, syn *apiv1.Synthesizer) *corev
 				},
 				RunAsUser:    &userID,
 				RunAsNonRoot: &yes,
-			},
-			Env: []corev1.EnvVar{
-				{
-					Name:  "COMPOSITION_NAME",
-					Value: comp.Name,
-				},
-				{
-					Name:  "COMPOSITION_NAMESPACE",
-					Value: comp.Namespace,
-				},
-				{
-					Name:  "COMPOSITION_GENERATION",
-					Value: strconv.FormatInt(comp.Generation, 10),
-				},
-				{
-					Name:  "SYNTHESIZER_GENERATION",
-					Value: strconv.FormatInt(syn.Generation, 10),
-				},
 			},
 		}},
 	}


### PR DESCRIPTION
Passes down labels from a CLI flag. Useful for signaling to log exporters, etc.