### PR TITLE
Don't roll out updates during deletion

### DIFF
--- a/internal/controllers/rollout/controller.go
+++ b/internal/controllers/rollout/controller.go
@@ -75,9 +75,9 @@ func (c *controller) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 
 		// Compositions aren't eligible to receive an updated synthesizer when:
 		// - They haven't ever been synthesized (they'll use the latest inputs anyway)
-		// - They are currently being synthesized
+		// - They are currently being synthesized or deleted
 		// - They are already in sync with the latest inputs
-		if comp.Status.CurrentSynthesis == nil || comp.Status.CurrentSynthesis.Synthesized == nil || isInSync(&comp, syn) {
+		if comp.Status.CurrentSynthesis == nil || comp.Status.CurrentSynthesis.Synthesized == nil || comp.DeletionTimestamp != nil || isInSync(&comp, syn) {
 			continue
 		}
 

--- a/internal/controllers/rollout/controller_test.go
+++ b/internal/controllers/rollout/controller_test.go
@@ -135,3 +135,54 @@ func TestSynthesizerRolloutCooldown(t *testing.T) {
 	require.NoError(t, client.IgnoreNotFound(cli.Get(ctx, client.ObjectKeyFromObject(comp), comp)))
 	assert.Equal(t, original.Status.CurrentSynthesis.ObservedSynthesizerGeneration, comp.Status.CurrentSynthesis.ObservedSynthesizerGeneration, "composition has not been resynthesized")
 }
+
+// TestSynthesizerRolloutDeleted proves that compositions will not be updated while deleting.
+func TestSynthesizerRolloutDeleted(t *testing.T) {
+	ctx := testutil.NewContext(t)
+	mgr := testutil.NewManager(t)
+	cli := mgr.GetClient()
+
+	require.NoError(t, NewController(mgr.Manager, time.Millisecond*10))
+	require.NoError(t, synthesis.NewPodLifecycleController(mgr.Manager, testSynthesisConfig))
+	testutil.WithFakeExecutor(t, mgr, func(ctx context.Context, s *apiv1.Synthesizer, input *krmv1.ResourceList) (*krmv1.ResourceList, error) {
+		output := &krmv1.ResourceList{}
+		return output, nil
+	})
+	mgr.Start(t)
+
+	syn := &apiv1.Synthesizer{}
+	syn.Name = "test-syn"
+	syn.Spec.Image = "test-syn-image"
+	require.NoError(t, cli.Create(ctx, syn))
+
+	comp := &apiv1.Composition{}
+	comp.Name = "test-comp"
+	comp.Namespace = "default"
+	comp.Finalizers = []string{"foo"}
+	comp.Spec.Synthesizer.Name = syn.Name
+	require.NoError(t, cli.Create(ctx, comp))
+
+	// Creation
+	testutil.Eventually(t, func() bool {
+		require.NoError(t, client.IgnoreNotFound(cli.Get(ctx, client.ObjectKeyFromObject(comp), comp)))
+		return comp.Status.CurrentSynthesis != nil && comp.Status.CurrentSynthesis.Synthesized != nil
+	})
+
+	// Start deletion
+	require.NoError(t, cli.Delete(ctx, comp))
+
+	// Update the synthesizer
+	err := retry.RetryOnConflict(testutil.Backoff, func() error {
+		if err := cli.Get(ctx, client.ObjectKeyFromObject(syn), syn); err != nil {
+			return err
+		}
+		syn.Spec.Image = "updated-image"
+		return cli.Update(ctx, syn)
+	})
+	require.NoError(t, err)
+
+	// Wait a bit and prove the composition wasn't updated
+	time.Sleep(time.Millisecond * 200)
+	require.NoError(t, cli.Get(ctx, client.ObjectKeyFromObject(comp), comp))
+	assert.Equal(t, int64(2), comp.Generation)
+}


### PR DESCRIPTION
The controller will enter a feedback loop of rolling out updates by swapping the current to previous synthesis, and reverting the swapped states by doing the opposite when a composition is being deleted when there isn't a reconciler process with a label selector that matches the composition.