### PR TITLE
Add callback from the write buffer

### DIFF
--- a/internal/controllers/reconciliation/controller.go
+++ b/internal/controllers/reconciliation/controller.go
@@ -165,7 +165,7 @@ func (c *Controller) Reconcile(ctx context.Context, req *reconstitution.Request)
 
 	// Store the results
 	deleted := current == nil || current.GetDeletionTimestamp() != nil
-	c.writeBuffer.PatchStatusAsync(ctx, &req.Manifest, patchResourceState(deleted, ready))
+	c.writeBuffer.PatchStatusAsync(ctx, &req.Manifest, patchResourceState(deleted, ready), func() {})
 	if ready == nil {
 		return ctrl.Result{RequeueAfter: wait.Jitter(c.readinessPollInterval, 0.1)}, nil
 	}

--- a/internal/flowcontrol/writebuffer.go
+++ b/internal/flowcontrol/writebuffer.go
@@ -24,6 +24,7 @@ type StatusPatchFn func(*apiv1.ResourceState) *apiv1.ResourceState
 type resourceSliceStatusUpdate struct {
 	SlicedResource *reconstitution.ManifestRef
 	PatchFn        StatusPatchFn
+	Callback       func()
 }
 
 // ResourceSliceWriteBuffer reduces load on etcd/apiserver by collecting resource slice status
@@ -56,7 +57,7 @@ func NewResourceSliceWriteBuffer(cli client.Client, batchInterval time.Duration,
 	}
 }
 
