### PR TITLE
Order CRD/CR interactions

### DIFF
--- a/internal/controllers/reconciliation/fixtures/crd-runtimetest-extra-property.yaml
+++ b/internal/controllers/reconciliation/fixtures/crd-runtimetest-extra-property.yaml
@@ -1,0 +1,53 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: runtimetests.enotest.azure.io
+spec:
+  group: enotest.azure.io
+  names:
+    kind: RuntimeTest
+    listKind: RuntimeTestList
+    plural: runtimetests
+    singular: runtimetest
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              addedValue:
+                type: integer
+              values:
+                items:
+                  properties:
+                    int:
+                      type: integer
+                  type: object
+                type: array
+            type: object
+          status:
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/internal/controllers/reconciliation/fixtures/crd-runtimetest.yaml
+++ b/internal/controllers/reconciliation/fixtures/crd-runtimetest.yaml
@@ -1,0 +1,51 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: runtimetests.enotest.azure.io
+spec:
+  group: enotest.azure.io
+  names:
+    kind: RuntimeTest
+    listKind: RuntimeTestList
+    plural: runtimetests
+    singular: runtimetest
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              values:
+                items:
+                  properties:
+                    int:
+                      type: integer
+                  type: object
+                type: array
+            type: object
+          status:
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/internal/controllers/reconciliation/ordering_test.go
+++ b/internal/controllers/reconciliation/ordering_test.go
@@ -148,7 +148,10 @@ func TestReadinessGroups(t *testing.T) {
 }
 
 func TestCRDOrdering(t *testing.T) {
-	testutil.AtLeastVersion(t, 16) // don't bother to support the old v1beta1 crd api
+	if !testutil.AtLeastVersion(t, 16) {
+		t.Skipf("test does not support the old v1beta1 crd api")
+		return
+	}
 	ctx := testutil.NewContext(t)
 	mgr := testutil.NewManager(t)
 	upstream := mgr.GetClient()

--- a/internal/controllers/reconciliation/ordering_test.go
+++ b/internal/controllers/reconciliation/ordering_test.go
@@ -148,10 +148,7 @@ func TestReadinessGroups(t *testing.T) {
 }
 
 func TestCRDOrdering(t *testing.T) {
-	scheme := runtime.NewScheme()
-	corev1.SchemeBuilder.AddToScheme(scheme)
-	testv1.SchemeBuilder.AddToScheme(scheme)
-
+	testutil.AtLeastVersion(t, 16) // don't bother to support the old v1beta1 crd api
 	ctx := testutil.NewContext(t)
 	mgr := testutil.NewManager(t)
 	upstream := mgr.GetClient()

--- a/internal/reconstitution/controller.go
+++ b/internal/reconstitution/controller.go
@@ -148,6 +148,9 @@ func (r *controller) HandleReadinessTransition(ctx context.Context, req ctrl.Req
 
 		synRef := &SynthesisRef{CompositionName: owner.Name, Namespace: req.Namespace, UUID: slice.Spec.SynthesisUUID}
 		resources := r.Cache.RangeByReadinessGroup(ctx, synRef, res.ReadinessGroup, RangeAsc)
+		if res.DefinedGroupKind != nil {
+			resources = append(resources, r.Cache.getByGK(synRef, *res.DefinedGroupKind)...)
+		}
 		for _, res := range resources {
 			// TODO: This can be optimized by skipping the Add call if `res` is already ready
 			r.queue.Add(Request{

--- a/internal/reconstitution/reconstitution.go
+++ b/internal/reconstitution/reconstitution.go
@@ -5,6 +5,7 @@ import (
 
 	apiv1 "github.com/Azure/eno/api/v1"
 	"github.com/Azure/eno/internal/resource"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 )
@@ -20,6 +21,7 @@ type Reconciler interface {
 type Client interface {
 	Get(ctx context.Context, syn *SynthesisRef, res *resource.Ref) (*resource.Resource, bool)
 	RangeByReadinessGroup(ctx context.Context, syn *SynthesisRef, group uint, dir RangeDirection) []*Resource
+	GetDefiningCRD(ctx context.Context, syn *SynthesisRef, gk schema.GroupKind) (*Resource, bool)
 }
 
 type RangeDirection bool

--- a/internal/resource/resource_test.go
+++ b/internal/resource/resource_test.go
@@ -144,6 +144,40 @@ var newResourceTests = []struct {
 			assert.True(t, r.patchSetsDeletionTimestamp())
 		},
 	},
+	{
+		Name: "crd",
+		Manifest: `{
+			"apiVersion": "apiextensions.k8s.io/v1",
+			"kind": "CustomResourceDefinition",
+			"metadata": {
+				"name": "foo"
+			},
+			"spec": {
+				"group": "test-group",
+				"names": {
+					"kind": "TestKind"
+				}
+			}
+		}`,
+		Assert: func(t *testing.T, r *Resource) {
+			assert.Equal(t, schema.GroupVersionKind{Group: "apiextensions.k8s.io", Version: "v1", Kind: "CustomResourceDefinition"}, r.GVK)
+			assert.Equal(t, &schema.GroupKind{Group: "test-group", Kind: "TestKind"}, r.DefinedGroupKind)
+		},
+	},
+	{
+		Name: "empty-crd",
+		Manifest: `{
+			"apiVersion": "apiextensions.k8s.io/v1",
+			"kind": "CustomResourceDefinition",
+			"metadata": {
+				"name": "foo"
+			}
+		}`,
+		Assert: func(t *testing.T, r *Resource) {
+			assert.Equal(t, schema.GroupVersionKind{Group: "apiextensions.k8s.io", Version: "v1", Kind: "CustomResourceDefinition"}, r.GVK)
+			assert.Equal(t, &schema.GroupKind{Group: "", Kind: ""}, r.DefinedGroupKind)
+		},
+	},
 }
 
 func TestNewResource(t *testing.T) {

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -405,3 +405,13 @@ func (e *ExecConn) Synthesize(ctx context.Context, syn *apiv1.Synthesizer, pod *
 
 	return bytes.NewBuffer(js), nil
 }
+
+func AtLeastVersion(t *testing.T, minor int) bool {
+	versionStr := os.Getenv("DOWNSTREAM_VERSION_MINOR")
+	if versionStr == "" {
+		return true // fail open for local dev
+	}
+
+	version, _ := strconv.Atoi(versionStr)
+	return version >= minor
+}


### PR DESCRIPTION
Guarantees that CRD updates land at least one second before any CRs of that group/kind are reconciled. See comments for more details.