### PR TITLE
More misc. bug fixes

### DIFF
--- a/api/v1/composition.go
+++ b/api/v1/composition.go
@@ -18,7 +18,7 @@ type CompositionList struct {
 //
 // Eno guarantees that a composition's resources will be deleted before the composition
 // finishes deletion by holding a finalizer on it. To delete the composition while leaving
-// the resources in place, set the annotation `eno.azure.io/reconcile-interval` to "orphan".
+// the resources in place, set the annotation `eno.azure.io/deletion-strategy` to "orphan".
 //
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status

--- a/api/v1/config/crd/eno.azure.io_compositions.yaml
+++ b/api/v1/config/crd/eno.azure.io_compositions.yaml
@@ -34,7 +34,7 @@ spec:
 
           Eno guarantees that a composition's resources will be deleted before the composition
           finishes deletion by holding a finalizer on it. To delete the composition while leaving
-          the resources in place, set the annotation `eno.azure.io/reconcile-interval` to "orphan".
+          the resources in place, set the annotation `eno.azure.io/deletion-strategy` to "orphan".
         properties:
           apiVersion:
             description: |-

--- a/docs/api.md
+++ b/docs/api.md
@@ -50,7 +50,7 @@ Changing the spec of a composition will result in re-synthesis.
 
 Eno guarantees that a composition's resources will be deleted before the composition
 finishes deletion by holding a finalizer on it. To delete the composition while leaving
-the resources in place, set the annotation `eno.azure.io/reconcile-interval` to "orphan".
+the resources in place, set the annotation `eno.azure.io/deletion-strategy` to "orphan".
 
 
 

--- a/internal/controllers/reconciliation/controller.go
+++ b/internal/controllers/reconciliation/controller.go
@@ -129,6 +129,7 @@ func (c *Controller) Reconcile(ctx context.Context, req *reconstitution.Request)
 	// Skip without logging since this is a very hot path
 	var modified bool
 	if hasChanged {
+		resource.ObserveVersion("") // in case reconciliation fails, invalidate the cache first to avoid skipping the next attempt
 		modified, err = c.reconcileResource(ctx, comp, prev, resource, current)
 		if err != nil {
 			return ctrl.Result{}, err

--- a/internal/controllers/reconciliation/controller.go
+++ b/internal/controllers/reconciliation/controller.go
@@ -143,7 +143,7 @@ func (c *Controller) Reconcile(ctx context.Context, req *reconstitution.Request)
 	slice := &apiv1.ResourceSlice{}
 	err = c.client.Get(ctx, req.Manifest.Slice, slice)
 	if err != nil {
-		return ctrl.Result{}, client.IgnoreNotFound(fmt.Errorf("getting resource slice: %w", err))
+		return ctrl.Result{}, fmt.Errorf("getting resource slice: %w", err)
 	}
 	var ready *metav1.Time
 	if status := req.Manifest.FindStatus(slice); status == nil || status.Ready == nil {

--- a/internal/controllers/reconciliation/rollout_test.go
+++ b/internal/controllers/reconciliation/rollout_test.go
@@ -89,20 +89,16 @@ func TestBulkRollout(t *testing.T) {
 	require.NoError(t, err)
 
 	testutil.Eventually(t, func() bool {
-		outOfSync := []string{}
 		for i := 0; i < n; i++ {
 			comp := &apiv1.Composition{}
 			comp.Name = fmt.Sprintf("test-comp-%d", i)
 			comp.Namespace = "default"
 			err := upstream.Get(ctx, client.ObjectKeyFromObject(comp), comp)
 			inSync := err == nil && comp.Status.CurrentSynthesis != nil && comp.Status.CurrentSynthesis.Reconciled != nil && comp.Status.CurrentSynthesis.ObservedSynthesizerGeneration == syn.Generation
-			if comp.Status.CurrentSynthesis != nil {
-				if !inSync {
-					outOfSync = append(outOfSync, fmt.Sprintf("composition %s with synthesized=%t reconciled=%t syngen=%d", comp.Name, comp.Status.CurrentSynthesis.Synthesized != nil, comp.Status.CurrentSynthesis.Reconciled != nil, comp.Status.CurrentSynthesis.ObservedSynthesizerGeneration))
-				}
+			if !inSync {
+				return false
 			}
 		}
-		// t.Logf("out of sync compositions: %+s", outOfSync)
-		return len(outOfSync) == 0
+		return true
 	})
 }

--- a/internal/controllers/reconciliation/rollout_test.go
+++ b/internal/controllers/reconciliation/rollout_test.go
@@ -1,0 +1,108 @@
+package reconciliation
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	apiv1 "github.com/Azure/eno/api/v1"
+	"github.com/Azure/eno/internal/controllers/aggregation"
+	testv1 "github.com/Azure/eno/internal/controllers/reconciliation/fixtures/v1"
+	"github.com/Azure/eno/internal/controllers/rollout"
+	"github.com/Azure/eno/internal/controllers/synthesis"
+	"github.com/Azure/eno/internal/testutil"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/util/retry"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func TestBulkRollout(t *testing.T) {
+	scheme := runtime.NewScheme()
+	corev1.SchemeBuilder.AddToScheme(scheme)
+	testv1.SchemeBuilder.AddToScheme(scheme)
+
+	ctx := testutil.NewContext(t)
+	mgr := testutil.NewManager(t)
+	upstream := mgr.GetClient()
+
+	// Register supporting controllers
+	require.NoError(t, rollout.NewController(mgr.Manager, time.Millisecond))
+	require.NoError(t, synthesis.NewStatusController(mgr.Manager))
+	require.NoError(t, aggregation.NewSliceController(mgr.Manager))
+	require.NoError(t, synthesis.NewPodLifecycleController(mgr.Manager, defaultConf))
+	require.NoError(t, synthesis.NewExecController(mgr.Manager, defaultConf, &testutil.ExecConn{Hook: func(s *apiv1.Synthesizer) []client.Object {
+		obj := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-obj",
+				Namespace: "default",
+			},
+			Data: map[string]string{"image": s.Spec.Image},
+		}
+
+		gvks, _, err := scheme.ObjectKinds(obj)
+		require.NoError(t, err)
+		obj.GetObjectKind().SetGroupVersionKind(gvks[0])
+		return []client.Object{obj}
+	}}))
+
+	// Test subject
+	setupTestSubject(t, mgr)
+	mgr.Start(t)
+
+	syn := &apiv1.Synthesizer{}
+	syn.Name = "test-syn"
+	syn.Spec.Image = "create"
+	require.NoError(t, upstream.Create(ctx, syn))
+
+	// Create a bunch of compositions
+	const n = 25
+	for i := 0; i < n; i++ {
+		comp := &apiv1.Composition{}
+		comp.Name = fmt.Sprintf("test-comp-%d", i)
+		comp.Namespace = "default"
+		comp.Spec.Synthesizer.Name = syn.Name
+		require.NoError(t, upstream.Create(ctx, comp))
+	}
+
+	testutil.Eventually(t, func() bool {
+		for i := 0; i < n; i++ {
+			comp := &apiv1.Composition{}
+			comp.Name = fmt.Sprintf("test-comp-%d", i)
+			comp.Namespace = "default"
+			err := upstream.Get(ctx, client.ObjectKeyFromObject(comp), comp)
+			inSync := err == nil && comp.Status.CurrentSynthesis != nil && comp.Status.CurrentSynthesis.Reconciled != nil && comp.Status.CurrentSynthesis.ObservedSynthesizerGeneration == syn.Generation
+			if !inSync {
+				return false
+			}
+		}
+		return true
+	})
+
+	// Update the synthesizer, prove all compositions converge
+	err := retry.RetryOnConflict(testutil.Backoff, func() error {
+		syn.Spec.Image = "updated"
+		return upstream.Update(ctx, syn)
+	})
+	require.NoError(t, err)
+
+	testutil.Eventually(t, func() bool {
+		outOfSync := []string{}
+		for i := 0; i < n; i++ {
+			comp := &apiv1.Composition{}
+			comp.Name = fmt.Sprintf("test-comp-%d", i)
+			comp.Namespace = "default"
+			err := upstream.Get(ctx, client.ObjectKeyFromObject(comp), comp)
+			inSync := err == nil && comp.Status.CurrentSynthesis != nil && comp.Status.CurrentSynthesis.Reconciled != nil && comp.Status.CurrentSynthesis.ObservedSynthesizerGeneration == syn.Generation
+			if comp.Status.CurrentSynthesis != nil {
+				if !inSync {
+					outOfSync = append(outOfSync, fmt.Sprintf("composition %s with synthesized=%t reconciled=%t syngen=%d", comp.Name, comp.Status.CurrentSynthesis.Synthesized != nil, comp.Status.CurrentSynthesis.Reconciled != nil, comp.Status.CurrentSynthesis.ObservedSynthesizerGeneration))
+				}
+			}
+		}
+		// t.Logf("out of sync compositions: %+s", outOfSync)
+		return len(outOfSync) == 0
+	})
+}

--- a/internal/controllers/reconciliation/status_test.go
+++ b/internal/controllers/reconciliation/status_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Azure/eno/internal/controllers/synthesis"
 	"github.com/Azure/eno/internal/testutil"
 	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -176,3 +177,67 @@ func TestReconcileStatus(t *testing.T) {
 }
 
 func isNotReady(state apiv1.ResourceState) bool { return state.Ready == nil }
+
+// TestStatusNegative covers a weird corner case where a resource fails a patch but is still marked as reconciled.
+func TestStatusNegative(t *testing.T) {
+	scheme := runtime.NewScheme()
+	corev1.SchemeBuilder.AddToScheme(scheme)
+	testv1.SchemeBuilder.AddToScheme(scheme)
+
+	ctx := testutil.NewContext(t)
+	mgr := testutil.NewManager(t)
+	upstream := mgr.GetClient()
+
+	obj := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-obj",
+			Namespace: "default",
+			Annotations: map[string]string{
+				"eno.azure.io/reconcile-interval": "1ms",
+			},
+		},
+		Data: map[string]string{"foo": "bar"},
+	}
+
+	// Register supporting controllers
+	require.NoError(t, rollout.NewController(mgr.Manager, time.Millisecond))
+	require.NoError(t, synthesis.NewStatusController(mgr.Manager))
+	require.NoError(t, synthesis.NewPodLifecycleController(mgr.Manager, defaultConf))
+	require.NoError(t, aggregation.NewSliceController(mgr.Manager))
+	require.NoError(t, synthesis.NewExecController(mgr.Manager, defaultConf, &testutil.ExecConn{Hook: func(s *apiv1.Synthesizer) []client.Object {
+		obj := obj.DeepCopy()
+		obj.Data = map[string]string{"foo": "baz"} // update: bar->baz
+		gvks, _, err := scheme.ObjectKinds(obj)
+		require.NoError(t, err)
+		obj.GetObjectKind().SetGroupVersionKind(gvks[0])
+		return []client.Object{obj}
+	}}))
+
+	// Test subject
+	c := setupTestSubject(t, mgr)
+	c.upstreamClient = testutil.NewReadOnlyClient(t, obj)
+	mgr.Start(t)
+
+	// Any syn/comp will do since we faked out the synthesizer pod
+	syn := &apiv1.Synthesizer{}
+	syn.Name = "test-syn"
+	syn.Spec.Image = "create"
+	require.NoError(t, upstream.Create(ctx, syn))
+
+	comp := &apiv1.Composition{}
+	comp.Name = "test-comp"
+	comp.Namespace = "default"
+	comp.Spec.Synthesizer.Name = syn.Name
+	require.NoError(t, upstream.Create(ctx, comp))
+
+	// Prove the resource was not marked as reconciled
+	// This would be better as a unit test where we can block on reconciliation,
+	// consider refactoring later (it will be non-trivial)
+	testutil.Eventually(t, func() bool {
+		err := upstream.Get(ctx, client.ObjectKeyFromObject(comp), comp)
+		return err == nil && comp.Status.CurrentSynthesis != nil && comp.Status.CurrentSynthesis.Synthesized != nil
+	})
+	time.Sleep(time.Second)
+	require.NoError(t, upstream.Get(ctx, client.ObjectKeyFromObject(comp), comp))
+	assert.Nil(t, comp.Status.CurrentSynthesis.Reconciled)
+}

