### PR TITLE
Move manifest ref from Request to Resource

### DIFF
--- a/internal/flowcontrol/writebuffer.go
+++ b/internal/flowcontrol/writebuffer.go
@@ -15,14 +15,14 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	apiv1 "github.com/Azure/eno/api/v1"
-	"github.com/Azure/eno/internal/reconstitution"
+	"github.com/Azure/eno/internal/resource"
 	"github.com/go-logr/logr"
 )
 
 type StatusPatchFn func(*apiv1.ResourceState) *apiv1.ResourceState
 
 type resourceSliceStatusUpdate struct {
-	SlicedResource *reconstitution.ManifestRef
+	SlicedResource *resource.ManifestRef
 	PatchFn        StatusPatchFn
 	Callback       func()
 }
@@ -57,7 +57,7 @@ func NewResourceSliceWriteBuffer(cli client.Client, batchInterval time.Duration,
 	}
 }
 
-func (w *ResourceSliceWriteBuffer) PatchStatusAsync(ctx context.Context, ref *reconstitution.ManifestRef, patchFn StatusPatchFn, cb func()) {
+func (w *ResourceSliceWriteBuffer) PatchStatusAsync(ctx context.Context, ref *resource.ManifestRef, patchFn StatusPatchFn, cb func()) {
 	w.mut.Lock()
 	defer w.mut.Unlock()
 

--- a/internal/flowcontrol/writebuffer_test.go
+++ b/internal/flowcontrol/writebuffer_test.go
@@ -14,7 +14,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	apiv1 "github.com/Azure/eno/api/v1"
-	"github.com/Azure/eno/internal/reconstitution"
+	"github.com/Azure/eno/internal/resource"
 	"github.com/Azure/eno/internal/testutil"
 )
 
@@ -30,7 +30,7 @@ func TestResourceSliceStatusUpdateBasics(t *testing.T) {
 	require.NoError(t, cli.Create(ctx, slice))
 
 	// One of the resources has been reconciled
-	req := &reconstitution.ManifestRef{}
+	req := &resource.ManifestRef{}
 	req.Slice.Name = "test-slice-1"
 	req.Index = 1
 	var callbackCalled bool
@@ -71,12 +71,12 @@ func TestResourceSliceStatusUpdateBatching(t *testing.T) {
 	require.NoError(t, cli.Create(ctx, slice))
 
 	// Two of the resources have been reconciled within the batch interval
-	req := &reconstitution.ManifestRef{}
+	req := &resource.ManifestRef{}
 	req.Slice.Name = "test-slice-1"
 	req.Index = 1
 	w.PatchStatusAsync(ctx, req, setReconciled(), func() {})
 
-	req = &reconstitution.ManifestRef{}
+	req = &resource.ManifestRef{}
 	req.Slice.Name = "test-slice-1"
 	req.Index = 2
 	w.PatchStatusAsync(ctx, req, setReconciled(), func() {})
@@ -103,7 +103,7 @@ func TestResourceSliceStatusUpdateNoUpdates(t *testing.T) {
 	require.NoError(t, cli.Create(ctx, slice))
 
 	// One of the resources has been reconciled
-	req := &reconstitution.ManifestRef{}
+	req := &resource.ManifestRef{}
 	req.Slice.Name = "test-slice-1"
 	req.Index = 1
 	w.PatchStatusAsync(ctx, req, setReconciled(), func() {})
@@ -122,7 +122,7 @@ func TestResourceSliceStatusUpdateMissingSlice(t *testing.T) {
 	cli := testutil.NewClient(t)
 	w := NewResourceSliceWriteBuffer(cli, 0, 1)
 
-	req := &reconstitution.ManifestRef{}
+	req := &resource.ManifestRef{}
 	req.Slice.Name = "test-slice-1" // this doesn't exist
 	w.PatchStatusAsync(ctx, req, setReconciled(), func() {})
 
@@ -152,7 +152,7 @@ func TestResourceSliceStatusUpdateNoChange(t *testing.T) {
 	require.NoError(t, cli.Create(ctx, slice))
 
 	// One of the resources has been reconciled
-	req := &reconstitution.ManifestRef{}
+	req := &resource.ManifestRef{}
 	req.Slice.Name = "test-slice-1"
 	req.Index = 1
 	w.PatchStatusAsync(ctx, req, setReconciled(), func() {})
@@ -176,7 +176,7 @@ func TestResourceSliceStatusUpdateUpdateError(t *testing.T) {
 	require.NoError(t, cli.Create(ctx, slice))
 
 	// One of the resources has been reconciled
-	req := &reconstitution.ManifestRef{}
+	req := &resource.ManifestRef{}
 	req.Slice.Name = "test-slice-1"
 	req.Index = 1
 	w.PatchStatusAsync(ctx, req, setReconciled(), func() {})

--- a/internal/reconstitution/cache.go
+++ b/internal/reconstitution/cache.go
@@ -107,23 +107,14 @@ func (c *Cache) buildResources(ctx context.Context, comp *apiv1.Composition, ite
 
 		// NOTE: In the future we can build a DAG here to find edges between dependant resources and append them to the Resource structs
 
-		for i, obj := range slice.Spec.Resources {
-			obj := obj
-
-			res, err := resource.NewResource(ctx, c.renv, &slice, &obj)
+		for i := range slice.Spec.Resources {
+			res, err := resource.NewResource(ctx, c.renv, &slice, i)
 			if err != nil {
 				return nil, nil, fmt.Errorf("building resource at index %d of slice %s: %w", i, slice.Name, err)
 			}
 			resources[res.Ref] = res
 			requests = append(requests, &Request{
-				Resource: res.Ref,
-				Manifest: ManifestRef{
-					Slice: types.NamespacedName{
-						Namespace: slice.Namespace,
-						Name:      slice.Name,
-					},
-					Index: i,
-				},
+				Resource:    res.Ref,
 				Composition: types.NamespacedName{Name: comp.Name, Namespace: comp.Namespace},
 			})
 		}

--- a/internal/reconstitution/cache_test.go
+++ b/internal/reconstitution/cache_test.go
@@ -222,13 +222,6 @@ func newCacheTestFixtures(sliceCount, resPerSliceCount int) (*apiv1.Composition,
 					Namespace: obj.Namespace,
 					Kind:      obj.Kind,
 				},
-				Manifest: ManifestRef{
-					Slice: types.NamespacedName{
-						Name:      slice.Name,
-						Namespace: slice.Namespace,
-					},
-					Index: j,
-				},
 				Composition: types.NamespacedName{Name: comp.Name, Namespace: comp.Namespace},
 			})
 		}

--- a/internal/reconstitution/reconstitution.go
+++ b/internal/reconstitution/reconstitution.go
@@ -21,20 +21,6 @@ type Client interface {
 	Get(ctx context.Context, syn *SynthesisRef, res *resource.Ref) (*resource.Resource, bool)
 }
 
-// ManifestRef references a particular resource manifest within a resource slice.
-type ManifestRef struct {
-	Slice types.NamespacedName
-	Index int // position of this manifest within the slice
-}
-
-func (m *ManifestRef) FindStatus(slice *apiv1.ResourceSlice) *apiv1.ResourceState {
-	if len(slice.Status.Resources) <= m.Index {
-		return nil
-	}
-	state := slice.Status.Resources[m.Index]
-	return &state
-}
-
 // SynthesisRef refers to a specific synthesis of a composition.
 type SynthesisRef struct {
 	CompositionName, Namespace, UUID string
@@ -52,7 +38,6 @@ func NewSynthesisRef(comp *apiv1.Composition) *SynthesisRef {
 // https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/reconcile#Request
 type Request struct {
 	Resource    resource.Ref
-	Manifest    ManifestRef
 	Composition types.NamespacedName
 }
 

--- a/internal/resource/resource_test.go
+++ b/internal/resource/resource_test.go
@@ -135,7 +135,11 @@ func TestNewResource(t *testing.T) {
 
 	for _, tc := range newResourceTests {
 		t.Run(tc.Name, func(t *testing.T) {
-			r, err := NewResource(ctx, renv, &apiv1.ResourceSlice{}, &apiv1.Manifest{Manifest: tc.Manifest})
+			r, err := NewResource(ctx, renv, &apiv1.ResourceSlice{
+				Spec: apiv1.ResourceSliceSpec{
+					Resources: []apiv1.Manifest{{Manifest: tc.Manifest}},
+				},
+			}, 0)
 			require.NoError(t, err)
 			tc.Assert(t, r)
 		})


### PR DESCRIPTION
Reconciliation queue work items should be deduplicated by the resource's group/kind/namespace/name (GKNN?) but currently they are also unique to a given resource slice slot.

So effectively we allow a workqueue item to be enqueued for both the previous and current version of the same resource, which is unnecessary and redundant.