### PR TITLE
Implement EnsureExists logic

### DIFF
--- a/api/v1/config/crd/eno.azure.io_synthesizers.yaml
+++ b/api/v1/config/crd/eno.azure.io_synthesizers.yaml
@@ -25,7 +25,23 @@ spec:
           that implements the [KRM Functions Specification](https://github.com/kubernetes-sigs/kustomize/blob/master/cmd/config/docs/api-conventions/functions-spec.md).\n\n\nSynthesizer
           processes are given some metadata about the composition they are synthesizing,
           and are expected\nto return a set of Kubernetes resources. Essentially they
-          generate the desired state for a set of Kubernetes resources.\n\n\nA special
+          generate the desired state for a set of Kubernetes resources.\n\n\nEno honors
+          a handful of annotations on resources emitted from synthesizers. They are
+          consumed by Eno i.e. are not passed to the \"real\", reconciled resource.\n-
+          eno.azure.io/reconcile-interval: How often to correct for any configuration
+          drift. Accepts durations parsable by time.ParseDuration.\n- eno.azure.io/disable-updates:
+          Ensure that the resource exists but never update it. Useful for populating
+          resources you expect another user/process to mutate.\n- eno.azure.io/readiness:
+          CEL expression used to assert that the resource is ready. More details below.\n-
+          eno.azure.io/readiness-*: Same as above, allows for multiple readiness checks.
+          All checks must pass for the resource to be considered ready.\n\n\nReadiness
+          expressions can return either bool or a Kubernetes condition struct.\nIf
+          a condition is returned it will be used as the resource's readiness time,
+          otherwise the controller will use wallclock time at the first moment it
+          noticed the truthy value.\nWhen possible, match on a timestamp to preserve
+          accuracy.\n\n\nExample matching on a condition:\n```cel\n\n\n\tself.status.conditions.filter(item,
+          item.type == 'Test' && item.status == 'False')\n\n\n```\n\n\nExample matching
+          on a boolean:\n```cel\n\n\n\tself.status.foo == 'bar'\n\n\n```\n\n\nA special
           resource can be returned from synthesizers: `eno.azure.io/v1.Patch`.\nExample:\n\n\n```yaml\n\n\n\t
           # - Nothing will happen if the resource doesn't exist\n\t # - Patches are
           only applied when they would result in a change\n\t # - Deleting the Patch

--- a/docs/api.md
+++ b/docs/api.md
@@ -261,6 +261,38 @@ Synthesizer processes are given some metadata about the composition they are syn
 to return a set of Kubernetes resources. Essentially they generate the desired state for a set of Kubernetes resources.
 
 
+Eno honors a handful of annotations on resources emitted from synthesizers. They are consumed by Eno i.e. are not passed to the "real", reconciled resource.
+- eno.azure.io/reconcile-interval: How often to correct for any configuration drift. Accepts durations parsable by time.ParseDuration.
+- eno.azure.io/disable-updates: Ensure that the resource exists but never update it. Useful for populating resources you expect another user/process to mutate.
+- eno.azure.io/readiness: CEL expression used to assert that the resource is ready. More details below.
+- eno.azure.io/readiness-*: Same as above, allows for multiple readiness checks. All checks must pass for the resource to be considered ready.
+
+
+Readiness expressions can return either bool or a Kubernetes condition struct.
+If a condition is returned it will be used as the resource's readiness time, otherwise the controller will use wallclock time at the first moment it noticed the truthy value.
+When possible, match on a timestamp to preserve accuracy.
+
+
+Example matching on a condition:
+```cel
+
+
+	self.status.conditions.filter(item, item.type == 'Test' && item.status == 'False')
+
+
+```
+
+
+Example matching on a boolean:
+```cel
+
+
+	self.status.foo == 'bar'
+
+
+```
+
+
 A special resource can be returned from synthesizers: `eno.azure.io/v1.Patch`.
 Example:
 

--- a/internal/controllers/reconciliation/controller.go
+++ b/internal/controllers/reconciliation/controller.go
@@ -213,6 +213,10 @@ func (c *Controller) reconcileResource(ctx context.Context, comp *apiv1.Composit
 		return true, nil
 	}
 
+	if resource.DisableUpdates {
+		return false, nil
+	}
+
 	// Compute a merge patch
 	prevRV := current.GetResourceVersion()
 	patch, patchType, err := c.buildPatch(ctx, prev, resource, current)

--- a/internal/resource/resource.go
+++ b/internal/resource/resource.go
@@ -42,6 +42,7 @@ type Resource struct {
 	SliceDeleted      bool
 	ReadinessChecks   readiness.Checks
 	Patch             jsonpatch.Patch
+	DisableUpdates    bool
 }
 
 func (r *Resource) Deleted() bool {
@@ -149,6 +150,10 @@ func NewResource(ctx context.Context, renv *readiness.Env, slice *apiv1.Resource
 	reconcileInterval, _ := time.ParseDuration(anno[reconcileIntervalKey])
 	res.ReconcileInterval = &metav1.Duration{Duration: reconcileInterval}
 	delete(anno, reconcileIntervalKey)
+
+	const disableUpdatesKey = "eno.azure.io/disable-updates"
+	res.DisableUpdates = anno[disableUpdatesKey] == "true"
+	delete(anno, disableUpdatesKey)
 
 	for key, value := range parsed.GetAnnotations() {
 		if !strings.HasPrefix(key, "eno.azure.io/readiness") {

--- a/internal/resource/resource_test.go
+++ b/internal/resource/resource_test.go
@@ -29,7 +29,8 @@ var newResourceTests = []struct {
 					"foo": "bar",
 					"eno.azure.io/reconcile-interval": "10s",
 					"eno.azure.io/readiness": "true",
-					"eno.azure.io/readiness-test": "false"
+					"eno.azure.io/readiness-test": "false",
+					"eno.azure.io/disable-updates": "true"
 				}
 			}
 		}`,
@@ -43,6 +44,7 @@ var newResourceTests = []struct {
 				Group:     "",
 				Kind:      "ConfigMap",
 			}, r.Ref)
+			assert.True(t, r.DisableUpdates)
 		},
 	},
 	{


### PR DESCRIPTION
Re-implements the EnsureExists logic found in old Kubernetes addon manager implementation(s).