### PR TITLE
Remove resource group/version/name/namespace from internal ref type

### DIFF
--- a/internal/controllers/reconciliation/controller.go
+++ b/internal/controllers/reconciliation/controller.go
@@ -95,7 +95,7 @@ func (c *Controller) Reconcile(ctx context.Context, req *reconstitution.Request)
 
 	// Find the current and (optionally) previous desired states in the cache
 	synRef := reconstitution.NewSynthesisRef(comp)
-	resource, exists := c.resourceClient.Get(ctx, synRef, &req.Resource)
+	resource, exists := c.resourceClient.Get(ctx, synRef, &req.Manifest)
 	if !exists {
 		// It's possible for the cache to be empty because a manifest for this resource no longer exists at the requested composition generation.
 		// Dropping the work item is safe since filling the new version will generate a new queue message.
@@ -106,7 +106,7 @@ func (c *Controller) Reconcile(ctx context.Context, req *reconstitution.Request)
 	var prev *reconstitution.Resource
 	if comp.Status.PreviousSynthesis != nil {
 		synRef.UUID = comp.Status.PreviousSynthesis.UUID
-		prev, _ = c.resourceClient.Get(ctx, synRef, &req.Resource)
+		prev, _ = c.resourceClient.Get(ctx, synRef, &req.Manifest)
 	}
 
 	// Keep track of the last reconciliation time and report on it relative to the resource's reconcile interval

--- a/internal/reconstitution/controller_test.go
+++ b/internal/reconstitution/controller_test.go
@@ -7,11 +7,11 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	apiv1 "github.com/Azure/eno/api/v1"
-	"github.com/Azure/eno/internal/resource"
 	"github.com/Azure/eno/internal/testutil"
 )
 
@@ -49,10 +49,9 @@ func TestControllerIntegration(t *testing.T) {
 	require.NoError(t, client.Create(ctx, slice))
 
 	// Prove the resource was cached
-	ref := &resource.Ref{
-		Name:      "foo",
-		Namespace: "bar",
-		Kind:      "baz",
+	ref := &ManifestRef{
+		Slice: types.NamespacedName{Namespace: slice.Namespace, Name: slice.Name},
+		Index: 0,
 	}
 	testutil.Eventually(t, func() bool {
 		_, exists := r.Get(ctx, compRef, ref)

--- a/internal/reconstitution/queueprocessor.go
+++ b/internal/reconstitution/queueprocessor.go
@@ -36,7 +36,7 @@ func (q *queueProcessor) processQueueItem(ctx context.Context) bool {
 		return false
 	}
 
-	logger := q.Logger.WithValues("compositionName", req.Composition.Name, "compositionNamespace", req.Composition.Namespace, "resourceKind", req.Resource.Kind, "resourceName", req.Resource.Name, "resourceNamespace", req.Resource.Namespace)
+	logger := q.Logger.WithValues("compositionName", req.Composition.Name, "compositionNamespace", req.Composition.Namespace)
 	ctx = logr.NewContext(ctx, logger)
 
 	result, err := q.Handler.Reconcile(ctx, req)

--- a/internal/reconstitution/reconstitution.go
+++ b/internal/reconstitution/reconstitution.go
@@ -18,7 +18,7 @@ type Reconciler interface {
 
 // Client provides read/write access to a collection of reconstituted resources.
 type Client interface {
-	Get(ctx context.Context, syn *SynthesisRef, res *resource.Ref) (*resource.Resource, bool)
+	Get(ctx context.Context, syn *SynthesisRef, res *ManifestRef) (*resource.Resource, bool)
 }
 
 // ManifestRef references a particular resource manifest within a resource slice.
@@ -51,7 +51,6 @@ func NewSynthesisRef(comp *apiv1.Composition) *SynthesisRef {
 // Request is like controller-runtime reconcile.Request but for reconstituted resources.
 // https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/reconcile#Request
 type Request struct {
-	Resource    resource.Ref
 	Manifest    ManifestRef
 	Composition types.NamespacedName
 }

--- a/internal/reconstitution/reconstitution_test.go
+++ b/internal/reconstitution/reconstitution_test.go
@@ -65,7 +65,7 @@ type testReconciler struct {
 }
 
 func (t *testReconciler) Reconcile(ctx context.Context, req *Request) (ctrl.Result, error) {
-	resource, exists := t.cache.Get(ctx, t.comp, &req.Resource)
+	resource, exists := t.cache.Get(ctx, t.comp, &req.Manifest)
 	if !exists {
 		panic("resource should exist in cache")
 	}


### PR DESCRIPTION
The reconstitution cache currently uses `resource.Ref` as the key type, but not all of its fields are necessary to establish uniqueness. Which doesn't really matter until it comes time to construct the key when the group/version/name/namespace aren't easily accessible, which will happen as part of the resource ordering functionality.

We can safely switch to `ManifestRef` because it still provides uniqueness (slice namespace/name/index).