### PR TITLE
Support watching inputs

### DIFF
--- a/cmd/eno-controller/main.go
+++ b/cmd/eno-controller/main.go
@@ -22,6 +22,7 @@ import (
 	"github.com/Azure/eno/internal/controllers/replication"
 	"github.com/Azure/eno/internal/controllers/rollout"
 	"github.com/Azure/eno/internal/controllers/synthesis"
+	"github.com/Azure/eno/internal/controllers/watch"
 	"github.com/Azure/eno/internal/controllers/watchdog"
 	"github.com/Azure/eno/internal/execution"
 	"github.com/Azure/eno/internal/manager"
@@ -124,6 +125,11 @@ func runController() error {
 	err = aggregation.NewCompositionController(mgr)
 	if err != nil {
 		return fmt.Errorf("constructing composition status aggregation controller: %w", err)
+	}
+
+	err = watch.NewController(mgr)
+	if err != nil {
+		return fmt.Errorf("constructing watch controller: %w", err)
 	}
 
 	return mgr.Start(ctx)

--- a/internal/controllers/rollout/controller.go
+++ b/internal/controllers/rollout/controller.go
@@ -81,7 +81,7 @@ func (c *controller) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 			continue
 		}
 
-		swapStates(&comp)
+		SwapStates(&comp)
 		err = c.client.Status().Update(ctx, &comp)
 		if err != nil {
 			return ctrl.Result{}, fmt.Errorf("swapping compisition state: %w", err)
@@ -94,7 +94,7 @@ func (c *controller) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	return ctrl.Result{}, nil
 }
 
-func swapStates(comp *apiv1.Composition) {
+func SwapStates(comp *apiv1.Composition) {
 	// If the previous state has been synthesized but not the current, keep the previous to avoid orphaning deleted resources
 	if comp.Status.CurrentSynthesis != nil && comp.Status.CurrentSynthesis.Synthesized != nil {
 		comp.Status.PreviousSynthesis = comp.Status.CurrentSynthesis

--- a/internal/controllers/watch/integration_test.go
+++ b/internal/controllers/watch/integration_test.go
@@ -1,0 +1,72 @@
+package watch
+
+import (
+	"testing"
+	"time"
+
+	apiv1 "github.com/Azure/eno/api/v1"
+	"github.com/Azure/eno/internal/testutil"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func TestBasics(t *testing.T) {
+	mgr := testutil.NewManager(t)
+	require.NoError(t, NewController(mgr.Manager))
+	mgr.Start(t)
+
+	ctx := testutil.NewContext(t)
+	cli := mgr.GetClient()
+
+	input := &corev1.ConfigMap{}
+	input.Name = "test-input"
+	input.Namespace = "default"
+	require.NoError(t, cli.Create(ctx, input))
+
+	synth := &apiv1.Synthesizer{}
+	synth.Name = "test-comp"
+	synth.Namespace = "default"
+	synth.Spec.Refs = []apiv1.Ref{{
+		Key: "foo",
+		Resource: apiv1.ResourceRef{
+			Version: "v1",
+			Kind:    "ConfigMap",
+		},
+	}}
+	require.NoError(t, cli.Create(ctx, synth))
+
+	comp := &apiv1.Composition{}
+	comp.Name = "test-comp"
+	comp.Namespace = "default"
+	comp.Spec.Synthesizer.Name = synth.Name
+	comp.Spec.Bindings = []apiv1.Binding{{
+		Key: "foo",
+		Resource: apiv1.ResourceBinding{
+			Name:      input.Name,
+			Namespace: input.Namespace,
+		},
+	}}
+	require.NoError(t, cli.Create(ctx, comp))
+
+	comp.Status.CurrentSynthesis = &apiv1.Synthesis{
+		Synthesized: ptr.To(metav1.Now()),
+	}
+	require.NoError(t, cli.Status().Update(ctx, comp))
+
+	// Make sure all informers are in sync
+	time.Sleep(time.Millisecond * 200)
+
+	// Update the input
+	input.Data = map[string]string{"foo": "bar"}
+	require.NoError(t, cli.Update(ctx, input))
+
+	// The composition should be resynthesized
+	testutil.Eventually(t, func() bool {
+		cli.Get(ctx, client.ObjectKeyFromObject(comp), comp)
+		syn := comp.Status.CurrentSynthesis
+		return syn != nil && syn.Synthesized == nil
+	})
+}

--- a/internal/controllers/watch/kind.go
+++ b/internal/controllers/watch/kind.go
@@ -1,0 +1,177 @@
+package watch
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"path"
+	"time"
+
+	apiv1 "github.com/Azure/eno/api/v1"
+	"github.com/Azure/eno/internal/controllers/rollout"
+	"github.com/Azure/eno/internal/manager"
+	"github.com/Azure/eno/internal/resource"
+	"github.com/go-logr/logr"
+	"golang.org/x/time/rate"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/util/workqueue"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+)
+
+type KindWatchController struct {
+	client client.Client
+	gvk    schema.GroupVersionKind
+	cancel context.CancelFunc
+}
+
+func NewKindWatchController(ctx context.Context, parent *WatchController, resource *apiv1.ResourceRef) (*KindWatchController, error) {
+	logger := logr.FromContextOrDiscard(ctx).WithValues("group", resource.Group, "version", resource.Version, "kind", resource.Kind)
+
+	k := &KindWatchController{
+		client: parent.mgr.GetClient(),
+		gvk: schema.GroupVersionKind{
+			Group:   resource.Group,
+			Version: resource.Version,
+			Kind:    resource.Kind,
+		},
+	}
+
+	ref := &metav1.PartialObjectMetadata{}
+	ref.SetGroupVersionKind(k.gvk)
+
+	rrc, err := controller.NewUnmanaged("kindWatchController", parent.mgr, controller.Options{
+		LogConstructor: manager.NewLogConstructor(parent.mgr, "kindWatchController"),
+		RateLimiter: &workqueue.BucketRateLimiter{
+			// Be careful about feedback loops - low, hardcoded rate limits make sense here.
+			// Maybe expose as a flag in the future.
+			Limiter: rate.NewLimiter(rate.Every(time.Second), 2),
+		},
+		Reconciler: k,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	err = rrc.Watch(source.Kind(parent.mgr.GetCache(), ref), &handler.EnqueueRequestForObject{})
+	if err != nil {
+		return nil, err
+	}
+
+	ctx, cancel := context.WithCancel(ctx)
+	k.cancel = cancel
+
+	go func() {
+		logger.V(1).Info("starting kind watch controller")
+		rrc.Start(ctx)
+		logger.V(1).Info("kind watch controller stopped")
+	}()
+
+	return k, nil
+}
+
+func (k *KindWatchController) Stop(ctx context.Context) {
+	logger := logr.FromContextOrDiscard(ctx)
+	if k.cancel != nil {
+		k.cancel()
+	}
+	logger.V(1).Info("stopping kind watch controller")
+}
+
+func (k *KindWatchController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	logger := logr.FromContextOrDiscard(ctx)
+
+	meta := &metav1.PartialObjectMetadata{}
+	meta.SetGroupVersionKind(k.gvk)
+	err := k.client.Get(ctx, req.NamespacedName, meta)
+	if err != nil {
+		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
+
+	list := &apiv1.SynthesizerList{}
+	err = k.client.List(ctx, list, client.MatchingFields{
+		manager.IdxSynthesizersByRef: path.Join(k.gvk.Group, k.gvk.Version, k.gvk.Kind),
+	})
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("listing synthesizers: %w", err)
+	}
+	rand.Shuffle(len(list.Items), func(i, j int) { list.Items[i] = list.Items[j] })
+
+	for _, synth := range list.Items {
+		list := &apiv1.CompositionList{}
+		err = k.client.List(ctx, list, client.MatchingFields{
+			manager.IdxCompositionsByBinding: path.Join(synth.Name, meta.Namespace, meta.Name),
+		})
+		if err != nil {
+			return ctrl.Result{}, fmt.Errorf("listing compositions: %w", err)
+		}
+		rand.Shuffle(len(list.Items), func(i, j int) { list.Items[i] = list.Items[j] })
+
+		for _, comp := range list.Items {
+			key := findRefKey(&comp, &synth, meta)
+			if key == "" {
+				logger.V(1).Info("no matching input key found for resource")
+				continue
+			}
+
+			revs := resource.NewInputRevisions(meta, key)
+			if !shouldCauseResynthesis(&comp, revs) {
+				continue
+			}
+
+			// Input has changed - resynthesize!
+			rollout.SwapStates(&comp)
+			err = k.client.Status().Update(ctx, &comp)
+			if err != nil {
+				return ctrl.Result{}, fmt.Errorf("swapping composition state: %w", err)
+			}
+			logger.V(0).Info("started resynthesis because input changed", "compositionName", comp.Name, "compositionNamespace", comp.Namespace, "ref", revs.Key)
+		}
+	}
+
+	return ctrl.Result{}, nil
+}
+
+func shouldCauseResynthesis(comp *apiv1.Composition, revs *apiv1.InputRevisions) bool {
+	if comp.DeletionTimestamp != nil || comp.Status.CurrentSynthesis == nil || comp.Status.CurrentSynthesis.Synthesized == nil {
+		return false
+	}
+
+	for _, r := range comp.Status.CurrentSynthesis.InputRevisions {
+		if r.Key != revs.Key {
+			continue
+		}
+		if revs.Revision == nil {
+			if r.Revision != nil && *r.Revision == *revs.Revision {
+				return true
+			}
+		} else {
+			return r.ResourceVersion == revs.ResourceVersion
+		}
+	}
+
+	return true // no matching keys
+}
+
+func findRefKey(comp *apiv1.Composition, synth *apiv1.Synthesizer, meta *metav1.PartialObjectMetadata) string {
+	var bindingKey string
+	for _, binding := range comp.Spec.Bindings {
+		if binding.Resource.Name == meta.GetName() && binding.Resource.Namespace == meta.GetNamespace() {
+			bindingKey = binding.Key
+			break
+		}
+	}
+
+	for _, ref := range synth.Spec.Refs {
+		gvk := meta.GetObjectKind().GroupVersionKind()
+		if bindingKey == ref.Key && ref.Resource.Group == gvk.Group && ref.Resource.Version == gvk.Version && ref.Resource.Kind == gvk.Kind {
+			return ref.Key
+		}
+	}
+
+	return ""
+}

--- a/internal/controllers/watch/watch.go
+++ b/internal/controllers/watch/watch.go
@@ -1,0 +1,79 @@
+package watch
+
+import (
+	"context"
+	"math/rand"
+
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	apiv1 "github.com/Azure/eno/api/v1"
+	"github.com/Azure/eno/internal/manager"
+)
+
+type WatchController struct {
+	mgr            ctrl.Manager
+	client         client.Client
+	refControllers map[apiv1.ResourceRef]*KindWatchController
+}
+
+func NewController(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		Named("watchControllerController").
+		Watches(&apiv1.Synthesizer{}, manager.SingleEventHandler()).
+		WithLogConstructor(manager.NewLogConstructor(mgr, "watchController")).
+		Complete(&WatchController{
+			mgr:            mgr,
+			client:         mgr.GetClient(),
+			refControllers: map[apiv1.ResourceRef]*KindWatchController{},
+		})
+}
+
+func (c *WatchController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	synths := &apiv1.SynthesizerList{}
+	err := c.client.List(ctx, synths)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	// It's important to randomize the order over which we iterate the synths,
+	// otherwise one bad resource reference can block the loop
+	rand.Shuffle(len(synths.Items), func(i, j int) { synths.Items[i] = synths.Items[j] })
+
+	// Start any missing controllers
+	synthsByRef := map[apiv1.ResourceRef]struct{}{}
+	for _, syn := range synths.Items {
+		if syn.DeletionTimestamp != nil {
+			continue
+		}
+		for _, ref := range syn.Spec.Refs {
+			ref := ref
+			synthsByRef[ref.Resource] = struct{}{}
+
+			current := c.refControllers[ref.Resource]
+			if current != nil {
+				continue // already running
+			}
+
+			rc, err := NewKindWatchController(ctx, c, &ref.Resource)
+			if err != nil {
+				return ctrl.Result{}, err
+			}
+			c.refControllers[ref.Resource] = rc
+			return ctrl.Result{Requeue: true}, nil
+		}
+	}
+
+	// Stop controllers that are no longer needed
+	for ref, rc := range c.refControllers {
+		if _, ok := synthsByRef[ref]; ok {
+			continue
+		}
+
+		rc.Stop(ctx)
+		delete(c.refControllers, ref)
+		return ctrl.Result{Requeue: true}, nil
+	}
+
+	return ctrl.Result{}, nil
+}

--- a/internal/controllers/watchdog/controller.go
+++ b/internal/controllers/watchdog/controller.go
@@ -19,7 +19,8 @@ type watchdogController struct {
 
 func NewController(mgr ctrl.Manager, threshold time.Duration) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&apiv1.Composition{}).
+		Named("watchdogController").
+		Watches(&apiv1.Composition{}, manager.SingleEventHandler()).
 		WithLogConstructor(manager.NewLogConstructor(mgr, "watchdogController")).
 		Complete(&watchdogController{
 			client:    mgr.GetClient(),

--- a/internal/execution/executor.go
+++ b/internal/execution/executor.go
@@ -3,7 +3,6 @@ package execution
 import (
 	"context"
 	"fmt"
-	"strconv"
 	"time"
 
 	apiv1 "github.com/Azure/eno/api/v1"
@@ -99,14 +98,7 @@ func (e *Executor) buildPodInput(ctx context.Context, comp *apiv1.Composition, s
 		logger.V(0).Info("retrieved input", "key", key, "latency", time.Since(start).Milliseconds())
 
 		// Store the revision to be written to the synthesis status later
-		ir := apiv1.InputRevisions{
-			Key:             key,
-			ResourceVersion: obj.GetResourceVersion(),
-		}
-		if rev, _ := strconv.Atoi(obj.GetAnnotations()["eno.azure.io/revision"]); rev != 0 {
-			ir.Revision = &rev
-		}
-		revs = append(revs, ir)
+		revs = append(revs, *resource.NewInputRevisions(obj, key))
 	}
 
 	return rl, revs, nil

--- a/internal/manager/indices.go
+++ b/internal/manager/indices.go
@@ -2,7 +2,9 @@ package manager
 
 import (
 	"context"
+	"path"
 
+	apiv1 "github.com/Azure/eno/api/v1"
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -16,6 +18,8 @@ const (
 	IdxCompositionsBySynthesizer   = ".spec.synthesizer"
 	IdxCompositionsBySymphony      = ".compositionsBySymphony"
 	IdxResourceSlicesByComposition = ".resourceSlicesByComposition"
+	IdxCompositionsByBinding       = ".compositionsByBinding"
+	IdxSynthesizersByRef           = ".synthesizersByRef"
 
 	CompositionNameLabelKey      = "eno.azure.io/composition-name"
 	CompositionNamespaceLabelKey = "eno.azure.io/composition-namespace"
@@ -62,5 +66,35 @@ func indexController() client.IndexerFunc {
 			return nil
 		}
 		return []string{owner.Name}
+	}
+}
+
+func indexResourceBindings() client.IndexerFunc {
+	return func(o client.Object) []string {
+		comp, ok := o.(*apiv1.Composition)
+		if !ok {
+			return nil
+		}
+
+		keys := []string{}
+		for _, binding := range comp.Spec.Bindings {
+			keys = append(keys, path.Join(comp.Spec.Synthesizer.Name, binding.Resource.Namespace, binding.Resource.Name))
+		}
+		return keys
+	}
+}
+
+func indexSynthRefs() client.IndexerFunc {
+	return func(o client.Object) []string {
+		synth, ok := o.(*apiv1.Synthesizer)
+		if !ok {
+			return nil
+		}
+
+		keys := []string{}
+		for _, ref := range synth.Spec.Refs {
+			keys = append(keys, path.Join(ref.Resource.Group, ref.Resource.Version, ref.Resource.Kind))
+		}
+		return keys
 	}
 }

--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -164,6 +164,16 @@ func newMgr(logger logr.Logger, opts *Options, isController, isReconciler bool) 
 		if err != nil {
 			return nil, err
 		}
+
+		err = mgr.GetFieldIndexer().IndexField(context.Background(), &apiv1.Composition{}, IdxCompositionsByBinding, indexResourceBindings())
+		if err != nil {
+			return nil, err
+		}
+
+		err = mgr.GetFieldIndexer().IndexField(context.Background(), &apiv1.Synthesizer{}, IdxSynthesizersByRef, indexSynthRefs())
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	if isReconciler {
@@ -213,4 +223,10 @@ func NewCompositionToResourceSliceHandler(cli client.Client) handler.EventHandle
 			apply(ctx, rli, de.Object)
 		},
 	}
+}
+
+func SingleEventHandler() handler.EventHandler {
+	return handler.EnqueueRequestsFromMapFunc(handler.MapFunc(func(ctx context.Context, o client.Object) []reconcile.Request {
+		return []reconcile.Request{{}}
+	}))
 }

--- a/internal/resource/resource.go
+++ b/internal/resource/resource.go
@@ -19,6 +19,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 var patchGVK = schema.GroupVersionKind{
@@ -273,4 +274,15 @@ func (l *lastReconciledMeta) ObserveReconciliation() time.Duration {
 
 	l.lastReconciled = &now
 	return latency
+}
+
+func NewInputRevisions(obj client.Object, refKey string) *apiv1.InputRevisions {
+	ir := apiv1.InputRevisions{
+		Key:             refKey,
+		ResourceVersion: obj.GetResourceVersion(),
+	}
+	if rev, _ := strconv.Atoi(obj.GetAnnotations()["eno.azure.io/revision"]); rev != 0 {
+		ir.Revision = &rev
+	}
+	return &ir
 }


### PR DESCRIPTION
Adds a "meta controller" that spawns a controller per unique `ref`, which resynthesizes compositions when their bound input resources change. Minimal implementation for now, will fill out more functionality (cooldown, etc.) later.