-func (w *ResourceSliceWriteBuffer) PatchStatusAsync(ctx context.Context, ref *reconstitution.ManifestRef, patchFn StatusPatchFn) {
+func (w *ResourceSliceWriteBuffer) PatchStatusAsync(ctx context.Context, ref *reconstitution.ManifestRef, patchFn StatusPatchFn, cb func()) {
 	w.mut.Lock()
 	defer w.mut.Unlock()
 
@@ -72,6 +73,7 @@ func (w *ResourceSliceWriteBuffer) PatchStatusAsync(ctx context.Context, ref *re
 	w.state[key] = append(currentSlice, &resourceSliceStatusUpdate{
 		SlicedResource: ref,
 		PatchFn:        patchFn,
+		Callback:       cb,
 	})
 	w.queue.Add(key)
 }
@@ -164,6 +166,7 @@ func (w *ResourceSliceWriteBuffer) updateSlice(ctx context.Context, sliceNSN typ
 	// Transform the set of patch funcs into a set of jsonpatch objects
 	unsafeSlice := slice.Status.Resources
 	var patches []*jsonPatch
+	var callbacks []func()
 	for _, update := range updates {
 		unsafeStatusPtr := &unsafeSlice[update.SlicedResource.Index]
 		patch := update.PatchFn(unsafeStatusPtr)
@@ -171,6 +174,7 @@ func (w *ResourceSliceWriteBuffer) updateSlice(ctx context.Context, sliceNSN typ
 			continue
 		}
 
+		callbacks = append(callbacks, update.Callback)
 		patches = append(patches, &jsonPatch{
 			Op:    "replace",
 			Path:  fmt.Sprintf("/status/resources/%d", update.SlicedResource.Index),
@@ -195,6 +199,9 @@ func (w *ResourceSliceWriteBuffer) updateSlice(ctx context.Context, sliceNSN typ
 
 	logger.V(0).Info(fmt.Sprintf("updated the status of %d resources in slice", len(updates)))
 	sliceStatusUpdates.Inc()
+	for _, cb := range callbacks {
+		cb()
+	}
 	return true
 }
 

--- a/internal/flowcontrol/writebuffer_test.go
+++ b/internal/flowcontrol/writebuffer_test.go
@@ -33,7 +33,10 @@ func TestResourceSliceStatusUpdateBasics(t *testing.T) {
 	req := &reconstitution.ManifestRef{}
 	req.Slice.Name = "test-slice-1"
 	req.Index = 1
-	w.PatchStatusAsync(ctx, req, setReconciled())
+	var callbackCalled bool
+	w.PatchStatusAsync(ctx, req, setReconciled(), func() {
+		callbackCalled = true
+	})
 
 	// Slice resource's status should reflect the patch
 	w.processQueueItem(ctx)
@@ -42,6 +45,7 @@ func TestResourceSliceStatusUpdateBasics(t *testing.T) {
 	assert.False(t, slice.Status.Resources[0].Reconciled)
 	assert.True(t, slice.Status.Resources[1].Reconciled)
 	assert.False(t, slice.Status.Resources[2].Reconciled)
+	assert.True(t, callbackCalled)
 
 	// All state has been flushed
 	assert.Len(t, w.state, 0)
@@ -70,12 +74,12 @@ func TestResourceSliceStatusUpdateBatching(t *testing.T) {
 	req := &reconstitution.ManifestRef{}
 	req.Slice.Name = "test-slice-1"
 	req.Index = 1
-	w.PatchStatusAsync(ctx, req, setReconciled())
+	w.PatchStatusAsync(ctx, req, setReconciled(), func() {})
 
 	req = &reconstitution.ManifestRef{}
 	req.Slice.Name = "test-slice-1"
 	req.Index = 2
-	w.PatchStatusAsync(ctx, req, setReconciled())
+	w.PatchStatusAsync(ctx, req, setReconciled(), func() {})
 
 	// Slice resource's status should be correct after a single update
 	w.processQueueItem(ctx)
@@ -102,7 +106,7 @@ func TestResourceSliceStatusUpdateNoUpdates(t *testing.T) {
 	req := &reconstitution.ManifestRef{}
 	req.Slice.Name = "test-slice-1"
 	req.Index = 1
-	w.PatchStatusAsync(ctx, req, setReconciled())
+	w.PatchStatusAsync(ctx, req, setReconciled(), func() {})
 
 	// Remove the update leaving the queue message in place
 	w.state = map[types.NamespacedName][]*resourceSliceStatusUpdate{}
@@ -120,7 +124,7 @@ func TestResourceSliceStatusUpdateMissingSlice(t *testing.T) {
 
 	req := &reconstitution.ManifestRef{}
 	req.Slice.Name = "test-slice-1" // this doesn't exist
-	w.PatchStatusAsync(ctx, req, setReconciled())
+	w.PatchStatusAsync(ctx, req, setReconciled(), func() {})
 
 	// Slice 404 drops the event and does not retry.
 	// Prevents a deadlock of this queue item.
@@ -151,7 +155,7 @@ func TestResourceSliceStatusUpdateNoChange(t *testing.T) {
 	req := &reconstitution.ManifestRef{}
 	req.Slice.Name = "test-slice-1"
 	req.Index = 1
-	w.PatchStatusAsync(ctx, req, setReconciled())
+	w.PatchStatusAsync(ctx, req, setReconciled(), func() {})
 
 	w.processQueueItem(ctx)
 }
@@ -175,7 +179,7 @@ func TestResourceSliceStatusUpdateUpdateError(t *testing.T) {
 	req := &reconstitution.ManifestRef{}
 	req.Slice.Name = "test-slice-1"
 	req.Index = 1
-	w.PatchStatusAsync(ctx, req, setReconciled())
+	w.PatchStatusAsync(ctx, req, setReconciled(), func() {})
 
 	// Both the queue item and state have persisted
 	w.processQueueItem(ctx)

--- a/internal/flowcontrol/writebuffer_test.go
+++ b/internal/flowcontrol/writebuffer_test.go
@@ -105,7 +105,7 @@ func TestResourceSliceStatusUpdateNoUpdates(t *testing.T) {
 	w.PatchStatusAsync(ctx, req, setReconciled())
 
 	// Remove the update leaving the queue message in place
-	w.state = map[types.NamespacedName][]*ResourceSliceStatusUpdate{}
+	w.state = map[types.NamespacedName][]*resourceSliceStatusUpdate{}
 
 	// Slice's status should not have been initialized
 	w.processQueueItem(ctx)


### PR DESCRIPTION
To implement the resource ordering feature we will need to requeue _after_ status updates. This change just adds the hook