### PR TITLE
Index resources by readiness group

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.21
 toolchain go1.21.5
 
 require (
+	github.com/emirpasic/gods/v2 v2.0.0-alpha
 	github.com/evanphx/json-patch/v5 v5.9.0
 	github.com/go-logr/logr v1.4.1
 	github.com/go-logr/zapr v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -88,6 +88,8 @@ github.com/docker/libtrust v0.0.0-20150114040149-fa567046d9b1 h1:ZClxb8laGDf5arX
 github.com/docker/libtrust v0.0.0-20150114040149-fa567046d9b1/go.mod h1:cyGadeNEkKy96OOhEzfZl+yxihPEzKnqJwvfuSUqbZE=
 github.com/emicklei/go-restful/v3 v3.12.0 h1:y2DdzBAURM29NFF94q6RaY4vjIH1rtwDapwQtU84iWk=
 github.com/emicklei/go-restful/v3 v3.12.0/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry+4bhvbpWn3mrbc=
+github.com/emirpasic/gods/v2 v2.0.0-alpha h1:dwFlh8pBg1VMOXWGipNMRt8v96dKAIvBehtCt6OtunU=
+github.com/emirpasic/gods/v2 v2.0.0-alpha/go.mod h1:W0y4M2dtBB9U5z3YlghmpuUhiaZT2h6yoeE+C1sCp6A=
 github.com/evanphx/json-patch v5.9.0+incompatible h1:fBXyNpNMuTTDdquAq/uisOr2lShz4oaXpDTX2bLe7ls=
 github.com/evanphx/json-patch v5.9.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch/v5 v5.9.0 h1:kcBlZQbplgElYIlo/n1hJbls2z/1awpXxpRi0/FOJfg=

--- a/internal/reconstitution/cache.go
+++ b/internal/reconstitution/cache.go
@@ -64,7 +64,7 @@ func (c *Cache) Get(ctx context.Context, comp *SynthesisRef, ref *resource.Ref) 
 	return res, ok
 }
 
