### PR TITLE
Parse readiness group annotation

### DIFF
--- a/internal/resource/resource.go
+++ b/internal/resource/resource.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -43,6 +44,7 @@ type Resource struct {
 	ReadinessChecks   readiness.Checks
 	Patch             jsonpatch.Patch
 	DisableUpdates    bool
+	ReadinessGroup    uint8
 }
 
 func (r *Resource) Deleted() bool {
@@ -155,7 +157,12 @@ func NewResource(ctx context.Context, renv *readiness.Env, slice *apiv1.Resource
 	res.DisableUpdates = anno[disableUpdatesKey] == "true"
 	delete(anno, disableUpdatesKey)
 
-	for key, value := range parsed.GetAnnotations() {
+	const readinessGroupKey = "eno.azure.io/readiness-group"
+	rg, _ := strconv.ParseUint(anno[readinessGroupKey], 10, 0)
+	res.ReadinessGroup = uint8(rg)
+	delete(anno, readinessGroupKey)
+
+	for key, value := range anno {
 		if !strings.HasPrefix(key, "eno.azure.io/readiness") {
 			continue
 		}

--- a/internal/resource/resource_test.go
+++ b/internal/resource/resource_test.go
@@ -46,7 +46,7 @@ var newResourceTests = []struct {
 				Kind:      "ConfigMap",
 			}, r.Ref)
 			assert.True(t, r.DisableUpdates)
-			assert.Equal(t, uint8(250), r.ReadinessGroup)
+			assert.Equal(t, uint(250), r.ReadinessGroup)
 		},
 	},
 	{
@@ -62,7 +62,7 @@ var newResourceTests = []struct {
 			}
 		}`,
 		Assert: func(t *testing.T, r *Resource) {
-			assert.Equal(t, uint8(0), r.ReadinessGroup)
+			assert.Equal(t, uint(0), r.ReadinessGroup)
 		},
 	},
 	{

--- a/internal/resource/resource_test.go
+++ b/internal/resource/resource_test.go
@@ -28,6 +28,7 @@ var newResourceTests = []struct {
 				"annotations": {
 					"foo": "bar",
 					"eno.azure.io/reconcile-interval": "10s",
+					"eno.azure.io/readiness-group": "250",
 					"eno.azure.io/readiness": "true",
 					"eno.azure.io/readiness-test": "false",
 					"eno.azure.io/disable-updates": "true"
@@ -45,6 +46,23 @@ var newResourceTests = []struct {
 				Kind:      "ConfigMap",
 			}, r.Ref)
 			assert.True(t, r.DisableUpdates)
+			assert.Equal(t, uint8(250), r.ReadinessGroup)
+		},
+	},
+	{
+		Name: "negative-readiness-group",
+		Manifest: `{
+			"apiVersion": "v1",
+			"kind": "ConfigMap",
+			"metadata": {
+				"name": "foo",
+				"annotations": {
+					"eno.azure.io/readiness-group": "-10"
+				}
+			}
+		}`,
+		Assert: func(t *testing.T, r *Resource) {
+			assert.Equal(t, uint8(0), r.ReadinessGroup)
 		},
 	},
 	{


### PR DESCRIPTION
Adds `eno.azure.io/readiness-group`, which will be used to order the reconciliation of some resources after the readiness of others.

Resources without the annotation are expected to become ready first, then any resources in readiness-group=1 can be reconciled, continuing from there. Gaps in readiness group IDs are tolerated.