### PR TITLE
Finish implementing deferred input rollouts

### DIFF
--- a/api/v1/composition.go
+++ b/api/v1/composition.go
@@ -43,9 +43,9 @@ type CompositionSpec struct {
 
 type CompositionStatus struct {
 	Simplified         *SimplifiedStatus `json:"simplified,omitempty"`
-	PendingResynthesis *metav1.Time      `json:"pendingResynthesis,omitempty"`
 	CurrentSynthesis   *Synthesis        `json:"currentSynthesis,omitempty"`
 	PreviousSynthesis  *Synthesis        `json:"previousSynthesis,omitempty"`
+	PendingResynthesis *metav1.Time      `json:"pendingResynthesis,omitempty"`
 }
 
 type SimplifiedStatus struct {
@@ -92,6 +92,10 @@ type Synthesis struct {
 
 	// InputRevisions contains the versions of the input resources that were used for this synthesis.
 	InputRevisions []InputRevisions `json:"inputRevisions,omitempty"`
+
+	// Deferred is true when this synthesis was the result of a deferred rollout,
+	// caused by a synthesizer of (deferred) input change.
+	Deferred bool `json:"deferred,omitempty"`
 }
 
 type Result struct {

--- a/api/v1/composition.go
+++ b/api/v1/composition.go
@@ -93,8 +93,8 @@ type Synthesis struct {
 	// InputRevisions contains the versions of the input resources that were used for this synthesis.
 	InputRevisions []InputRevisions `json:"inputRevisions,omitempty"`
 
-	// Deferred is true when this synthesis was the result of a deferred rollout,
-	// caused by a synthesizer of (deferred) input change.
+	// Deferred is true when this synthesis was caused by a change to either the synthesizer
+	// or an input with a ref that sets `Defer == true`.
 	Deferred bool `json:"deferred,omitempty"`
 }
 

--- a/api/v1/composition.go
+++ b/api/v1/composition.go
@@ -42,9 +42,10 @@ type CompositionSpec struct {
 }
 
 type CompositionStatus struct {
-	Simplified        *SimplifiedStatus `json:"simplified,omitempty"`
-	CurrentSynthesis  *Synthesis        `json:"currentSynthesis,omitempty"`
-	PreviousSynthesis *Synthesis        `json:"previousSynthesis,omitempty"`
+	Simplified         *SimplifiedStatus `json:"simplified,omitempty"`
+	PendingResynthesis *metav1.Time      `json:"pendingResynthesis,omitempty"`
+	CurrentSynthesis   *Synthesis        `json:"currentSynthesis,omitempty"`
+	PreviousSynthesis  *Synthesis        `json:"previousSynthesis,omitempty"`
 }
 
 type SimplifiedStatus struct {

--- a/api/v1/config/crd/eno.azure.io_compositions.yaml
+++ b/api/v1/config/crd/eno.azure.io_compositions.yaml
@@ -181,6 +181,9 @@ spec:
                       Used internally for strict ordering semantics.
                     type: string
                 type: object
+              pendingResynthesis:
+                format: date-time
+                type: string
               previousSynthesis:
                 description: |-
                   A synthesis is the result of synthesizing a composition.

--- a/api/v1/config/crd/eno.azure.io_compositions.yaml
+++ b/api/v1/config/crd/eno.azure.io_compositions.yaml
@@ -105,6 +105,11 @@ spec:
                     description: Counter used internally to calculate back off when
                       retrying failed syntheses.
                     type: integer
+                  deferred:
+                    description: |-
+                      Deferred is true when this synthesis was the result of a deferred rollout,
+                      caused by a synthesizer of (deferred) input change.
+                    type: boolean
                   inputRevisions:
                     description: InputRevisions contains the versions of the input
                       resources that were used for this synthesis.
@@ -193,6 +198,11 @@ spec:
                     description: Counter used internally to calculate back off when
                       retrying failed syntheses.
                     type: integer
+                  deferred:
+                    description: |-
+                      Deferred is true when this synthesis was the result of a deferred rollout,
+                      caused by a synthesizer of (deferred) input change.
+                    type: boolean
                   inputRevisions:
                     description: InputRevisions contains the versions of the input
                       resources that were used for this synthesis.

--- a/api/v1/zz_generated.deepcopy.go
+++ b/api/v1/zz_generated.deepcopy.go
@@ -113,6 +113,10 @@ func (in *CompositionStatus) DeepCopyInto(out *CompositionStatus) {
 		*out = new(SimplifiedStatus)
 		**out = **in
 	}
+	if in.PendingResynthesis != nil {
+		in, out := &in.PendingResynthesis, &out.PendingResynthesis
+		*out = (*in).DeepCopy()
+	}
 	if in.CurrentSynthesis != nil {
 		in, out := &in.CurrentSynthesis, &out.CurrentSynthesis
 		*out = new(Synthesis)

--- a/api/v1/zz_generated.deepcopy.go
+++ b/api/v1/zz_generated.deepcopy.go
@@ -113,10 +113,6 @@ func (in *CompositionStatus) DeepCopyInto(out *CompositionStatus) {
 		*out = new(SimplifiedStatus)
 		**out = **in
 	}
-	if in.PendingResynthesis != nil {
-		in, out := &in.PendingResynthesis, &out.PendingResynthesis
-		*out = (*in).DeepCopy()
-	}
 	if in.CurrentSynthesis != nil {
 		in, out := &in.CurrentSynthesis, &out.CurrentSynthesis
 		*out = new(Synthesis)
@@ -126,6 +122,10 @@ func (in *CompositionStatus) DeepCopyInto(out *CompositionStatus) {
 		in, out := &in.PreviousSynthesis, &out.PreviousSynthesis
 		*out = new(Synthesis)
 		(*in).DeepCopyInto(*out)
+	}
+	if in.PendingResynthesis != nil {
+		in, out := &in.PendingResynthesis, &out.PendingResynthesis
+		*out = (*in).DeepCopy()
 	}
 }
 

--- a/cmd/eno-controller/main.go
+++ b/cmd/eno-controller/main.go
@@ -97,7 +97,7 @@ func runController() error {
 		return fmt.Errorf("constructing manager: %w", err)
 	}
 
-	err = rollout.NewController(mgr, rolloutCooldown)
+	err = rollout.NewSynthesizerController(mgr, rolloutCooldown)
 	if err != nil {
 		return fmt.Errorf("constructing rollout controller: %w", err)
 	}

--- a/cmd/eno-controller/main.go
+++ b/cmd/eno-controller/main.go
@@ -97,7 +97,12 @@ func runController() error {
 		return fmt.Errorf("constructing manager: %w", err)
 	}
 
-	err = rollout.NewSynthesizerController(mgr, rolloutCooldown)
+	err = rollout.NewController(mgr, rolloutCooldown)
+	if err != nil {
+		return fmt.Errorf("constructing rollout controller: %w", err)
+	}
+
+	err = rollout.NewSynthesizerController(mgr)
 	if err != nil {
 		return fmt.Errorf("constructing rollout controller: %w", err)
 	}

--- a/cmd/eno-controller/main.go
+++ b/cmd/eno-controller/main.go
@@ -64,7 +64,7 @@ func runController() error {
 	flag.StringVar(&synconf.PodServiceAccount, "synthesizer-pod-service-account", "", "Service account name to be assigned to synthesizer Pods.")
 	flag.BoolVar(&debugLogging, "debug", true, "Enable debug logging")
 	flag.DurationVar(&watchdogThres, "watchdog-threshold", time.Minute*5, "How long before the watchdog considers a mid-transition resource to be stuck")
-	flag.DurationVar(&rolloutCooldown, "rollout-cooldown", time.Second*2, "How long before an update to related resource (synthesizer, bindings, etc.) will trigger a composition's re-synthesis")
+	flag.DurationVar(&rolloutCooldown, "rollout-cooldown", time.Minute, "How long before an update to a related resource (synthesizer, bindings, etc.) will trigger a second composition's re-synthesis")
 	flag.StringVar(&taintToleration, "taint-toleration", "", "Node NoSchedule taint to be tolerated by synthesizer pods e.g. taintKey=taintValue to match on value, just taintKey to match on presence of the taint")
 	flag.StringVar(&nodeAffinity, "node-affinity", "", "Synthesizer pods will be created with this required node affinity expression e.g. labelKey=labelValue to match on value, just labelKey to match on presence of the label")
 	mgrOpts.Bind(flag.CommandLine)

--- a/dev/build.sh
+++ b/dev/build.sh
@@ -22,5 +22,5 @@ done
 wait
 
 # Deploy!
-cat "$(dirname "$0")/deploy.yaml" | envsubst | kubectl apply -f -
+cat "$(dirname "$0")/deploy.yaml" | envsubst | kubectl apply -f - -f ./api/v1/config/crd
 echo "Success! You're running tag: $TAG"

--- a/docs/api.md
+++ b/docs/api.md
@@ -91,6 +91,7 @@ _Appears in:_
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
 | `simplified` _[SimplifiedStatus](#simplifiedstatus)_ |  |  |  |
+| `pendingResynthesis` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#time-v1-meta)_ |  |  |  |
 | `currentSynthesis` _[Synthesis](#synthesis)_ |  |  |  |
 | `previousSynthesis` _[Synthesis](#synthesis)_ |  |  |  |
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -91,9 +91,9 @@ _Appears in:_
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
 | `simplified` _[SimplifiedStatus](#simplifiedstatus)_ |  |  |  |
-| `pendingResynthesis` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#time-v1-meta)_ |  |  |  |
 | `currentSynthesis` _[Synthesis](#synthesis)_ |  |  |  |
 | `previousSynthesis` _[Synthesis](#synthesis)_ |  |  |  |
+| `pendingResynthesis` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#time-v1-meta)_ |  |  |  |
 
 
 
@@ -301,6 +301,7 @@ _Appears in:_
 | `attempts` _integer_ | Counter used internally to calculate back off when retrying failed syntheses. |  |  |
 | `results` _[Result](#result) array_ | Results are passed through opaquely from the synthesizer's KRM function. |  |  |
 | `inputRevisions` _[InputRevisions](#inputrevisions) array_ | InputRevisions contains the versions of the input resources that were used for this synthesis. |  |  |
+| `deferred` _boolean_ | Deferred is true when this synthesis was the result of a deferred rollout,<br />caused by a synthesizer of (deferred) input change. |  |  |
 
 
 #### Synthesizer

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -224,4 +224,4 @@ Changes to deferred input resources (`ref.defer == true`) and synthesizers are s
 
 - All effected compositions are marked as pending resynthesis immediately
 - A maximum of one composition pending resynthesis can begin resynthesis per cooldown period
-- The next pending composition can start after the cooldown period has expired AND all resynthesis has completed or been retried at least once
+- The next pending composition can start after the cooldown period has expired AND all resynthesis has completed (with success or terminal error) or been retried at least once

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -215,3 +215,13 @@ patch:
   ops:
     - { "op": "add", "path": "/metadata/deletionTimestamp", "value": "anything" }
 ```
+
+
+# Rollouts
+
+Composition changes are resynthesized immediately.
+Changes to deferred input resources (`ref.defer == true`) and synthesizers are subject to the global cooldown period.
+
+- All effected compositions are marked as pending resynthesis immediately
+- A maximum of one composition pending resynthesis can begin resynthesis per cooldown period
+- The next pending composition can start after the cooldown period has expired AND all resynthesis has completed or been retried at least once

--- a/internal/controllers/aggregation/composition.go
+++ b/internal/controllers/aggregation/composition.go
@@ -84,7 +84,7 @@ func (c *compositionController) aggregate(comp *apiv1.Composition) *apiv1.Simpli
 		copy.Status = "Ready"
 	}
 	if comp.Status.PendingResynthesis != nil {
-		copy.Status = "PendingResynthesis"
+		copy.Status = "WaitingForCooldown"
 	}
 
 	return copy

--- a/internal/controllers/aggregation/composition.go
+++ b/internal/controllers/aggregation/composition.go
@@ -83,6 +83,9 @@ func (c *compositionController) aggregate(comp *apiv1.Composition) *apiv1.Simpli
 	if comp.Status.CurrentSynthesis.Ready != nil {
 		copy.Status = "Ready"
 	}
+	if comp.Status.PendingResynthesis != nil {
+		copy.Status = "PendingResynthesis"
+	}
 
 	return copy
 }

--- a/internal/controllers/aggregation/composition_test.go
+++ b/internal/controllers/aggregation/composition_test.go
@@ -62,6 +62,16 @@ func TestCompositionSimplification(t *testing.T) {
 				Error:  "foo",
 			},
 		},
+		{
+			Input: apiv1.CompositionStatus{
+				PendingResynthesis: ptr.To(metav1.Now()),
+				CurrentSynthesis: &apiv1.Synthesis{
+					Ready:   ptr.To(metav1.Now()),
+				}},
+			Expected: apiv1.SimplifiedStatus{
+				Status: "PendingResynthesis",
+			},
+		},
 	}
 
 	for _, tc := range tests {

--- a/internal/controllers/aggregation/composition_test.go
+++ b/internal/controllers/aggregation/composition_test.go
@@ -66,10 +66,10 @@ func TestCompositionSimplification(t *testing.T) {
 			Input: apiv1.CompositionStatus{
 				PendingResynthesis: ptr.To(metav1.Now()),
 				CurrentSynthesis: &apiv1.Synthesis{
-					Ready:   ptr.To(metav1.Now()),
+					Ready: ptr.To(metav1.Now()),
 				}},
 			Expected: apiv1.SimplifiedStatus{
-				Status: "PendingResynthesis",
+				Status: "WaitingForCooldown",
 			},
 		},
 	}

--- a/internal/controllers/reconciliation/crud_test.go
+++ b/internal/controllers/reconciliation/crud_test.go
@@ -217,7 +217,8 @@ func TestCRUD(t *testing.T) {
 			downstream := mgr.DownstreamClient
 
 			// Register supporting controllers
-			require.NoError(t, rollout.NewSynthesizerController(mgr.Manager, time.Millisecond))
+			require.NoError(t, rollout.NewSynthesizerController(mgr.Manager))
+			require.NoError(t, rollout.NewController(mgr.Manager, time.Millisecond))
 			require.NoError(t, synthesis.NewPodLifecycleController(mgr.Manager, defaultConf))
 			testutil.WithFakeExecutor(t, mgr, newSliceBuilder(t, scheme, &test))
 
@@ -385,7 +386,8 @@ func TestReconcileInterval(t *testing.T) {
 	downstream := mgr.DownstreamClient
 
 	// Register supporting controllers
-	require.NoError(t, rollout.NewSynthesizerController(mgr.Manager, time.Millisecond))
+	require.NoError(t, rollout.NewSynthesizerController(mgr.Manager))
+	require.NoError(t, rollout.NewController(mgr.Manager, time.Millisecond))
 	require.NoError(t, synthesis.NewPodLifecycleController(mgr.Manager, defaultConf))
 	testutil.WithFakeExecutor(t, mgr, func(ctx context.Context, s *apiv1.Synthesizer, input *krmv1.ResourceList) (*krmv1.ResourceList, error) {
 		output := &krmv1.ResourceList{}
@@ -455,7 +457,8 @@ func TestReconcileCacheRace(t *testing.T) {
 	downstream := mgr.DownstreamClient
 
 	// Register supporting controllers
-	require.NoError(t, rollout.NewSynthesizerController(mgr.Manager, time.Millisecond))
+	require.NoError(t, rollout.NewSynthesizerController(mgr.Manager))
+	require.NoError(t, rollout.NewController(mgr.Manager, time.Millisecond))
 	require.NoError(t, synthesis.NewPodLifecycleController(mgr.Manager, defaultConf))
 	renderN := 0
 	testutil.WithFakeExecutor(t, mgr, func(ctx context.Context, s *apiv1.Synthesizer, input *krmv1.ResourceList) (*krmv1.ResourceList, error) {
@@ -527,7 +530,8 @@ func TestCompositionDeletionOrdering(t *testing.T) {
 	downstream := mgr.DownstreamClient
 
 	// Register supporting controllers
-	require.NoError(t, rollout.NewSynthesizerController(mgr.Manager, time.Millisecond))
+	require.NoError(t, rollout.NewSynthesizerController(mgr.Manager))
+	require.NoError(t, rollout.NewController(mgr.Manager, time.Millisecond))
 	require.NoError(t, synthesis.NewSliceCleanupController(mgr.Manager))
 	require.NoError(t, synthesis.NewPodLifecycleController(mgr.Manager, defaultConf))
 	require.NoError(t, aggregation.NewSliceController(mgr.Manager))
@@ -695,7 +699,8 @@ func TestDisableUpdates(t *testing.T) {
 	downstream := mgr.DownstreamClient
 
 	// Register supporting controllers
-	require.NoError(t, rollout.NewSynthesizerController(mgr.Manager, time.Millisecond))
+	require.NoError(t, rollout.NewSynthesizerController(mgr.Manager))
+	require.NoError(t, rollout.NewController(mgr.Manager, time.Millisecond))
 	require.NoError(t, synthesis.NewPodLifecycleController(mgr.Manager, defaultConf))
 	testutil.WithFakeExecutor(t, mgr, func(ctx context.Context, s *apiv1.Synthesizer, input *krmv1.ResourceList) (*krmv1.ResourceList, error) {
 		output := &krmv1.ResourceList{}
@@ -764,7 +769,8 @@ func TestOrphanedCompositionDeletion(t *testing.T) {
 	upstream := mgr.GetClient()
 
 	// Register supporting controllers
-	require.NoError(t, rollout.NewSynthesizerController(mgr.Manager, time.Millisecond))
+	require.NoError(t, rollout.NewSynthesizerController(mgr.Manager))
+	require.NoError(t, rollout.NewController(mgr.Manager, time.Millisecond))
 	require.NoError(t, synthesis.NewSliceCleanupController(mgr.Manager))
 	require.NoError(t, synthesis.NewPodLifecycleController(mgr.Manager, defaultConf))
 	require.NoError(t, aggregation.NewSliceController(mgr.Manager))

--- a/internal/controllers/reconciliation/crud_test.go
+++ b/internal/controllers/reconciliation/crud_test.go
@@ -217,7 +217,7 @@ func TestCRUD(t *testing.T) {
 			downstream := mgr.DownstreamClient
 
 			// Register supporting controllers
-			require.NoError(t, rollout.NewController(mgr.Manager, time.Millisecond))
+			require.NoError(t, rollout.NewSynthesizerController(mgr.Manager, time.Millisecond))
 			require.NoError(t, synthesis.NewPodLifecycleController(mgr.Manager, defaultConf))
 			testutil.WithFakeExecutor(t, mgr, newSliceBuilder(t, scheme, &test))
 
@@ -385,7 +385,7 @@ func TestReconcileInterval(t *testing.T) {
 	downstream := mgr.DownstreamClient
 
 	// Register supporting controllers
-	require.NoError(t, rollout.NewController(mgr.Manager, time.Millisecond))
+	require.NoError(t, rollout.NewSynthesizerController(mgr.Manager, time.Millisecond))
 	require.NoError(t, synthesis.NewPodLifecycleController(mgr.Manager, defaultConf))
 	testutil.WithFakeExecutor(t, mgr, func(ctx context.Context, s *apiv1.Synthesizer, input *krmv1.ResourceList) (*krmv1.ResourceList, error) {
 		output := &krmv1.ResourceList{}
@@ -455,7 +455,7 @@ func TestReconcileCacheRace(t *testing.T) {
 	downstream := mgr.DownstreamClient
 
 	// Register supporting controllers
-	require.NoError(t, rollout.NewController(mgr.Manager, time.Millisecond))
+	require.NoError(t, rollout.NewSynthesizerController(mgr.Manager, time.Millisecond))
 	require.NoError(t, synthesis.NewPodLifecycleController(mgr.Manager, defaultConf))
 	renderN := 0
 	testutil.WithFakeExecutor(t, mgr, func(ctx context.Context, s *apiv1.Synthesizer, input *krmv1.ResourceList) (*krmv1.ResourceList, error) {
@@ -527,7 +527,7 @@ func TestCompositionDeletionOrdering(t *testing.T) {
 	downstream := mgr.DownstreamClient
 
 	// Register supporting controllers
-	require.NoError(t, rollout.NewController(mgr.Manager, time.Millisecond))
+	require.NoError(t, rollout.NewSynthesizerController(mgr.Manager, time.Millisecond))
 	require.NoError(t, synthesis.NewSliceCleanupController(mgr.Manager))
 	require.NoError(t, synthesis.NewPodLifecycleController(mgr.Manager, defaultConf))
 	require.NoError(t, aggregation.NewSliceController(mgr.Manager))
@@ -695,7 +695,7 @@ func TestDisableUpdates(t *testing.T) {
 	downstream := mgr.DownstreamClient
 
 	// Register supporting controllers
-	require.NoError(t, rollout.NewController(mgr.Manager, time.Millisecond))
+	require.NoError(t, rollout.NewSynthesizerController(mgr.Manager, time.Millisecond))
 	require.NoError(t, synthesis.NewPodLifecycleController(mgr.Manager, defaultConf))
 	testutil.WithFakeExecutor(t, mgr, func(ctx context.Context, s *apiv1.Synthesizer, input *krmv1.ResourceList) (*krmv1.ResourceList, error) {
 		output := &krmv1.ResourceList{}
@@ -764,7 +764,7 @@ func TestOrphanedCompositionDeletion(t *testing.T) {
 	upstream := mgr.GetClient()
 
 	// Register supporting controllers
-	require.NoError(t, rollout.NewController(mgr.Manager, time.Millisecond))
+	require.NoError(t, rollout.NewSynthesizerController(mgr.Manager, time.Millisecond))
 	require.NoError(t, synthesis.NewSliceCleanupController(mgr.Manager))
 	require.NoError(t, synthesis.NewPodLifecycleController(mgr.Manager, defaultConf))
 	require.NoError(t, aggregation.NewSliceController(mgr.Manager))

--- a/internal/controllers/reconciliation/error_test.go
+++ b/internal/controllers/reconciliation/error_test.go
@@ -37,7 +37,7 @@ func TestTerminalError(t *testing.T) {
 	upstream := mgr.GetClient()
 
 	// Register supporting controllers
-	require.NoError(t, rollout.NewController(mgr.Manager, time.Millisecond))
+	require.NoError(t, rollout.NewSynthesizerController(mgr.Manager, time.Millisecond))
 	require.NoError(t, synthesis.NewSliceCleanupController(mgr.Manager))
 	require.NoError(t, synthesis.NewPodLifecycleController(mgr.Manager, defaultConf))
 	require.NoError(t, aggregation.NewSliceController(mgr.Manager))

--- a/internal/controllers/reconciliation/error_test.go
+++ b/internal/controllers/reconciliation/error_test.go
@@ -37,7 +37,8 @@ func TestTerminalError(t *testing.T) {
 	upstream := mgr.GetClient()
 
 	// Register supporting controllers
-	require.NoError(t, rollout.NewSynthesizerController(mgr.Manager, time.Millisecond))
+	require.NoError(t, rollout.NewSynthesizerController(mgr.Manager))
+	require.NoError(t, rollout.NewController(mgr.Manager, time.Millisecond))
 	require.NoError(t, synthesis.NewSliceCleanupController(mgr.Manager))
 	require.NoError(t, synthesis.NewPodLifecycleController(mgr.Manager, defaultConf))
 	require.NoError(t, aggregation.NewSliceController(mgr.Manager))

--- a/internal/controllers/reconciliation/helm_test.go
+++ b/internal/controllers/reconciliation/helm_test.go
@@ -47,7 +47,7 @@ func TestHelmOwnershipTransfer(t *testing.T) {
 	require.NoError(t, os.WriteFile(kubeconfigPath, kc, 0600))
 
 	// Register supporting controllers
-	require.NoError(t, rollout.NewController(mgr.Manager, time.Millisecond))
+	require.NoError(t, rollout.NewSynthesizerController(mgr.Manager, time.Millisecond))
 	require.NoError(t, synthesis.NewPodLifecycleController(mgr.Manager, defaultConf))
 	require.NoError(t, aggregation.NewSliceController(mgr.Manager))
 	require.NoError(t, synthesis.NewSliceCleanupController(mgr.Manager))

--- a/internal/controllers/reconciliation/helm_test.go
+++ b/internal/controllers/reconciliation/helm_test.go
@@ -47,7 +47,8 @@ func TestHelmOwnershipTransfer(t *testing.T) {
 	require.NoError(t, os.WriteFile(kubeconfigPath, kc, 0600))
 
 	// Register supporting controllers
-	require.NoError(t, rollout.NewSynthesizerController(mgr.Manager, time.Millisecond))
+	require.NoError(t, rollout.NewSynthesizerController(mgr.Manager))
+	require.NoError(t, rollout.NewController(mgr.Manager, time.Millisecond))
 	require.NoError(t, synthesis.NewPodLifecycleController(mgr.Manager, defaultConf))
 	require.NoError(t, aggregation.NewSliceController(mgr.Manager))
 	require.NoError(t, synthesis.NewSliceCleanupController(mgr.Manager))

--- a/internal/controllers/reconciliation/ordering_test.go
+++ b/internal/controllers/reconciliation/ordering_test.go
@@ -37,7 +37,7 @@ func TestReadinessGroups(t *testing.T) {
 	upstream := mgr.GetClient()
 
 	// Register supporting controllers
-	require.NoError(t, rollout.NewController(mgr.Manager, time.Millisecond))
+	require.NoError(t, rollout.NewSynthesizerController(mgr.Manager, time.Millisecond))
 	require.NoError(t, aggregation.NewSliceController(mgr.Manager))
 	require.NoError(t, synthesis.NewPodLifecycleController(mgr.Manager, defaultConf))
 	require.NoError(t, synthesis.NewSliceCleanupController(mgr.Manager))
@@ -161,7 +161,7 @@ func TestCRDOrdering(t *testing.T) {
 	upstream := mgr.GetClient()
 
 	// Register supporting controllers
-	require.NoError(t, rollout.NewController(mgr.Manager, time.Millisecond))
+	require.NoError(t, rollout.NewSynthesizerController(mgr.Manager, time.Millisecond))
 	require.NoError(t, aggregation.NewSliceController(mgr.Manager))
 	require.NoError(t, synthesis.NewPodLifecycleController(mgr.Manager, defaultConf))
 	require.NoError(t, synthesis.NewSliceCleanupController(mgr.Manager))

--- a/internal/controllers/reconciliation/ordering_test.go
+++ b/internal/controllers/reconciliation/ordering_test.go
@@ -37,7 +37,8 @@ func TestReadinessGroups(t *testing.T) {
 	upstream := mgr.GetClient()
 
 	// Register supporting controllers
-	require.NoError(t, rollout.NewSynthesizerController(mgr.Manager, time.Millisecond))
+	require.NoError(t, rollout.NewSynthesizerController(mgr.Manager))
+	require.NoError(t, rollout.NewController(mgr.Manager, time.Millisecond))
 	require.NoError(t, aggregation.NewSliceController(mgr.Manager))
 	require.NoError(t, synthesis.NewPodLifecycleController(mgr.Manager, defaultConf))
 	require.NoError(t, synthesis.NewSliceCleanupController(mgr.Manager))
@@ -161,7 +162,8 @@ func TestCRDOrdering(t *testing.T) {
 	upstream := mgr.GetClient()
 
 	// Register supporting controllers
-	require.NoError(t, rollout.NewSynthesizerController(mgr.Manager, time.Millisecond))
+	require.NoError(t, rollout.NewSynthesizerController(mgr.Manager))
+	require.NoError(t, rollout.NewController(mgr.Manager, time.Millisecond))
 	require.NoError(t, aggregation.NewSliceController(mgr.Manager))
 	require.NoError(t, synthesis.NewPodLifecycleController(mgr.Manager, defaultConf))
 	require.NoError(t, synthesis.NewSliceCleanupController(mgr.Manager))

--- a/internal/controllers/reconciliation/patch_test.go
+++ b/internal/controllers/reconciliation/patch_test.go
@@ -32,7 +32,8 @@ func TestPatchCreation(t *testing.T) {
 	downstream := mgr.DownstreamClient
 
 	// Register supporting controllers
-	require.NoError(t, rollout.NewSynthesizerController(mgr.Manager, time.Millisecond))
+	require.NoError(t, rollout.NewSynthesizerController(mgr.Manager))
+	require.NoError(t, rollout.NewController(mgr.Manager, time.Millisecond))
 	require.NoError(t, synthesis.NewPodLifecycleController(mgr.Manager, defaultConf))
 	require.NoError(t, aggregation.NewSliceController(mgr.Manager))
 	testutil.WithFakeExecutor(t, mgr, func(ctx context.Context, s *apiv1.Synthesizer, input *krmv1.ResourceList) (*krmv1.ResourceList, error) {
@@ -95,7 +96,8 @@ func TestPatchDeletion(t *testing.T) {
 	downstream := mgr.DownstreamClient
 
 	// Register supporting controllers
-	require.NoError(t, rollout.NewSynthesizerController(mgr.Manager, time.Millisecond))
+	require.NoError(t, rollout.NewSynthesizerController(mgr.Manager))
+	require.NoError(t, rollout.NewController(mgr.Manager, time.Millisecond))
 	require.NoError(t, synthesis.NewPodLifecycleController(mgr.Manager, defaultConf))
 	require.NoError(t, aggregation.NewSliceController(mgr.Manager))
 	testutil.WithFakeExecutor(t, mgr, func(ctx context.Context, s *apiv1.Synthesizer, input *krmv1.ResourceList) (*krmv1.ResourceList, error) {

--- a/internal/controllers/reconciliation/patch_test.go
+++ b/internal/controllers/reconciliation/patch_test.go
@@ -32,7 +32,7 @@ func TestPatchCreation(t *testing.T) {
 	downstream := mgr.DownstreamClient
 
 	// Register supporting controllers
-	require.NoError(t, rollout.NewController(mgr.Manager, time.Millisecond))
+	require.NoError(t, rollout.NewSynthesizerController(mgr.Manager, time.Millisecond))
 	require.NoError(t, synthesis.NewPodLifecycleController(mgr.Manager, defaultConf))
 	require.NoError(t, aggregation.NewSliceController(mgr.Manager))
 	testutil.WithFakeExecutor(t, mgr, func(ctx context.Context, s *apiv1.Synthesizer, input *krmv1.ResourceList) (*krmv1.ResourceList, error) {
@@ -95,7 +95,7 @@ func TestPatchDeletion(t *testing.T) {
 	downstream := mgr.DownstreamClient
 
 	// Register supporting controllers
-	require.NoError(t, rollout.NewController(mgr.Manager, time.Millisecond))
+	require.NoError(t, rollout.NewSynthesizerController(mgr.Manager, time.Millisecond))
 	require.NoError(t, synthesis.NewPodLifecycleController(mgr.Manager, defaultConf))
 	require.NoError(t, aggregation.NewSliceController(mgr.Manager))
 	testutil.WithFakeExecutor(t, mgr, func(ctx context.Context, s *apiv1.Synthesizer, input *krmv1.ResourceList) (*krmv1.ResourceList, error) {

--- a/internal/controllers/reconciliation/rollout_test.go
+++ b/internal/controllers/reconciliation/rollout_test.go
@@ -31,7 +31,7 @@ func TestBulkRollout(t *testing.T) {
 	upstream := mgr.GetClient()
 
 	// Register supporting controllers
-	require.NoError(t, rollout.NewController(mgr.Manager, time.Millisecond))
+	require.NoError(t, rollout.NewSynthesizerController(mgr.Manager, time.Millisecond))
 	require.NoError(t, aggregation.NewSliceController(mgr.Manager))
 	require.NoError(t, synthesis.NewPodLifecycleController(mgr.Manager, defaultConf))
 	testutil.WithFakeExecutor(t, mgr, func(ctx context.Context, s *apiv1.Synthesizer, input *krmv1.ResourceList) (*krmv1.ResourceList, error) {

--- a/internal/controllers/reconciliation/rollout_test.go
+++ b/internal/controllers/reconciliation/rollout_test.go
@@ -31,7 +31,8 @@ func TestBulkRollout(t *testing.T) {
 	upstream := mgr.GetClient()
 
 	// Register supporting controllers
-	require.NoError(t, rollout.NewSynthesizerController(mgr.Manager, time.Millisecond))
+	require.NoError(t, rollout.NewSynthesizerController(mgr.Manager))
+	require.NoError(t, rollout.NewController(mgr.Manager, time.Millisecond))
 	require.NoError(t, aggregation.NewSliceController(mgr.Manager))
 	require.NoError(t, synthesis.NewPodLifecycleController(mgr.Manager, defaultConf))
 	testutil.WithFakeExecutor(t, mgr, func(ctx context.Context, s *apiv1.Synthesizer, input *krmv1.ResourceList) (*krmv1.ResourceList, error) {

--- a/internal/controllers/reconciliation/status_test.go
+++ b/internal/controllers/reconciliation/status_test.go
@@ -36,7 +36,7 @@ func TestResourceReadiness(t *testing.T) {
 	downstream := mgr.DownstreamClient
 
 	// Register supporting controllers
-	require.NoError(t, rollout.NewController(mgr.Manager, time.Millisecond))
+	require.NoError(t, rollout.NewSynthesizerController(mgr.Manager, time.Millisecond))
 	require.NoError(t, synthesis.NewPodLifecycleController(mgr.Manager, defaultConf))
 	require.NoError(t, aggregation.NewSliceController(mgr.Manager))
 	testutil.WithFakeExecutor(t, mgr, func(ctx context.Context, s *apiv1.Synthesizer, input *krmv1.ResourceList) (*krmv1.ResourceList, error) {

--- a/internal/controllers/reconciliation/status_test.go
+++ b/internal/controllers/reconciliation/status_test.go
@@ -36,7 +36,8 @@ func TestResourceReadiness(t *testing.T) {
 	downstream := mgr.DownstreamClient
 
 	// Register supporting controllers
-	require.NoError(t, rollout.NewSynthesizerController(mgr.Manager, time.Millisecond))
+	require.NoError(t, rollout.NewSynthesizerController(mgr.Manager))
+	require.NoError(t, rollout.NewController(mgr.Manager, time.Millisecond))
 	require.NoError(t, synthesis.NewPodLifecycleController(mgr.Manager, defaultConf))
 	require.NoError(t, aggregation.NewSliceController(mgr.Manager))
 	testutil.WithFakeExecutor(t, mgr, func(ctx context.Context, s *apiv1.Synthesizer, input *krmv1.ResourceList) (*krmv1.ResourceList, error) {

--- a/internal/controllers/reconciliation/symphony_test.go
+++ b/internal/controllers/reconciliation/symphony_test.go
@@ -38,7 +38,8 @@ func TestSymphonyIntegration(t *testing.T) {
 	require.NoError(t, upstream.Create(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "test"}}))
 
 	// Register supporting controllers
-	require.NoError(t, rollout.NewSynthesizerController(mgr.Manager, time.Millisecond))
+	require.NoError(t, rollout.NewSynthesizerController(mgr.Manager))
+	require.NoError(t, rollout.NewController(mgr.Manager, time.Millisecond))
 	require.NoError(t, synthesis.NewPodLifecycleController(mgr.Manager, defaultConf))
 	require.NoError(t, replication.NewSymphonyController(mgr.Manager))
 	require.NoError(t, aggregation.NewSymphonyController(mgr.Manager))

--- a/internal/controllers/reconciliation/symphony_test.go
+++ b/internal/controllers/reconciliation/symphony_test.go
@@ -38,7 +38,7 @@ func TestSymphonyIntegration(t *testing.T) {
 	require.NoError(t, upstream.Create(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "test"}}))
 
 	// Register supporting controllers
-	require.NoError(t, rollout.NewController(mgr.Manager, time.Millisecond))
+	require.NoError(t, rollout.NewSynthesizerController(mgr.Manager, time.Millisecond))
 	require.NoError(t, synthesis.NewPodLifecycleController(mgr.Manager, defaultConf))
 	require.NoError(t, replication.NewSymphonyController(mgr.Manager))
 	require.NoError(t, aggregation.NewSymphonyController(mgr.Manager))

--- a/internal/controllers/rollout/controller.go
+++ b/internal/controllers/rollout/controller.go
@@ -1,0 +1,102 @@
+package rollout
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"time"
+
+	"github.com/go-logr/logr"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	apiv1 "github.com/Azure/eno/api/v1"
+	"github.com/Azure/eno/internal/controllers/synthesis"
+	"github.com/Azure/eno/internal/manager"
+)
+
+type controller struct {
+	client   client.Client
+	cooldown time.Duration
+}
+
+func NewController(mgr ctrl.Manager, cooldown time.Duration) error {
+	c := &controller{
+		client:   mgr.GetClient(),
+		cooldown: cooldown,
+	}
+	return ctrl.NewControllerManagedBy(mgr).
+		Named("rolloutController").
+		Watches(&apiv1.Composition{}, manager.SingleEventHandler()).
+		WithLogConstructor(manager.NewLogConstructor(mgr, "rolloutController")).
+		Complete(c)
+}
+
+func (c *controller) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	logger := logr.FromContextOrDiscard(ctx)
+
+	comps := &apiv1.CompositionList{}
+	err := c.client.List(ctx, comps)
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("listing compositions: %w", err)
+	}
+
+	// Find the current cooldown period, wait for the next if needed
+	// Block on any active deferred syntheses with less than 2 attempts to avoid high concurrency
+	var lastDeferredSynthesisCompletion *metav1.Time
+	for _, comp := range comps.Items {
+		current := comp.Status.CurrentSynthesis
+		if current == nil || !current.Deferred {
+			continue
+		}
+		if current.Synthesized == nil && current.Attempts < 2 {
+			return ctrl.Result{RequeueAfter: c.cooldown}, nil
+		}
+		if lastDeferredSynthesisCompletion == nil || lastDeferredSynthesisCompletion.Before(current.Synthesized) {
+			lastDeferredSynthesisCompletion = current.Synthesized
+		}
+	}
+	if lastDeferredSynthesisCompletion != nil {
+		delta := c.cooldown - time.Since(lastDeferredSynthesisCompletion.Time)
+		if delta > 0 {
+			return ctrl.Result{RequeueAfter: delta}, nil
+		}
+	}
+
+	// Sort for FIFO
+	sort.Slice(comps.Items, func(i, j int) bool {
+		return ptr.Deref(comps.Items[j].Status.PendingResynthesis, metav1.Time{}).After(ptr.Deref(comps.Items[i].Status.PendingResynthesis, metav1.Time{}).Time)
+	})
+
+	for _, comp := range comps.Items {
+		logger = logger.WithValues("compositionName", comp.Name, "compositionNamespace", comp.Namespace, "compositionGeneration", comp.Generation)
+		if comp.Status.PendingResynthesis == nil || comp.Status.CurrentSynthesis == nil {
+			continue
+		}
+
+		// Guarantee that we don't violate the cooldown period in the case of stale informers
+		if comp.Status.CurrentSynthesis.Deferred {
+			delta := c.cooldown - time.Since(comp.Status.PendingResynthesis.Time)
+			if delta > 0 {
+				return ctrl.Result{RequeueAfter: delta}, nil
+			}
+		}
+
+		pendingTime := comp.Status.PendingResynthesis
+		synthesis.SwapStates(&comp)
+		comp.Status.CurrentSynthesis.Deferred = true
+		comp.Status.PendingResynthesis = nil
+		err = c.client.Status().Update(ctx, &comp)
+		if err != nil {
+			return ctrl.Result{}, fmt.Errorf("initiating resynthesis: %w", err)
+		}
+
+		logger.Info("progressing deferred resynthesis", "latency", time.Since(pendingTime.Time).Milliseconds())
+		return ctrl.Result{RequeueAfter: c.cooldown}, nil
+	}
+
+	// drop the work item until a composition changes
+	return ctrl.Result{}, nil
+}

--- a/internal/controllers/rollout/controller_test.go
+++ b/internal/controllers/rollout/controller_test.go
@@ -1,0 +1,255 @@
+package rollout
+
+import (
+	"testing"
+	"time"
+
+	apiv1 "github.com/Azure/eno/api/v1"
+	"github.com/Azure/eno/internal/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+func TestController(t *testing.T) {
+	cooldown := time.Second
+
+	tests := []struct {
+		Name              string
+		ExpectedSyntheses []string
+		ShouldRequeue     bool
+		Inputs            []*apiv1.Composition
+	}{
+		{
+			Name:              "one resource, ready for rollout",
+			ExpectedSyntheses: []string{"test"},
+			ShouldRequeue:     true,
+			Inputs: []*apiv1.Composition{{
+				ObjectMeta: metav1.ObjectMeta{Name: "test"},
+				Status: apiv1.CompositionStatus{
+					PendingResynthesis: inThePast(4),
+					CurrentSynthesis: &apiv1.Synthesis{
+						Deferred:    true,
+						Synthesized: inThePast(8),
+					},
+				},
+			}},
+		},
+		{
+			Name:          "one resource, existing deferred synthesis within cooldown period",
+			ShouldRequeue: true,
+			Inputs: []*apiv1.Composition{{
+				ObjectMeta: metav1.ObjectMeta{Name: "test"},
+				Status: apiv1.CompositionStatus{
+					PendingResynthesis: inThePast(4),
+					CurrentSynthesis: &apiv1.Synthesis{
+						Deferred:    true,
+						Synthesized: inThePast(0),
+					},
+				},
+			}},
+		},
+		{
+			Name:              "one resource with existing deferred synthesis within cooldown period, another with an active non-rollout synthesis",
+			ExpectedSyntheses: []string{"test-1"},
+			ShouldRequeue:     true,
+			Inputs: []*apiv1.Composition{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "test-1"},
+					Status: apiv1.CompositionStatus{
+						PendingResynthesis: inThePast(4),
+						CurrentSynthesis: &apiv1.Synthesis{
+							Deferred:    true,
+							Synthesized: inThePast(8),
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "test-2"},
+					Status: apiv1.CompositionStatus{
+						CurrentSynthesis: &apiv1.Synthesis{},
+					},
+				},
+			},
+		},
+		{
+			Name:          "one resource with existing deferred synthesis within cooldown period, another with an active rollout synthesis",
+			ShouldRequeue: true,
+			Inputs: []*apiv1.Composition{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "test-1"},
+					Status: apiv1.CompositionStatus{
+						PendingResynthesis: inThePast(4),
+						CurrentSynthesis: &apiv1.Synthesis{
+							Deferred:    true,
+							Synthesized: inThePast(8),
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "test-2"},
+					Status: apiv1.CompositionStatus{
+						CurrentSynthesis: &apiv1.Synthesis{
+							Deferred: true,
+						},
+					},
+				},
+			},
+		},
+		{
+			Name:              "one resource, existing non-deferred synthesis within cooldown period",
+			ExpectedSyntheses: []string{"test"},
+			ShouldRequeue:     true,
+			Inputs: []*apiv1.Composition{{
+				ObjectMeta: metav1.ObjectMeta{Name: "test"},
+				Status: apiv1.CompositionStatus{
+					PendingResynthesis: inThePast(4),
+					CurrentSynthesis: &apiv1.Synthesis{
+						Synthesized: inThePast(0),
+					},
+				},
+			}},
+		},
+		{
+			Name:          "one resource, not ready for rollout",
+			ShouldRequeue: true,
+			Inputs: []*apiv1.Composition{{
+				ObjectMeta: metav1.ObjectMeta{Name: "test"},
+				Status: apiv1.CompositionStatus{
+					PendingResynthesis: inThePast(0),
+					CurrentSynthesis: &apiv1.Synthesis{
+						Deferred:    true,
+						Synthesized: inThePast(8),
+					},
+				},
+			}},
+		},
+		{
+			Name: "no syntheses",
+			Inputs: []*apiv1.Composition{{
+				ObjectMeta: metav1.ObjectMeta{Name: "test"},
+				Status:     apiv1.CompositionStatus{},
+			}},
+		},
+		{
+			Name: "one resource, pending but never synthesized",
+			Inputs: []*apiv1.Composition{{
+				ObjectMeta: metav1.ObjectMeta{Name: "test"},
+				Status: apiv1.CompositionStatus{
+					PendingResynthesis: inThePast(4),
+				},
+			}},
+		},
+		{
+			Name:          "one resource, actively synthesizing rollout",
+			ShouldRequeue: true,
+			Inputs: []*apiv1.Composition{{
+				ObjectMeta: metav1.ObjectMeta{Name: "test"},
+				Status: apiv1.CompositionStatus{
+					PendingResynthesis: inThePast(4),
+					CurrentSynthesis: &apiv1.Synthesis{
+						Deferred:    true,
+						Synthesized: nil,
+					},
+				},
+			}},
+		},
+		{
+			Name:              "one resource, actively synthesizing (not rollout)",
+			ExpectedSyntheses: []string{"test"},
+			ShouldRequeue:     true,
+			Inputs: []*apiv1.Composition{{
+				ObjectMeta: metav1.ObjectMeta{Name: "test"},
+				Status: apiv1.CompositionStatus{
+					PendingResynthesis: inThePast(4),
+					CurrentSynthesis: &apiv1.Synthesis{
+						Synthesized: nil,
+					},
+				},
+			}},
+		},
+		{
+			Name:              "one resource, actively synthesizing with 2 attempts",
+			ExpectedSyntheses: []string{"test"},
+			ShouldRequeue:     true,
+			Inputs: []*apiv1.Composition{{
+				ObjectMeta: metav1.ObjectMeta{Name: "test"},
+				Status: apiv1.CompositionStatus{
+					PendingResynthesis: inThePast(4),
+					CurrentSynthesis: &apiv1.Synthesis{
+						Attempts:    2,
+						Synthesized: nil,
+					},
+				},
+			}},
+		},
+		{
+			Name:              "fifo semantics",
+			ExpectedSyntheses: []string{"test-2"},
+			ShouldRequeue:     true,
+			Inputs: []*apiv1.Composition{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "test-1"},
+					Status: apiv1.CompositionStatus{
+						PendingResynthesis: inThePast(4),
+						CurrentSynthesis: &apiv1.Synthesis{
+							Synthesized: inThePast(8),
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "test-2"},
+					Status: apiv1.CompositionStatus{
+						PendingResynthesis: inThePast(5),
+						CurrentSynthesis: &apiv1.Synthesis{
+							Synthesized: inThePast(8),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	ctx := testutil.NewContext(t)
+	for _, tc := range tests {
+		t.Run(tc.Name, func(t *testing.T) {
+			cli := testutil.NewClient(t)
+			for _, comp := range tc.Inputs {
+				err := cli.Create(ctx, comp)
+				require.NoError(t, err)
+
+				// set a fake value so we can prove if the controller swapped states later
+				if comp.Status.CurrentSynthesis != nil {
+					comp.Status.CurrentSynthesis.UUID = "foo"
+				}
+
+				err = cli.Status().Update(ctx, comp)
+				require.NoError(t, err)
+			}
+
+			c := &controller{client: cli, cooldown: cooldown}
+			resp, err := c.Reconcile(ctx, ctrl.Request{})
+			require.NoError(t, err)
+			assert.Equal(t, tc.ShouldRequeue, resp.RequeueAfter != 0 || resp.Requeue)
+
+			list := &apiv1.CompositionList{}
+			err = cli.List(ctx, list)
+			require.NoError(t, err)
+
+			var names []string
+			for _, c := range list.Items {
+				if c.Status.CurrentSynthesis != nil && c.Status.CurrentSynthesis.UUID != "foo" {
+					names = append(names, c.Name)
+					break
+				}
+			}
+			assert.Equal(t, tc.ExpectedSyntheses, names)
+		})
+	}
+}
+
+func inThePast(seconds int) *metav1.Time {
+	return ptr.To(metav1.Time{Time: time.Now().Add(-time.Duration(seconds) * time.Second)})
+}

--- a/internal/controllers/rollout/integration_test.go
+++ b/internal/controllers/rollout/integration_test.go
@@ -28,7 +28,8 @@ func TestSynthesizerRollout(t *testing.T) {
 	mgr := testutil.NewManager(t)
 	cli := mgr.GetClient()
 
-	require.NoError(t, NewSynthesizerController(mgr.Manager, time.Millisecond*10))
+	require.NoError(t, NewSynthesizerController(mgr.Manager))
+	require.NoError(t, NewController(mgr.Manager, time.Millisecond*10))
 	require.NoError(t, synthesis.NewPodLifecycleController(mgr.Manager, testSynthesisConfig))
 	testutil.WithFakeExecutor(t, mgr, func(ctx context.Context, s *apiv1.Synthesizer, input *krmv1.ResourceList) (*krmv1.ResourceList, error) {
 		output := &krmv1.ResourceList{}
@@ -78,7 +79,8 @@ func TestSynthesizerRolloutCooldown(t *testing.T) {
 	mgr := testutil.NewManager(t)
 	cli := mgr.GetClient()
 
-	require.NoError(t, NewSynthesizerController(mgr.Manager, time.Hour))
+	require.NoError(t, NewSynthesizerController(mgr.Manager))
+	require.NoError(t, NewController(mgr.Manager, time.Hour))
 	require.NoError(t, synthesis.NewPodLifecycleController(mgr.Manager, testSynthesisConfig))
 	testutil.WithFakeExecutor(t, mgr, func(ctx context.Context, s *apiv1.Synthesizer, input *krmv1.ResourceList) (*krmv1.ResourceList, error) {
 		output := &krmv1.ResourceList{}
@@ -142,7 +144,8 @@ func TestSynthesizerRolloutDeleted(t *testing.T) {
 	mgr := testutil.NewManager(t)
 	cli := mgr.GetClient()
 
-	require.NoError(t, NewSynthesizerController(mgr.Manager, time.Millisecond*10))
+	require.NoError(t, NewSynthesizerController(mgr.Manager))
+	require.NoError(t, NewController(mgr.Manager, time.Millisecond*10))
 	require.NoError(t, synthesis.NewPodLifecycleController(mgr.Manager, testSynthesisConfig))
 	testutil.WithFakeExecutor(t, mgr, func(ctx context.Context, s *apiv1.Synthesizer, input *krmv1.ResourceList) (*krmv1.ResourceList, error) {
 		output := &krmv1.ResourceList{}

--- a/internal/controllers/rollout/synthesizer.go
+++ b/internal/controllers/rollout/synthesizer.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"math/rand"
-	"time"
 
 	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/api/equality"
@@ -23,15 +22,12 @@ import (
 )
 
 type synthController struct {
-	client   client.Client
-	cooldown time.Duration
+	client client.Client
 }
 
-// NewSynthesizerController re-synthesizes compositions when their synthesizer has changed while honoring a cooldown period.
-func NewSynthesizerController(mgr ctrl.Manager, cooldown time.Duration) error {
+func NewSynthesizerController(mgr ctrl.Manager) error {
 	c := &synthController{
-		client:   mgr.GetClient(),
-		cooldown: cooldown,
+		client: mgr.GetClient(),
 	}
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&apiv1.Synthesizer{}).

--- a/internal/controllers/rollout/synthesizer.go
+++ b/internal/controllers/rollout/synthesizer.go
@@ -22,14 +22,14 @@ import (
 	"github.com/Azure/eno/internal/manager"
 )
 
-type controller struct {
+type synthController struct {
 	client   client.Client
 	cooldown time.Duration
 }
 
-// NewController re-synthesizes compositions when their synthesizer has changed while honoring a cooldown period.
-func NewController(mgr ctrl.Manager, cooldown time.Duration) error {
-	c := &controller{
+// NewSynthesizerController re-synthesizes compositions when their synthesizer has changed while honoring a cooldown period.
+func NewSynthesizerController(mgr ctrl.Manager, cooldown time.Duration) error {
+	c := &synthController{
 		client:   mgr.GetClient(),
 		cooldown: cooldown,
 	}
@@ -40,7 +40,7 @@ func NewController(mgr ctrl.Manager, cooldown time.Duration) error {
 		Complete(c)
 }
 
-func (c *controller) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+func (c *synthController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	logger := logr.FromContextOrDiscard(ctx)
 
 	syn := &apiv1.Synthesizer{}

--- a/internal/controllers/rollout/synthesizer.go
+++ b/internal/controllers/rollout/synthesizer.go
@@ -63,6 +63,7 @@ func (c *synthController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 
 		// Compositions aren't eligible to receive an updated synthesizer when:
 		// - They haven't ever been synthesized (they'll use the latest inputs anyway)
+		// - They are already on the latest version of the synthesizer
 		// - They are currently being synthesized or deleted
 		// - They are already pending resynthesis
 		// - They are already in sync with the latest inputs

--- a/internal/controllers/rollout/synthesizer_test.go
+++ b/internal/controllers/rollout/synthesizer_test.go
@@ -28,7 +28,7 @@ func TestSynthesizerRollout(t *testing.T) {
 	mgr := testutil.NewManager(t)
 	cli := mgr.GetClient()
 
-	require.NoError(t, NewController(mgr.Manager, time.Millisecond*10))
+	require.NoError(t, NewSynthesizerController(mgr.Manager, time.Millisecond*10))
 	require.NoError(t, synthesis.NewPodLifecycleController(mgr.Manager, testSynthesisConfig))
 	testutil.WithFakeExecutor(t, mgr, func(ctx context.Context, s *apiv1.Synthesizer, input *krmv1.ResourceList) (*krmv1.ResourceList, error) {
 		output := &krmv1.ResourceList{}
@@ -78,7 +78,7 @@ func TestSynthesizerRolloutCooldown(t *testing.T) {
 	mgr := testutil.NewManager(t)
 	cli := mgr.GetClient()
 
-	require.NoError(t, NewController(mgr.Manager, time.Hour))
+	require.NoError(t, NewSynthesizerController(mgr.Manager, time.Hour))
 	require.NoError(t, synthesis.NewPodLifecycleController(mgr.Manager, testSynthesisConfig))
 	testutil.WithFakeExecutor(t, mgr, func(ctx context.Context, s *apiv1.Synthesizer, input *krmv1.ResourceList) (*krmv1.ResourceList, error) {
 		output := &krmv1.ResourceList{}
@@ -142,7 +142,7 @@ func TestSynthesizerRolloutDeleted(t *testing.T) {
 	mgr := testutil.NewManager(t)
 	cli := mgr.GetClient()
 
-	require.NoError(t, NewController(mgr.Manager, time.Millisecond*10))
+	require.NoError(t, NewSynthesizerController(mgr.Manager, time.Millisecond*10))
 	require.NoError(t, synthesis.NewPodLifecycleController(mgr.Manager, testSynthesisConfig))
 	testutil.WithFakeExecutor(t, mgr, func(ctx context.Context, s *apiv1.Synthesizer, input *krmv1.ResourceList) (*krmv1.ResourceList, error) {
 		output := &krmv1.ResourceList{}

--- a/internal/execution/executor.go
+++ b/internal/execution/executor.go
@@ -191,6 +191,7 @@ func (e *Executor) updateComposition(ctx context.Context, oldComp *apiv1.Composi
 		}
 
 		now := metav1.Now()
+		comp.Status.PendingResynthesis = nil
 		comp.Status.CurrentSynthesis.Synthesized = &now
 		comp.Status.CurrentSynthesis.ResourceSlices = refs
 		comp.Status.CurrentSynthesis.ObservedSynthesizerGeneration = syn.Generation

--- a/internal/execution/executor.go
+++ b/internal/execution/executor.go
@@ -191,7 +191,6 @@ func (e *Executor) updateComposition(ctx context.Context, oldComp *apiv1.Composi
 		}
 
 		now := metav1.Now()
-		comp.Status.PendingResynthesis = nil
 		comp.Status.CurrentSynthesis.Synthesized = &now
 		comp.Status.CurrentSynthesis.ResourceSlices = refs
 		comp.Status.CurrentSynthesis.ObservedSynthesizerGeneration = syn.Generation


### PR DESCRIPTION
Replaces the existing rollout controller with a new implementation that implements slightly nicer semantics (see reference docs for details).