-func (c *Cache) ListReadinessGroups(ctx context.Context, comp *SynthesisRef, group uint, dir int) []*Resource {
+func (c *Cache) RangeByReadinessGroup(ctx context.Context, comp *SynthesisRef, group uint, dir int) []*Resource {
 	c.mut.Lock()
 	defer c.mut.Unlock()
 

--- a/internal/reconstitution/cache.go
+++ b/internal/reconstitution/cache.go
@@ -12,6 +12,7 @@ import (
 	apiv1 "github.com/Azure/eno/api/v1"
 	"github.com/Azure/eno/internal/readiness"
 	"github.com/Azure/eno/internal/resource"
+	"github.com/emirpasic/gods/v2/trees/redblacktree"
 	"github.com/go-logr/logr"
 )
 
@@ -23,8 +24,14 @@ type Cache struct {
 	renv   *readiness.Env
 
 	mut                         sync.Mutex
-	resources                   map[SynthesisRef]map[resource.Ref]*Resource
+	resources                   map[SynthesisRef]*resources
 	synthesisUUIDsByComposition map[types.NamespacedName][]string
+}
+
+// resources contains a set of indexed resources scoped to a single Composition
+type resources struct {
+	ByRef            map[resource.Ref]*Resource
+	ByReadinessGroup *redblacktree.Tree[uint, []*Resource]
 }
 
 func NewCache(client client.Client) *Cache {
@@ -35,7 +42,7 @@ func NewCache(client client.Client) *Cache {
 	return &Cache{
 		client:                      client,
 		renv:                        renv,
-		resources:                   make(map[SynthesisRef]map[resource.Ref]*Resource),
+		resources:                   make(map[SynthesisRef]*resources),
 		synthesisUUIDsByComposition: make(map[types.NamespacedName][]string),
 	}
 }
@@ -49,12 +56,54 @@ func (c *Cache) Get(ctx context.Context, comp *SynthesisRef, ref *resource.Ref) 
 		return nil, false
 	}
 
-	res, ok := resources[*ref]
+	res, ok := resources.ByRef[*ref]
 	if !ok {
 		return nil, false
 	}
 
 	return res, ok
+}
+
+func (c *Cache) ListReadinessGroups(ctx context.Context, comp *SynthesisRef, group uint, dir int) []*Resource {
+	c.mut.Lock()
+	defer c.mut.Unlock()
+
+	if group == 0 && dir == -1 {
+		return nil
+	}
+
+	resources, ok := c.resources[*comp]
+	if !ok {
+		return nil
+	}
+
+	node := resources.ByReadinessGroup.GetNode(group)
+	if node == nil {
+		return nil // the given group must have a resource, otherwise we wouldn't be looking it up
+	}
+
+	// If we're adjacent...
+	if dir > 0 {
+		if node.Right != nil {
+			return node.Right.Value
+		}
+	} else {
+		if node.Left != nil {
+			return node.Left.Value
+		}
+	}
+
+	// ...otherwise we need to find it
+	if dir > 0 {
+		node, ok = resources.ByReadinessGroup.Ceiling(group + 1)
+	} else {
+		node, ok = resources.ByReadinessGroup.Floor(group - 1)
+	}
+	if !ok {
+		return nil // no previous node!
+	}
+
+	return node.Value
 }
 
 // hasSynthesis returns true when the cache contains the resulting resources of the given synthesis.
@@ -96,8 +145,11 @@ func (c *Cache) fill(ctx context.Context, comp *apiv1.Composition, synthesis *ap
 	return requests, nil
 }
 
-func (c *Cache) buildResources(ctx context.Context, comp *apiv1.Composition, items []apiv1.ResourceSlice) (map[resource.Ref]*Resource, []*Request, error) {
-	resources := map[resource.Ref]*Resource{}
+func (c *Cache) buildResources(ctx context.Context, comp *apiv1.Composition, items []apiv1.ResourceSlice) (*resources, []*Request, error) {
+	resources := &resources{
+		ByRef:            map[resource.Ref]*Resource{},
+		ByReadinessGroup: redblacktree.New[uint, []*Resource](),
+	}
 	requests := []*Request{}
 	for _, slice := range items {
 		slice := slice
@@ -105,14 +157,16 @@ func (c *Cache) buildResources(ctx context.Context, comp *apiv1.Composition, ite
 			return nil, nil, errors.New("stale informer - refusing to fill cache")
 		}
 
-		// NOTE: In the future we can build a DAG here to find edges between dependant resources and append them to the Resource structs
-
 		for i := range slice.Spec.Resources {
 			res, err := resource.NewResource(ctx, c.renv, &slice, i)
 			if err != nil {
 				return nil, nil, fmt.Errorf("building resource at index %d of slice %s: %w", i, slice.Name, err)
 			}
-			resources[res.Ref] = res
+			resources.ByRef[res.Ref] = res
+
+			current, _ := resources.ByReadinessGroup.Get(res.ReadinessGroup)
+			resources.ByReadinessGroup.Put(res.ReadinessGroup, append(current, res))
+
 			requests = append(requests, &Request{
 				Resource:    res.Ref,
 				Composition: types.NamespacedName{Name: comp.Name, Namespace: comp.Namespace},

--- a/internal/reconstitution/cache_test.go
+++ b/internal/reconstitution/cache_test.go
@@ -11,6 +11,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	apiv1 "github.com/Azure/eno/api/v1"
 	"github.com/Azure/eno/internal/resource"
@@ -209,6 +210,7 @@ func newCacheTestFixtures(sliceCount, resPerSliceCount int) (*apiv1.Composition,
 			obj.APIVersion = "v1"
 			obj.Annotations = map[string]string{
 				"eno.azure.io/readiness":            "self.foo > self.bar",
+				"eno.azure.io/readiness-group":      fmt.Sprintf("%d", j%2),
 				"eno.azure.io/readiness-test-check": "self.bar > self.baz",
 			}
 			js, _ := json.Marshal(obj)
@@ -229,4 +231,96 @@ func newCacheTestFixtures(sliceCount, resPerSliceCount int) (*apiv1.Composition,
 	}
 
 	return comp, synth, resources, requests
+}
+
+func TestCacheListReadinessGroups(t *testing.T) {
+	ctx := testutil.NewContext(t)
+
+	cli := testutil.NewClient(t)
+	c := NewCache(cli)
+
+	comp := &apiv1.Composition{}
+	comp.Namespace = string(uuid.NewString())
+	comp.Name = string(uuid.NewString())
+	synth := &apiv1.Synthesis{UUID: uuid.NewString()} // just not 0
+	comp.Status.CurrentSynthesis = synth
+	compRef := NewSynthesisRef(comp)
+
+	obj := &corev1.ConfigMap{}
+	obj.Name = "default-group"
+	obj.Namespace = "default"
+	obj.Kind = "ConfigMap"
+	obj.APIVersion = "v1"
+	resources := []client.Object{}
+	resources = append(resources, obj)
+
+	obj = obj.DeepCopy()
+	obj.Name = "group-1"
+	obj.Annotations = map[string]string{
+		"eno.azure.io/readiness-group": "1",
+	}
+	resources = append(resources, obj)
+
+	obj = obj.DeepCopy()
+	obj.Name = "group-3"
+	obj.Annotations = map[string]string{
+		"eno.azure.io/readiness-group": "3",
+	}
+	resources = append(resources, obj)
+
+	obj = obj.DeepCopy()
+	obj.Name = "group-also-1"
+	obj.Annotations = map[string]string{
+		"eno.azure.io/readiness-group": "1",
+	}
+	resources = append(resources, obj)
+
+	slice := apiv1.ResourceSlice{}
+	slice.Name = string(uuid.NewString())
+	slice.Namespace = "slice-ns"
+	for _, obj := range resources {
+		js, _ := json.Marshal(obj)
+		slice.Spec.Resources = append(slice.Spec.Resources, apiv1.Manifest{Manifest: string(js)})
+	}
+
+	_, err := c.fill(ctx, comp, synth, []apiv1.ResourceSlice{slice})
+	require.NoError(t, err)
+
+	refs := c.ListReadinessGroups(ctx, compRef, 100, 1)
+	assert.Equal(t, []string{}, reqsToNames(refs))
+
+	refs = c.ListReadinessGroups(ctx, &SynthesisRef{CompositionName: "nope"}, 1, 1)
+	assert.Equal(t, []string{}, reqsToNames(refs))
+
+	refs = c.ListReadinessGroups(ctx, compRef, 100, -1)
+	assert.Equal(t, []string{}, reqsToNames(refs))
+
+	refs = c.ListReadinessGroups(ctx, &SynthesisRef{CompositionName: "nope"}, 1, -1)
+	assert.Equal(t, []string{}, reqsToNames(refs))
+
+	refs = c.ListReadinessGroups(ctx, compRef, 0, 1)
+	assert.Equal(t, []string{"group-1", "group-also-1"}, reqsToNames(refs))
+
+	refs = c.ListReadinessGroups(ctx, compRef, 1, 1)
+	assert.Equal(t, []string{"group-3"}, reqsToNames(refs))
+
+	refs = c.ListReadinessGroups(ctx, compRef, 3, 1)
+	assert.Equal(t, []string{}, reqsToNames(refs))
+
+	refs = c.ListReadinessGroups(ctx, compRef, 0, -1)
+	assert.Equal(t, []string{}, reqsToNames(refs))
+
+	refs = c.ListReadinessGroups(ctx, compRef, 1, -1)
+	assert.Equal(t, []string{"default-group"}, reqsToNames(refs))
+
+	refs = c.ListReadinessGroups(ctx, compRef, 3, -1)
+	assert.Equal(t, []string{"group-1", "group-also-1"}, reqsToNames(refs))
+}
+
+func reqsToNames(resources []*Resource) []string {
+	strs := make([]string, len(resources))
+	for i, resource := range resources {
+		strs[i] = resource.Ref.Name
+	}
+	return strs
 }

--- a/internal/reconstitution/reconstitution.go
+++ b/internal/reconstitution/reconstitution.go
@@ -19,7 +19,7 @@ type Reconciler interface {
 // Client provides read/write access to a collection of reconstituted resources.
 type Client interface {
 	Get(ctx context.Context, syn *SynthesisRef, res *resource.Ref) (*resource.Resource, bool)
-	ListReadinessGroups(ctx context.Context, syn *SynthesisRef, group uint, dir int) []*Resource
+	RangeByReadinessGroup(ctx context.Context, syn *SynthesisRef, group uint, dir int) []*Resource
 }
 
 // SynthesisRef refers to a specific synthesis of a composition.

--- a/internal/reconstitution/reconstitution.go
+++ b/internal/reconstitution/reconstitution.go
@@ -19,6 +19,7 @@ type Reconciler interface {
 // Client provides read/write access to a collection of reconstituted resources.
 type Client interface {
 	Get(ctx context.Context, syn *SynthesisRef, res *resource.Ref) (*resource.Resource, bool)
+	ListReadinessGroups(ctx context.Context, syn *SynthesisRef, group uint, dir int) []*Resource
 }
 
 // SynthesisRef refers to a specific synthesis of a composition.


### PR DESCRIPTION
Uses a red-black tree to index resources by their readiness group. Lookups are cheap, so the reconciliation controller doesn't need tricks like maintaining its own representation of the rollout state.