--- a/internal/controllers/rollout/controller.go
+++ b/internal/controllers/rollout/controller.go
@@ -88,7 +88,7 @@ func (c *controller) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		}
 
 		logger.V(1).Info("advancing rollout process")
-		return ctrl.Result{}, nil
+		return ctrl.Result{Requeue: true}, nil
 	}
 
 	return ctrl.Result{}, nil

--- a/internal/controllers/rollout/controller.go
+++ b/internal/controllers/rollout/controller.go
@@ -58,12 +58,6 @@ func (c *controller) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 
 	var latestRollout time.Time
 	for _, comp := range compList.Items {
-		// For every synthesizer, only one composition can be the target of a rolling change at any point in time.
-		// To avoid blocked rollouts caused by compositions that cannot be synthesized, also time out and move on eventually.
-		if isRolling(&comp) {
-			return ctrl.Result{}, nil
-		}
-
 		if comp.Status.CurrentSynthesis != nil && comp.Status.PreviousSynthesis != nil && comp.Status.CurrentSynthesis.Synthesized != nil && comp.Status.CurrentSynthesis.Synthesized.Time.After(latestRollout) {
 			latestRollout = comp.Status.CurrentSynthesis.Synthesized.Time
 		}
@@ -113,10 +107,6 @@ func swapStates(comp *apiv1.Composition) {
 
 func isInSync(comp *apiv1.Composition, syn *apiv1.Synthesizer) bool {
 	return comp.Status.CurrentSynthesis.ObservedSynthesizerGeneration >= syn.Generation
-}
-
-func isRolling(comp *apiv1.Composition) bool {
-	return comp.Status.CurrentSynthesis != nil && comp.Status.PreviousSynthesis != nil && comp.Status.CurrentSynthesis.Synthesized == nil
 }
 
 func newCompositionHandler() handler.EventHandler {

--- a/internal/controllers/synthesis/lifecycle.go
+++ b/internal/controllers/synthesis/lifecycle.go
@@ -103,7 +103,7 @@ func (c *podLifecycleController) Reconcile(ctx context.Context, req ctrl.Request
 
 	if comp.DeletionTimestamp != nil {
 		ctx = logr.NewContext(ctx, logger)
-		return c.reconcileDeletedComposition(ctx, comp, pods)
+		return c.reconcileDeletedComposition(ctx, comp)
 	}
 
 	// Swap the state to prepare for resynthesis if needed
@@ -177,7 +177,7 @@ func (c *podLifecycleController) Reconcile(ctx context.Context, req ctrl.Request
 	return ctrl.Result{}, nil
 }
 
-func (c *podLifecycleController) reconcileDeletedComposition(ctx context.Context, comp *apiv1.Composition, pods *corev1.PodList) (ctrl.Result, error) {
+func (c *podLifecycleController) reconcileDeletedComposition(ctx context.Context, comp *apiv1.Composition) (ctrl.Result, error) {
 	logger := logr.FromContextOrDiscard(ctx)
 
 	// If the composition was being synthesized at the time of deletion we need to swap the previous

--- a/internal/controllers/synthesis/lifecycle.go
+++ b/internal/controllers/synthesis/lifecycle.go
@@ -319,5 +319,5 @@ func shouldUpdateDeletedCompositionStatus(comp *apiv1.Composition) bool {
 }
 
 func isReconciling(comp *apiv1.Composition) bool {
-	return comp.Status.CurrentSynthesis != nil && (comp.Status.CurrentSynthesis.Reconciled == nil) || comp.Status.CurrentSynthesis.ObservedCompositionGeneration != comp.Generation
+	return comp.Status.CurrentSynthesis != nil && (comp.Status.CurrentSynthesis.Reconciled == nil || comp.Status.CurrentSynthesis.ObservedCompositionGeneration != comp.Generation)
 }

--- a/internal/controllers/synthesis/status.go
+++ b/internal/controllers/synthesis/status.go
@@ -69,7 +69,7 @@ func (c *statusController) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		compGen, _ = strconv.ParseInt(pod.Annotations["eno.azure.io/composition-generation"], 10, 0)
 		synGen, _  = strconv.ParseInt(pod.Annotations["eno.azure.io/synthesizer-generation"], 10, 0)
 	)
-	logger.WithValues("synthesizerGeneration", synGen, "compositionGeneration", compGen)
+	logger = logger.WithValues("synthesizerGeneration", synGen, "compositionGeneration", compGen)
 	if shouldWriteStatus(comp, compGen, pod.CreationTimestamp) {
 		if comp.Status.CurrentSynthesis == nil {
 			comp.Status.CurrentSynthesis = &apiv1.Synthesis{}

--- a/internal/resource/resource.go
+++ b/internal/resource/resource.go
@@ -27,7 +27,7 @@ var patchGVK = schema.GroupVersionKind{
 
 // Ref refers to a specific synthesized resource.
 type Ref struct {
-	Name, Namespace, Kind string
+	Name, Namespace, Group, Kind string
 }
 
 // Resource is the controller's internal representation of a single resource out of a ResourceSlice.
@@ -114,6 +114,7 @@ func NewResource(ctx context.Context, renv *readiness.Env, slice *apiv1.Resource
 	res.GVK = gvk
 	res.Ref.Name = parsed.GetName()
 	res.Ref.Namespace = parsed.GetNamespace()
+	res.Ref.Group = parsed.GroupVersionKind().Group
 	res.Ref.Kind = parsed.GetKind()
 	logger = logger.WithValues("resourceKind", parsed.GetKind(), "resourceName", parsed.GetName(), "resourceNamespace", parsed.GetNamespace())
 

--- a/internal/resource/resource_test.go
+++ b/internal/resource/resource_test.go
@@ -37,6 +37,34 @@ var newResourceTests = []struct {
 			assert.Equal(t, schema.GroupVersionKind{Version: "v1", Kind: "ConfigMap"}, r.GVK)
 			assert.Len(t, r.ReadinessChecks, 2)
 			assert.Equal(t, time.Second*10, r.ReconcileInterval.Duration)
+			assert.Equal(t, Ref{
+				Name:      "foo",
+				Namespace: "",
+				Group:     "",
+				Kind:      "ConfigMap",
+			}, r.Ref)
+		},
+	},
+	{
+		Name: "deployment",
+		Manifest: `{
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
+			"metadata": {
+				"name": "foo",
+				"namespace": "bar"
+			}
+		}`,
+		Assert: func(t *testing.T, r *Resource) {
+			assert.Equal(t, schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "Deployment"}, r.GVK)
+			assert.Len(t, r.ReadinessChecks, 0)
+			assert.Nil(t, r.ReconcileInterval)
+			assert.Equal(t, Ref{
+				Name:      "foo",
+				Namespace: "bar",
+				Group:     "apps",
+				Kind:      "Deployment",
+			}, r.Ref)
 		},
 	},
 	{


### PR DESCRIPTION
The main symptom these fixes address is stuck synth update rollouts. There are essentially three bugs that contribute to this, addressed in separate commits.

This also includes a change to include the API group in resource references, which in turn adds it to their index key. Resources are unique per kind+group, so this change solves for a rare case where the same type is used by resources in multiple groups.