### PR TITLE
Add key annotation to inputs

### DIFF
--- a/internal/execution/executor.go
+++ b/internal/execution/executor.go
@@ -94,6 +94,12 @@ func (e *Executor) buildPodInput(ctx context.Context, comp *apiv1.Composition, s
 		if err != nil {
 			return nil, nil, fmt.Errorf("getting resource for ref %q: %w", key, err)
 		}
+		anno := obj.GetAnnotations()
+		if anno == nil {
+			anno = map[string]string{}
+		}
+		anno["eno.azure.io/input-key"] = key
+		obj.SetAnnotations(anno)
 		rl.Items = append(rl.Items, obj)
 		logger.V(0).Info("retrieved input", "key", key, "latency", time.Since(start).Milliseconds())
 

--- a/internal/execution/executor_test.go
+++ b/internal/execution/executor_test.go
@@ -154,6 +154,7 @@ func TestWithInputs(t *testing.T) {
 			require.Len(t, rl.Items, 1)
 			assert.Equal(t, "ConfigMap", rl.Items[0].GetKind())
 			assert.Equal(t, "test-input", rl.Items[0].GetName())
+			assert.Equal(t, map[string]string{"eno.azure.io/input-key": "foo"}, rl.Items[0].GetAnnotations())
 
 			out := &unstructured.Unstructured{
 				Object: map[string]any{


### PR DESCRIPTION
Help synthesizers correlate a given input back to the corresponding ref/binding key.