### PR TITLE
Add synthesis UUID to resource slice spec

### DIFF
--- a/api/v1/config/crd/eno.azure.io_resourceslices.yaml
+++ b/api/v1/config/crd/eno.azure.io_resourceslices.yaml
@@ -51,6 +51,8 @@ spec:
                       type: string
                   type: object
                 type: array
+              synthesisUUID:
+                type: string
             type: object
           status:
             properties:

--- a/api/v1/resourceslice.go
+++ b/api/v1/resourceslice.go
@@ -21,6 +21,7 @@ type ResourceSlice struct {
 
 type ResourceSliceSpec struct {
 	CompositionGeneration int64      `json:"compositionGeneration,omitempty"`
+	SynthesisUUID         string     `json:"synthesisUUID,omitempty"`
 	Resources             []Manifest `json:"resources,omitempty"`
 }
 

--- a/internal/resource/resource.go
+++ b/internal/resource/resource.go
@@ -174,7 +174,7 @@ func NewResource(ctx context.Context, renv *readiness.Env, slice *apiv1.Resource
 
 	const reconcileIntervalKey = "eno.azure.io/reconcile-interval"
 	reconcileInterval, err := time.ParseDuration(anno[reconcileIntervalKey])
-	if err != nil {
+	if anno[reconcileIntervalKey] != "" && err != nil {
 		logger.V(0).Info("invalid reconcile interval - ignoring")
 	}
 	res.ReconcileInterval = &metav1.Duration{Duration: reconcileInterval}
@@ -186,7 +186,7 @@ func NewResource(ctx context.Context, renv *readiness.Env, slice *apiv1.Resource
 
 	const readinessGroupKey = "eno.azure.io/readiness-group"
 	rg, err := strconv.ParseUint(anno[readinessGroupKey], 10, 64)
-	if err != nil {
+	if anno[readinessGroupKey] != "" && err != nil {
 		logger.V(0).Info("invalid readiness group - ignoring")
 	}
 	res.ReadinessGroup = uint(rg)

--- a/internal/resource/slicing.go
+++ b/internal/resource/slicing.go
@@ -75,6 +75,9 @@ func Slice(comp *apiv1.Composition, previous []*apiv1.ResourceSlice, outputs []*
 				BlockOwnerDeletion: &blockOwnerDeletion, // we need the composition in order to successfully delete its resource slices
 				Controller:         &blockOwnerDeletion,
 			}}
+			if comp.Status.CurrentSynthesis != nil {
+				slice.Spec.SynthesisUUID = comp.Status.CurrentSynthesis.UUID
+			}
 			slice.Spec.CompositionGeneration = comp.Generation
 			slices = append(slices, slice)
 		}

--- a/internal/resource/slicing_test.go
+++ b/internal/resource/slicing_test.go
@@ -32,11 +32,12 @@ func TestSliceTombstonesBasics(t *testing.T) {
 		},
 	}}
 
-	slices, err := Slice(&apiv1.Composition{}, []*apiv1.ResourceSlice{}, outputs, 100000)
+	slices, err := Slice(&apiv1.Composition{Status: apiv1.CompositionStatus{CurrentSynthesis: &apiv1.Synthesis{UUID: "test-uuid"}}}, []*apiv1.ResourceSlice{}, outputs, 100000)
 	require.NoError(t, err)
 	require.Len(t, slices, 1)
 	require.Len(t, slices[0].Spec.Resources, 1)
 	assert.False(t, slices[0].Spec.Resources[0].Deleted)
+	assert.Equal(t, "test-uuid", slices[0].Spec.SynthesisUUID)
 
 	// Remove the resource - initial tombstone record is created
 	slices, err = Slice(&apiv1.Composition{}, slices, []*unstructured.Unstructured{}, 100000)


### PR DESCRIPTION
The current compositionGeneration doesn't necessarily change for every synthesis - we need to pass the UUID to guarantee those semantics (which will be useful for some other features).