### PR TITLE
Set useragent

### DIFF
--- a/cmd/eno-controller/main.go
+++ b/cmd/eno-controller/main.go
@@ -62,6 +62,7 @@ func run() error {
 	}
 	logger := zapr.NewLogger(zl)
 
+	mgrOpts.Rest.UserAgent = "eno-controller"
 	mgr, err := manager.New(logger, mgrOpts)
 	if err != nil {
 		return fmt.Errorf("constructing manager: %w", err)

--- a/cmd/eno-reconciler/main.go
+++ b/cmd/eno-reconciler/main.go
@@ -79,6 +79,7 @@ func run() error {
 		mgrOpts.CompositionSelector = labels.Everything()
 	}
 
+	mgrOpts.Rest.UserAgent = "eno-reconciler"
 	mgr, err := manager.NewReconciler(logger, mgrOpts)
 	if err != nil {
 		return fmt.Errorf("constructing manager: %w", err)


### PR DESCRIPTION
The controller-runtime clients set a reasonable default based on the os.Args[0]. But the client we construct for exec requests does not. Setting one explicitly makes both clients present the same user agent.