### PR TITLE
Misc. Flake fixes

### DIFF
--- a/internal/controllers/synthesis/integration_test.go
+++ b/internal/controllers/synthesis/integration_test.go
@@ -77,7 +77,7 @@ func TestControllerHappyPath(t *testing.T) {
 
 	// The synthesizer is eventually executed a second time
 	testutil.Eventually(t, func() bool {
-		return conn.Calls.Load() == 2
+		return conn.Calls.Load() >= 2
 	})
 
 	// The pod is deleted


### PR DESCRIPTION
- Tolerate multiple syntheses in the controller tests, this only happens in testing code because Pods are (too?) fast.
- Observe the resource-version for a given resource only after successful reconciliation.