### PR TITLE
Fix deadlock around pod status

### DIFF
--- a/internal/controllers/synthesis/lifecycle.go
+++ b/internal/controllers/synthesis/lifecycle.go
@@ -290,7 +290,7 @@ func shouldDeletePod(logger logr.Logger, comp *apiv1.Composition, syn *apiv1.Syn
 		}
 
 		isCurrent := podIsCurrent(comp, &pod)
-		if !isCurrent {
+		if !isCurrent || pod.Status.Phase == corev1.PodSucceeded {
 			logger = logger.WithValues("reason", "Superseded")
 			return logger, &pod, true
 		}

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -370,6 +370,16 @@ func WithFakeExecutor(t *testing.T, mgr *Manager, sh execution.SynthesizerHandle
 			return reconcile.Result{}, err
 		}
 
+		err = mgr.GetClient().Get(ctx, client.ObjectKeyFromObject(pod), pod)
+		if err != nil {
+			return reconcile.Result{}, nil
+		}
+		pod.Status.Phase = corev1.PodSucceeded
+		err = mgr.GetClient().Status().Update(ctx, pod)
+		if err != nil {
+			return reconcile.Result{}, nil
+		}
+
 		return reconcile.Result{}, nil
 	})
 


### PR DESCRIPTION
When a composition's current synthesis doesn't match that of a synthesizer pod, the pod's executor should not update the status - its immutable and should only be written by the pod of the correct version.

This works as-is but one test case is flaky because we don't handle an edge case: what happens when that pod is `Succeeded` but the synthesis still has a nil `Synthesized` time. Since we limit the number of concurrent running pods per synthesis to 1, we need to delete pods where the executor has returned even if the synthesis status hasn't been updated.