### PR TITLE
Move discovery invalidation logic into reconciler

### DIFF
--- a/cmd/eno-reconciler/main.go
+++ b/cmd/eno-reconciler/main.go
@@ -47,7 +47,6 @@ func run() error {
 			DiscoveryRPS: 2,
 		}
 	)
-	flag.BoolVar(&recOpts.RediscoverWhenNotFound, "rediscover-when-not-found", true, "Invalidate discovery cache when any type is not found in the openapi spec. Set this to false on <= k8s 1.14")
 	flag.DurationVar(&writeBatchInterval, "write-batch-interval", time.Second*5, "The max throughput of composition status updates")
 	flag.BoolVar(&debugLogging, "debug", true, "Enable debug logging")
 	flag.StringVar(&remoteKubeconfigFile, "remote-kubeconfig", "", "Path to the kubeconfig of the apiserver where the resources will be reconciled. The config from the environment is used if this is not provided")

--- a/internal/controllers/reconciliation/controller.go
+++ b/internal/controllers/reconciliation/controller.go
@@ -36,8 +36,7 @@ type Options struct {
 	WriteBuffer *flowcontrol.ResourceSliceWriteBuffer
 	Downstream  *rest.Config
 
-	DiscoveryRPS           float32
-	RediscoverWhenNotFound bool
+	DiscoveryRPS float32
 
 	Timeout               time.Duration
 	ReadinessPollInterval time.Duration
@@ -61,7 +60,7 @@ func New(opts Options) (*Controller, error) {
 		return nil, err
 	}
 
-	disc, err := discovery.NewCache(opts.Downstream, opts.DiscoveryRPS, opts.RediscoverWhenNotFound)
+	disc, err := discovery.NewCache(opts.Downstream, opts.DiscoveryRPS)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/controllers/reconciliation/controller_test.go
+++ b/internal/controllers/reconciliation/controller_test.go
@@ -27,14 +27,13 @@ func setupTestSubject(t *testing.T, mgr *testutil.Manager) *Controller {
 	rswb := flowcontrol.NewResourceSliceWriteBufferForManager(mgr.Manager, time.Millisecond*10, 1)
 	cache := reconstitution.NewCache(mgr.GetClient())
 	rc, err := New(Options{
-		Manager:                mgr.Manager,
-		Cache:                  cache,
-		WriteBuffer:            rswb,
-		Downstream:             mgr.DownstreamRestConfig,
-		DiscoveryRPS:           5,
-		RediscoverWhenNotFound: testutil.AtLeastVersion(t, 15),
-		Timeout:                time.Minute,
-		ReadinessPollInterval:  time.Hour,
+		Manager:               mgr.Manager,
+		Cache:                 cache,
+		WriteBuffer:           rswb,
+		Downstream:            mgr.DownstreamRestConfig,
+		DiscoveryRPS:          5,
+		Timeout:               time.Minute,
+		ReadinessPollInterval: time.Hour,
 	})
 	require.NoError(t, err)
 

--- a/internal/discovery/cache_test.go
+++ b/internal/discovery/cache_test.go
@@ -1,9 +1,9 @@
 package discovery
 
 import (
-	"context"
 	"testing"
 
+	"github.com/Azure/eno/internal/testutil"
 	openapi_v2 "github.com/google/gnostic-models/openapiv2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -11,11 +11,10 @@ import (
 	"k8s.io/client-go/discovery/fake"
 )
 
-// Positive behavior is covered by controller integration tests
-
 func TestDiscoveryCacheRefill(t *testing.T) {
-	client := &fakeDiscovery{}
-	d := &Cache{client: client, fillWhenNotFound: true}
+	ctx := testutil.NewContext(t)
+	client := &fakeDiscovery{Info: &openapi_v2.Info{Version: "v1.15.0"}}
+	d := &Cache{client: client}
 
 	gvk := schema.GroupVersionKind{
 		Group:   "test-group",
@@ -23,11 +22,11 @@ func TestDiscoveryCacheRefill(t *testing.T) {
 		Kind:    "TestKind1",
 	}
 
-	s, err := d.Get(context.Background(), gvk)
+	s, err := d.Get(ctx, gvk)
 	require.NoError(t, err)
 	assert.Nil(t, s)
 
-	s, err = d.Get(context.Background(), gvk)
+	s, err = d.Get(ctx, gvk)
 	require.NoError(t, err)
 	assert.Nil(t, s)
 
@@ -35,8 +34,9 @@ func TestDiscoveryCacheRefill(t *testing.T) {
 }
 
 func TestDiscoveryCacheRefillDisabled(t *testing.T) {
-	client := &fakeDiscovery{}
-	d := &Cache{client: client, fillWhenNotFound: false}
+	ctx := testutil.NewContext(t)
+	client := &fakeDiscovery{Info: &openapi_v2.Info{Version: "v1.14.123"}}
+	d := &Cache{client: client}
 
 	gvk := schema.GroupVersionKind{
 		Group:   "test-group",
@@ -44,24 +44,62 @@ func TestDiscoveryCacheRefillDisabled(t *testing.T) {
 		Kind:    "TestKind1",
 	}
 
-	s, err := d.Get(context.Background(), gvk)
+	s, err := d.Get(ctx, gvk)
 	require.NoError(t, err)
 	assert.Nil(t, s)
 
-	s, err = d.Get(context.Background(), gvk)
+	s, err = d.Get(ctx, gvk)
 	require.NoError(t, err)
 	assert.Nil(t, s)
 
 	assert.Equal(t, 1, client.Calls)
 }
 
+func TestDiscoveryCacheRefillVersionMissing(t *testing.T) {
+	ctx := testutil.NewContext(t)
+	client := &fakeDiscovery{}
+	d := &Cache{client: client}
+
+	gvk := schema.GroupVersionKind{
+		Group:   "test-group",
+		Version: "test-version",
+		Kind:    "TestKind1",
+	}
+
+	s, err := d.Get(ctx, gvk)
+	require.NoError(t, err)
+	assert.Nil(t, s)
+
+	s, err = d.Get(ctx, gvk)
+	require.NoError(t, err)
+	assert.Nil(t, s)
+
+	assert.Equal(t, 4, client.Calls)
+}
+
+func TestWithRealApiserver(t *testing.T) {
+	ctx := testutil.NewContext(t)
+	mgr := testutil.NewManager(t)
+	cache, err := NewCache(mgr.DownstreamRestConfig, 10)
+	require.NoError(t, err)
+
+	gvk := schema.GroupVersionKind{
+		Version: "v1",
+		Kind:    "Pod",
+	}
+	s, err := cache.Get(ctx, gvk)
+	require.NoError(t, err)
+	assert.NotNil(t, s)
+}
+
 // the fake.FakeDiscovery doesn't allow fake OpenAPISchema return values.
 type fakeDiscovery struct {
 	fake.FakeDiscovery
+	Info  *openapi_v2.Info
 	Calls int
 }
 
 func (f *fakeDiscovery) OpenAPISchema() (*openapi_v2.Document, error) {
 	f.Calls++
-	return &openapi_v2.Document{}, nil
+	return &openapi_v2.Document{Info: f.Info}, nil
 }

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -328,16 +328,6 @@ func newFakePodRuntime(t testing.TB, mgr ctrl.Manager) {
 	require.NoError(t, err)
 }
 
-func AtLeastVersion(t *testing.T, minor int) bool {
-	versionStr := os.Getenv("DOWNSTREAM_VERSION_MINOR")
-	if versionStr == "" {
-		return true // fail open for local dev
-	}
-
-	version, _ := strconv.Atoi(versionStr)
-	return version >= minor
-}
-
 type ExecConn struct {
 	Hook    func(s *apiv1.Synthesizer) []client.Object
 	PodHook func(p *corev1.Pod)


### PR DESCRIPTION
Currently the reconciler process needs to be configured to handle schema cache invalidation correctly on different versions of apiserver. This change makes it so that clients don't need to know about this detail by moving the logic into the reconciler's discovery cache.

Also adds a 24hr cache invalidation to ensure that we eventually converge in cases where very old apiservers are upgraded.