### PR TITLE
Misc. resilience improvements

### DIFF
--- a/api/v1/config/crd/eno.azure.io_compositions.yaml
+++ b/api/v1/config/crd/eno.azure.io_compositions.yaml
@@ -107,8 +107,8 @@ spec:
                     type: integer
                   deferred:
                     description: |-
-                      Deferred is true when this synthesis was the result of a deferred rollout,
-                      caused by a synthesizer of (deferred) input change.
+                      Deferred is true when this synthesis was caused by a change to either the synthesizer
+                      or an input with a ref that sets `Defer == true`.
                     type: boolean
                   inputRevisions:
                     description: InputRevisions contains the versions of the input
@@ -200,8 +200,8 @@ spec:
                     type: integer
                   deferred:
                     description: |-
-                      Deferred is true when this synthesis was the result of a deferred rollout,
-                      caused by a synthesizer of (deferred) input change.
+                      Deferred is true when this synthesis was caused by a change to either the synthesizer
+                      or an input with a ref that sets `Defer == true`.
                     type: boolean
                   inputRevisions:
                     description: InputRevisions contains the versions of the input

--- a/api/v1/config/crd/eno.azure.io_resourceslices.yaml
+++ b/api/v1/config/crd/eno.azure.io_resourceslices.yaml
@@ -37,6 +37,8 @@ spec:
             type: object
           spec:
             properties:
+              attempt:
+                type: integer
               compositionGeneration:
                 format: int64
                 type: integer

--- a/api/v1/resourceslice.go
+++ b/api/v1/resourceslice.go
@@ -22,6 +22,7 @@ type ResourceSlice struct {
 type ResourceSliceSpec struct {
 	CompositionGeneration int64      `json:"compositionGeneration,omitempty"`
 	SynthesisUUID         string     `json:"synthesisUUID,omitempty"`
+	Attempt               int        `json:"attempt,omitempty"`
 	Resources             []Manifest `json:"resources,omitempty"`
 }
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -301,7 +301,7 @@ _Appears in:_
 | `attempts` _integer_ | Counter used internally to calculate back off when retrying failed syntheses. |  |  |
 | `results` _[Result](#result) array_ | Results are passed through opaquely from the synthesizer's KRM function. |  |  |
 | `inputRevisions` _[InputRevisions](#inputrevisions) array_ | InputRevisions contains the versions of the input resources that were used for this synthesis. |  |  |
-| `deferred` _boolean_ | Deferred is true when this synthesis was the result of a deferred rollout,<br />caused by a synthesizer of (deferred) input change. |  |  |
+| `deferred` _boolean_ | Deferred is true when this synthesis was caused by a change to either the synthesizer<br />or an input with a ref that sets `Defer == true`. |  |  |
 
 
 #### Synthesizer

--- a/internal/controllers/aggregation/composition.go
+++ b/internal/controllers/aggregation/composition.go
@@ -66,6 +66,11 @@ func (c *compositionController) aggregate(comp *apiv1.Composition) *apiv1.Simpli
 		return copy
 	}
 
+	if comp.Status.CurrentSynthesis.UUID == "" {
+		copy.Status = "WaitingForDispatch"
+		return copy
+	}
+
 	for _, result := range comp.Status.CurrentSynthesis.Results {
 		if result.Severity == krmv1.ResultSeverityError {
 			copy.Error = result.Message

--- a/internal/controllers/aggregation/composition.go
+++ b/internal/controllers/aggregation/composition.go
@@ -40,8 +40,9 @@ func (c *compositionController) Reconcile(ctx context.Context, req ctrl.Request)
 	if equality.Semantic.DeepEqual(next, comp.Status.Simplified) {
 		return ctrl.Result{}, nil
 	}
-	comp.Status.Simplified = next
-	if err := c.client.Status().Update(ctx, comp); err != nil {
+	copy := comp.DeepCopy()
+	copy.Status.Simplified = next
+	if err := c.client.Status().Patch(ctx, copy, client.MergeFrom(comp)); err != nil {
 		return ctrl.Result{}, fmt.Errorf("updating status: %w", err)
 	}
 

--- a/internal/controllers/aggregation/composition_test.go
+++ b/internal/controllers/aggregation/composition_test.go
@@ -24,23 +24,29 @@ func TestCompositionSimplification(t *testing.T) {
 		{
 			Input: apiv1.CompositionStatus{CurrentSynthesis: &apiv1.Synthesis{}},
 			Expected: apiv1.SimplifiedStatus{
+				Status: "WaitingForDispatch",
+			},
+		},
+		{
+			Input: apiv1.CompositionStatus{CurrentSynthesis: &apiv1.Synthesis{UUID: "uuid"}},
+			Expected: apiv1.SimplifiedStatus{
 				Status: "Synthesizing",
 			},
 		},
 		{
-			Input: apiv1.CompositionStatus{CurrentSynthesis: &apiv1.Synthesis{Synthesized: ptr.To(metav1.Now())}},
+			Input: apiv1.CompositionStatus{CurrentSynthesis: &apiv1.Synthesis{UUID: "uuid", Synthesized: ptr.To(metav1.Now())}},
 			Expected: apiv1.SimplifiedStatus{
 				Status: "Reconciling",
 			},
 		},
 		{
-			Input: apiv1.CompositionStatus{CurrentSynthesis: &apiv1.Synthesis{Reconciled: ptr.To(metav1.Now())}},
+			Input: apiv1.CompositionStatus{CurrentSynthesis: &apiv1.Synthesis{UUID: "uuid", Reconciled: ptr.To(metav1.Now())}},
 			Expected: apiv1.SimplifiedStatus{
 				Status: "NotReady",
 			},
 		},
 		{
-			Input: apiv1.CompositionStatus{CurrentSynthesis: &apiv1.Synthesis{Ready: ptr.To(metav1.Now())}},
+			Input: apiv1.CompositionStatus{CurrentSynthesis: &apiv1.Synthesis{UUID: "uuid", Ready: ptr.To(metav1.Now())}},
 			Expected: apiv1.SimplifiedStatus{
 				Status: "Ready",
 			},
@@ -54,6 +60,7 @@ func TestCompositionSimplification(t *testing.T) {
 		{
 			Input: apiv1.CompositionStatus{
 				CurrentSynthesis: &apiv1.Synthesis{
+					UUID:    "uuid",
 					Ready:   ptr.To(metav1.Now()),
 					Results: []apiv1.Result{{Message: "foo", Severity: "error"}},
 				}},
@@ -66,6 +73,7 @@ func TestCompositionSimplification(t *testing.T) {
 			Input: apiv1.CompositionStatus{
 				PendingResynthesis: ptr.To(metav1.Now()),
 				CurrentSynthesis: &apiv1.Synthesis{
+					UUID:  "uuid",
 					Ready: ptr.To(metav1.Now()),
 				}},
 			Expected: apiv1.SimplifiedStatus{

--- a/internal/controllers/flowcontrol/metrics.go
+++ b/internal/controllers/flowcontrol/metrics.go
@@ -1,0 +1,26 @@
+package flowcontrol
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+var (
+	pendingSyntheses = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Name: "eno_pending_syntheses_total",
+			Help: "Count of the syntheses that are being deferred by a flow control mechanism",
+		},
+	)
+	activeSyntheses = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Name: "eno_active_syntheses_total",
+			Help: "Count of the syntheses that are being synthesized",
+		},
+	)
+)
+
+func init() {
+	metrics.Registry.MustRegister(pendingSyntheses)
+	metrics.Registry.MustRegister(activeSyntheses)
+}

--- a/internal/controllers/flowcontrol/synthesis.go
+++ b/internal/controllers/flowcontrol/synthesis.go
@@ -1,0 +1,81 @@
+package flowcontrol
+
+import (
+	"context"
+	"fmt"
+
+	apiv1 "github.com/Azure/eno/api/v1"
+	"github.com/Azure/eno/internal/manager"
+	"github.com/go-logr/logr"
+	"github.com/google/uuid"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type synthesisConcurrencyLimiter struct {
+	client client.Client
+	limit  int
+}
+
+func NewSynthesisConcurrencyLimiter(mgr ctrl.Manager, limit int) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		Named("synthesisConcurrencyLimiter").
+		Watches(&apiv1.Composition{}, manager.SingleEventHandler()).
+		WithLogConstructor(manager.NewLogConstructor(mgr, "synthesisConcurrencyLimiter")).
+		Complete(&synthesisConcurrencyLimiter{
+			client: mgr.GetClient(),
+			limit:  limit,
+		})
+}
+
+func (c *synthesisConcurrencyLimiter) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	logger := logr.FromContextOrDiscard(ctx)
+
+	list := &apiv1.CompositionList{}
+	err := c.client.List(ctx, list)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	var active int
+	var pending int
+	var next *apiv1.Composition
+	for _, comp := range list.Items {
+		comp := comp
+		current := comp.Status.CurrentSynthesis
+		if current != nil && current.Synthesized != nil {
+			continue // already synthesized
+		}
+		if current == nil || current.UUID == "" {
+			pending++
+			next = &comp
+		} else {
+			active++
+		}
+	}
+	activeSyntheses.Add(float64(active))
+	pendingSyntheses.Add(float64(pending))
+
+	if active >= c.limit {
+		logger.V(1).Info("refusing to dispatch synthesis because concurrency limit has been reached", "active", active, "pending", pending)
+		return ctrl.Result{}, nil
+	}
+
+	if next == nil {
+		return ctrl.Result{}, nil // nothing to dispatch
+	}
+	logger = logger.WithValues("compositionName", next.Name, "compositionNamespace", next.Namespace, "compositionGeneration", next.Generation)
+
+	// Dispatch the next pending synthesis
+	if next.Status.CurrentSynthesis == nil {
+		next.Status.CurrentSynthesis = &apiv1.Synthesis{}
+	}
+	next.Status.CurrentSynthesis.UUID = uuid.NewString()
+
+	if err := c.client.Status().Update(ctx, next); err != nil {
+		return ctrl.Result{}, fmt.Errorf("writing uuid to composition status: %w", err)
+	}
+	logger.V(1).Info("dispatched synthesis")
+
+	return ctrl.Result{}, nil
+}

--- a/internal/controllers/flowcontrol/synthesis_test.go
+++ b/internal/controllers/flowcontrol/synthesis_test.go
@@ -1,0 +1,67 @@
+package flowcontrol
+
+import (
+	"testing"
+
+	apiv1 "github.com/Azure/eno/api/v1"
+	"github.com/Azure/eno/internal/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func TestSynthesisConcurrencyLimitUnder(t *testing.T) {
+	cli := testutil.NewClient(t)
+	ctx := testutil.NewContext(t)
+	c := &synthesisConcurrencyLimiter{}
+	c.client = cli
+	c.limit = 1
+
+	comp := &apiv1.Composition{}
+	comp.Name = "test-comp"
+	require.NoError(t, cli.Create(ctx, comp))
+
+	_, err := c.Reconcile(ctx, ctrl.Request{})
+	require.NoError(t, err)
+
+	err = cli.Get(ctx, client.ObjectKeyFromObject(comp), comp)
+	require.NoError(t, err)
+	assert.NotEmpty(t, comp.Status.CurrentSynthesis.UUID)
+}
+
+func TestSynthesisConcurrencyLimitOver(t *testing.T) {
+	cli := testutil.NewClient(t)
+	ctx := testutil.NewContext(t)
+	c := &synthesisConcurrencyLimiter{}
+	c.client = cli
+	c.limit = 1
+
+	comp := &apiv1.Composition{}
+	comp.Name = "test-comp"
+	require.NoError(t, cli.Create(ctx, comp))
+
+	comp2 := &apiv1.Composition{}
+	comp2.Name = "test-comp-2"
+	require.NoError(t, cli.Create(ctx, comp2))
+
+	for i := 0; i < 3; i++ {
+		_, err := c.Reconcile(ctx, ctrl.Request{})
+		require.NoError(t, err)
+	}
+
+	var active int
+	err := cli.Get(ctx, client.ObjectKeyFromObject(comp), comp)
+	require.NoError(t, err)
+	if comp.Status.CurrentSynthesis != nil && comp.Status.CurrentSynthesis.UUID != "" {
+		active++
+	}
+
+	err = cli.Get(ctx, client.ObjectKeyFromObject(comp2), comp2)
+	require.NoError(t, err)
+	if comp2.Status.CurrentSynthesis != nil && comp2.Status.CurrentSynthesis.UUID != "" {
+		active++
+	}
+
+	assert.Equal(t, 1, active) // only one was dispatched
+}

--- a/internal/controllers/reconciliation/crud_test.go
+++ b/internal/controllers/reconciliation/crud_test.go
@@ -22,6 +22,7 @@ import (
 
 	apiv1 "github.com/Azure/eno/api/v1"
 	"github.com/Azure/eno/internal/controllers/aggregation"
+	"github.com/Azure/eno/internal/controllers/flowcontrol"
 	testv1 "github.com/Azure/eno/internal/controllers/reconciliation/fixtures/v1"
 	"github.com/Azure/eno/internal/controllers/rollout"
 	"github.com/Azure/eno/internal/controllers/synthesis"
@@ -217,6 +218,7 @@ func TestCRUD(t *testing.T) {
 			downstream := mgr.DownstreamClient
 
 			// Register supporting controllers
+			require.NoError(t, flowcontrol.NewSynthesisConcurrencyLimiter(mgr.Manager, 10))
 			require.NoError(t, rollout.NewSynthesizerController(mgr.Manager))
 			require.NoError(t, rollout.NewController(mgr.Manager, time.Millisecond))
 			require.NoError(t, synthesis.NewPodLifecycleController(mgr.Manager, defaultConf))
@@ -386,6 +388,7 @@ func TestReconcileInterval(t *testing.T) {
 	downstream := mgr.DownstreamClient
 
 	// Register supporting controllers
+	require.NoError(t, flowcontrol.NewSynthesisConcurrencyLimiter(mgr.Manager, 10))
 	require.NoError(t, rollout.NewSynthesizerController(mgr.Manager))
 	require.NoError(t, rollout.NewController(mgr.Manager, time.Millisecond))
 	require.NoError(t, synthesis.NewPodLifecycleController(mgr.Manager, defaultConf))
@@ -457,6 +460,7 @@ func TestReconcileCacheRace(t *testing.T) {
 	downstream := mgr.DownstreamClient
 
 	// Register supporting controllers
+	require.NoError(t, flowcontrol.NewSynthesisConcurrencyLimiter(mgr.Manager, 10))
 	require.NoError(t, rollout.NewSynthesizerController(mgr.Manager))
 	require.NoError(t, rollout.NewController(mgr.Manager, time.Millisecond))
 	require.NoError(t, synthesis.NewPodLifecycleController(mgr.Manager, defaultConf))
@@ -530,6 +534,7 @@ func TestCompositionDeletionOrdering(t *testing.T) {
 	downstream := mgr.DownstreamClient
 
 	// Register supporting controllers
+	require.NoError(t, flowcontrol.NewSynthesisConcurrencyLimiter(mgr.Manager, 10))
 	require.NoError(t, rollout.NewSynthesizerController(mgr.Manager))
 	require.NoError(t, rollout.NewController(mgr.Manager, time.Millisecond))
 	require.NoError(t, synthesis.NewSliceCleanupController(mgr.Manager))
@@ -605,6 +610,7 @@ func TestMidSynthesisDeletion(t *testing.T) {
 	downstream := mgr.DownstreamClient
 
 	// Register supporting controllers
+	require.NoError(t, flowcontrol.NewSynthesisConcurrencyLimiter(mgr.Manager, 10))
 	require.NoError(t, synthesis.NewSliceCleanupController(mgr.Manager))
 	require.NoError(t, synthesis.NewPodLifecycleController(mgr.Manager, defaultConf))
 	require.NoError(t, aggregation.NewSliceController(mgr.Manager))
@@ -699,6 +705,7 @@ func TestDisableUpdates(t *testing.T) {
 	downstream := mgr.DownstreamClient
 
 	// Register supporting controllers
+	require.NoError(t, flowcontrol.NewSynthesisConcurrencyLimiter(mgr.Manager, 10))
 	require.NoError(t, rollout.NewSynthesizerController(mgr.Manager))
 	require.NoError(t, rollout.NewController(mgr.Manager, time.Millisecond))
 	require.NoError(t, synthesis.NewPodLifecycleController(mgr.Manager, defaultConf))
@@ -769,6 +776,7 @@ func TestOrphanedCompositionDeletion(t *testing.T) {
 	upstream := mgr.GetClient()
 
 	// Register supporting controllers
+	require.NoError(t, flowcontrol.NewSynthesisConcurrencyLimiter(mgr.Manager, 10))
 	require.NoError(t, rollout.NewSynthesizerController(mgr.Manager))
 	require.NoError(t, rollout.NewController(mgr.Manager, time.Millisecond))
 	require.NoError(t, synthesis.NewSliceCleanupController(mgr.Manager))

--- a/internal/controllers/reconciliation/error_test.go
+++ b/internal/controllers/reconciliation/error_test.go
@@ -2,6 +2,7 @@ package reconciliation
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -179,4 +180,55 @@ func TestTerminalError(t *testing.T) {
 	// Prove that the failed synthesis isn't retained
 	assert.Len(t, comp.Status.CurrentSynthesis.Results, 0)
 	assert.Len(t, comp.Status.PreviousSynthesis.Results, 0)
+}
+
+// TestSliceCleanupOutdated proves there is an upper bound on how many resource slices
+// can exist for a given composition even when it's stuck in a synthesis retry loop.
+func TestSliceCleanupOutdated(t *testing.T) {
+	scheme := runtime.NewScheme()
+	corev1.SchemeBuilder.AddToScheme(scheme)
+	testv1.SchemeBuilder.AddToScheme(scheme)
+
+	ctx := testutil.NewContext(t)
+	mgr := testutil.NewManager(t)
+	upstream := mgr.GetClient()
+
+	// Register supporting controllers
+	require.NoError(t, flowcontrol.NewSynthesisConcurrencyLimiter(mgr.Manager, 10))
+	require.NoError(t, rollout.NewSynthesizerController(mgr.Manager))
+	require.NoError(t, rollout.NewController(mgr.Manager, time.Millisecond))
+	require.NoError(t, synthesis.NewSliceCleanupController(mgr.Manager))
+	require.NoError(t, synthesis.NewPodLifecycleController(mgr.Manager, defaultConf))
+	require.NoError(t, aggregation.NewSliceController(mgr.Manager))
+	testutil.WithFakeExecutor(t, mgr, func(ctx context.Context, s *apiv1.Synthesizer, input *krmv1.ResourceList) (*krmv1.ResourceList, error) {
+		return nil, fmt.Errorf("uh oh")
+	})
+
+	// Test subject
+	setupTestSubject(t, mgr)
+	mgr.Start(t)
+
+	syn := &apiv1.Synthesizer{}
+	syn.Name = "test-syn"
+	syn.Spec.Image = "create"
+	require.NoError(t, upstream.Create(ctx, syn))
+
+	comp := &apiv1.Composition{}
+	comp.Name = "test-comp"
+	comp.Namespace = "default"
+	comp.Spec.Synthesizer.Name = syn.Name
+	require.NoError(t, upstream.Create(ctx, comp))
+
+	// Wait for a few attempts
+	testutil.Eventually(t, func() bool {
+		err := upstream.Get(ctx, client.ObjectKeyFromObject(comp), comp)
+		return err == nil && comp.Status.CurrentSynthesis != nil && comp.Status.CurrentSynthesis.Attempts >= 3
+	})
+
+	// There should not be more than one set of resource slices
+	testutil.Eventually(t, func() bool {
+		sliceList := &apiv1.ResourceSliceList{}
+		err := upstream.List(ctx, sliceList)
+		return err == nil && len(sliceList.Items) < 2
+	})
 }

--- a/internal/controllers/reconciliation/error_test.go
+++ b/internal/controllers/reconciliation/error_test.go
@@ -16,6 +16,7 @@ import (
 
 	apiv1 "github.com/Azure/eno/api/v1"
 	"github.com/Azure/eno/internal/controllers/aggregation"
+	"github.com/Azure/eno/internal/controllers/flowcontrol"
 	testv1 "github.com/Azure/eno/internal/controllers/reconciliation/fixtures/v1"
 	"github.com/Azure/eno/internal/controllers/rollout"
 	"github.com/Azure/eno/internal/controllers/synthesis"
@@ -37,6 +38,7 @@ func TestTerminalError(t *testing.T) {
 	upstream := mgr.GetClient()
 
 	// Register supporting controllers
+	require.NoError(t, flowcontrol.NewSynthesisConcurrencyLimiter(mgr.Manager, 10))
 	require.NoError(t, rollout.NewSynthesizerController(mgr.Manager))
 	require.NoError(t, rollout.NewController(mgr.Manager, time.Millisecond))
 	require.NoError(t, synthesis.NewSliceCleanupController(mgr.Manager))

--- a/internal/controllers/reconciliation/helm_test.go
+++ b/internal/controllers/reconciliation/helm_test.go
@@ -10,6 +10,7 @@ import (
 
 	apiv1 "github.com/Azure/eno/api/v1"
 	"github.com/Azure/eno/internal/controllers/aggregation"
+	"github.com/Azure/eno/internal/controllers/flowcontrol"
 	testv1 "github.com/Azure/eno/internal/controllers/reconciliation/fixtures/v1"
 	"github.com/Azure/eno/internal/controllers/rollout"
 	"github.com/Azure/eno/internal/controllers/synthesis"
@@ -47,6 +48,7 @@ func TestHelmOwnershipTransfer(t *testing.T) {
 	require.NoError(t, os.WriteFile(kubeconfigPath, kc, 0600))
 
 	// Register supporting controllers
+	require.NoError(t, flowcontrol.NewSynthesisConcurrencyLimiter(mgr.Manager, 10))
 	require.NoError(t, rollout.NewSynthesizerController(mgr.Manager))
 	require.NoError(t, rollout.NewController(mgr.Manager, time.Millisecond))
 	require.NoError(t, synthesis.NewPodLifecycleController(mgr.Manager, defaultConf))

--- a/internal/controllers/reconciliation/ordering_test.go
+++ b/internal/controllers/reconciliation/ordering_test.go
@@ -11,6 +11,7 @@ import (
 
 	apiv1 "github.com/Azure/eno/api/v1"
 	"github.com/Azure/eno/internal/controllers/aggregation"
+	"github.com/Azure/eno/internal/controllers/flowcontrol"
 	testv1 "github.com/Azure/eno/internal/controllers/reconciliation/fixtures/v1"
 	"github.com/Azure/eno/internal/controllers/rollout"
 	"github.com/Azure/eno/internal/controllers/synthesis"
@@ -37,6 +38,7 @@ func TestReadinessGroups(t *testing.T) {
 	upstream := mgr.GetClient()
 
 	// Register supporting controllers
+	require.NoError(t, flowcontrol.NewSynthesisConcurrencyLimiter(mgr.Manager, 10))
 	require.NoError(t, rollout.NewSynthesizerController(mgr.Manager))
 	require.NoError(t, rollout.NewController(mgr.Manager, time.Millisecond))
 	require.NoError(t, aggregation.NewSliceController(mgr.Manager))
@@ -162,6 +164,7 @@ func TestCRDOrdering(t *testing.T) {
 	upstream := mgr.GetClient()
 
 	// Register supporting controllers
+	require.NoError(t, flowcontrol.NewSynthesisConcurrencyLimiter(mgr.Manager, 10))
 	require.NoError(t, rollout.NewSynthesizerController(mgr.Manager))
 	require.NoError(t, rollout.NewController(mgr.Manager, time.Millisecond))
 	require.NoError(t, aggregation.NewSliceController(mgr.Manager))

--- a/internal/controllers/reconciliation/patch_test.go
+++ b/internal/controllers/reconciliation/patch_test.go
@@ -7,6 +7,7 @@ import (
 
 	apiv1 "github.com/Azure/eno/api/v1"
 	"github.com/Azure/eno/internal/controllers/aggregation"
+	"github.com/Azure/eno/internal/controllers/flowcontrol"
 	testv1 "github.com/Azure/eno/internal/controllers/reconciliation/fixtures/v1"
 	"github.com/Azure/eno/internal/controllers/rollout"
 	"github.com/Azure/eno/internal/controllers/synthesis"
@@ -32,6 +33,7 @@ func TestPatchCreation(t *testing.T) {
 	downstream := mgr.DownstreamClient
 
 	// Register supporting controllers
+	require.NoError(t, flowcontrol.NewSynthesisConcurrencyLimiter(mgr.Manager, 10))
 	require.NoError(t, rollout.NewSynthesizerController(mgr.Manager))
 	require.NoError(t, rollout.NewController(mgr.Manager, time.Millisecond))
 	require.NoError(t, synthesis.NewPodLifecycleController(mgr.Manager, defaultConf))
@@ -96,6 +98,7 @@ func TestPatchDeletion(t *testing.T) {
 	downstream := mgr.DownstreamClient
 
 	// Register supporting controllers
+	require.NoError(t, flowcontrol.NewSynthesisConcurrencyLimiter(mgr.Manager, 10))
 	require.NoError(t, rollout.NewSynthesizerController(mgr.Manager))
 	require.NoError(t, rollout.NewController(mgr.Manager, time.Millisecond))
 	require.NoError(t, synthesis.NewPodLifecycleController(mgr.Manager, defaultConf))

--- a/internal/controllers/reconciliation/rollout_test.go
+++ b/internal/controllers/reconciliation/rollout_test.go
@@ -8,6 +8,7 @@ import (
 
 	apiv1 "github.com/Azure/eno/api/v1"
 	"github.com/Azure/eno/internal/controllers/aggregation"
+	"github.com/Azure/eno/internal/controllers/flowcontrol"
 	testv1 "github.com/Azure/eno/internal/controllers/reconciliation/fixtures/v1"
 	"github.com/Azure/eno/internal/controllers/rollout"
 	"github.com/Azure/eno/internal/controllers/synthesis"
@@ -31,6 +32,7 @@ func TestBulkRollout(t *testing.T) {
 	upstream := mgr.GetClient()
 
 	// Register supporting controllers
+	require.NoError(t, flowcontrol.NewSynthesisConcurrencyLimiter(mgr.Manager, 10))
 	require.NoError(t, rollout.NewSynthesizerController(mgr.Manager))
 	require.NoError(t, rollout.NewController(mgr.Manager, time.Millisecond))
 	require.NoError(t, aggregation.NewSliceController(mgr.Manager))

--- a/internal/controllers/reconciliation/status_test.go
+++ b/internal/controllers/reconciliation/status_test.go
@@ -7,6 +7,7 @@ import (
 
 	apiv1 "github.com/Azure/eno/api/v1"
 	"github.com/Azure/eno/internal/controllers/aggregation"
+	"github.com/Azure/eno/internal/controllers/flowcontrol"
 	testv1 "github.com/Azure/eno/internal/controllers/reconciliation/fixtures/v1"
 	"github.com/Azure/eno/internal/controllers/rollout"
 	"github.com/Azure/eno/internal/controllers/synthesis"
@@ -36,6 +37,7 @@ func TestResourceReadiness(t *testing.T) {
 	downstream := mgr.DownstreamClient
 
 	// Register supporting controllers
+	require.NoError(t, flowcontrol.NewSynthesisConcurrencyLimiter(mgr.Manager, 10))
 	require.NoError(t, rollout.NewSynthesizerController(mgr.Manager))
 	require.NoError(t, rollout.NewController(mgr.Manager, time.Millisecond))
 	require.NoError(t, synthesis.NewPodLifecycleController(mgr.Manager, defaultConf))

--- a/internal/controllers/reconciliation/symphony_test.go
+++ b/internal/controllers/reconciliation/symphony_test.go
@@ -18,6 +18,7 @@ import (
 
 	apiv1 "github.com/Azure/eno/api/v1"
 	"github.com/Azure/eno/internal/controllers/aggregation"
+	"github.com/Azure/eno/internal/controllers/flowcontrol"
 	"github.com/Azure/eno/internal/controllers/replication"
 	"github.com/Azure/eno/internal/controllers/rollout"
 	"github.com/Azure/eno/internal/controllers/synthesis"
@@ -38,6 +39,7 @@ func TestSymphonyIntegration(t *testing.T) {
 	require.NoError(t, upstream.Create(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "test"}}))
 
 	// Register supporting controllers
+	require.NoError(t, flowcontrol.NewSynthesisConcurrencyLimiter(mgr.Manager, 10))
 	require.NoError(t, rollout.NewSynthesizerController(mgr.Manager))
 	require.NoError(t, rollout.NewController(mgr.Manager, time.Millisecond))
 	require.NoError(t, synthesis.NewPodLifecycleController(mgr.Manager, defaultConf))

--- a/internal/controllers/rollout/integration_test.go
+++ b/internal/controllers/rollout/integration_test.go
@@ -11,6 +11,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	apiv1 "github.com/Azure/eno/api/v1"
+	"github.com/Azure/eno/internal/controllers/flowcontrol"
 	"github.com/Azure/eno/internal/controllers/synthesis"
 	"github.com/Azure/eno/internal/testutil"
 	krmv1 "github.com/Azure/eno/pkg/krm/functions/api/v1"
@@ -28,6 +29,7 @@ func TestSynthesizerRollout(t *testing.T) {
 	mgr := testutil.NewManager(t)
 	cli := mgr.GetClient()
 
+	require.NoError(t, flowcontrol.NewSynthesisConcurrencyLimiter(mgr.Manager, 10))
 	require.NoError(t, NewSynthesizerController(mgr.Manager))
 	require.NoError(t, NewController(mgr.Manager, time.Millisecond*10))
 	require.NoError(t, synthesis.NewPodLifecycleController(mgr.Manager, testSynthesisConfig))
@@ -79,6 +81,7 @@ func TestSynthesizerRolloutCooldown(t *testing.T) {
 	mgr := testutil.NewManager(t)
 	cli := mgr.GetClient()
 
+	require.NoError(t, flowcontrol.NewSynthesisConcurrencyLimiter(mgr.Manager, 10))
 	require.NoError(t, NewSynthesizerController(mgr.Manager))
 	require.NoError(t, NewController(mgr.Manager, time.Hour))
 	require.NoError(t, synthesis.NewPodLifecycleController(mgr.Manager, testSynthesisConfig))
@@ -144,6 +147,7 @@ func TestSynthesizerRolloutDeleted(t *testing.T) {
 	mgr := testutil.NewManager(t)
 	cli := mgr.GetClient()
 
+	require.NoError(t, flowcontrol.NewSynthesisConcurrencyLimiter(mgr.Manager, 10))
 	require.NoError(t, NewSynthesizerController(mgr.Manager))
 	require.NoError(t, NewController(mgr.Manager, time.Millisecond*10))
 	require.NoError(t, synthesis.NewPodLifecycleController(mgr.Manager, testSynthesisConfig))

--- a/internal/controllers/synthesis/backoff_test.go
+++ b/internal/controllers/synthesis/backoff_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	apiv1 "github.com/Azure/eno/api/v1"
+	"github.com/Azure/eno/internal/controllers/flowcontrol"
 	"github.com/Azure/eno/internal/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -18,6 +19,7 @@ func TestControllerBackoff(t *testing.T) {
 	cli := mgr.GetClient()
 
 	require.NoError(t, NewPodLifecycleController(mgr.Manager, minimalTestConfig))
+	require.NoError(t, flowcontrol.NewSynthesisConcurrencyLimiter(mgr.Manager, 10))
 	mgr.Start(t)
 
 	syn := &apiv1.Synthesizer{}

--- a/internal/controllers/synthesis/integration_test.go
+++ b/internal/controllers/synthesis/integration_test.go
@@ -16,6 +16,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	apiv1 "github.com/Azure/eno/api/v1"
+	"github.com/Azure/eno/internal/controllers/flowcontrol"
 	"github.com/Azure/eno/internal/testutil"
 	krmv1 "github.com/Azure/eno/pkg/krm/functions/api/v1"
 )
@@ -33,6 +34,7 @@ func TestControllerHappyPath(t *testing.T) {
 	mgr := testutil.NewManager(t)
 	cli := mgr.GetClient()
 
+	require.NoError(t, flowcontrol.NewSynthesisConcurrencyLimiter(mgr.Manager, 10))
 	require.NoError(t, NewPodLifecycleController(mgr.Manager, minimalTestConfig))
 
 	calls := atomic.Int64{}
@@ -172,6 +174,7 @@ func TestControllerSwitchingSynthesizers(t *testing.T) {
 		return output, nil
 	})
 
+	require.NoError(t, flowcontrol.NewSynthesisConcurrencyLimiter(mgr.Manager, 10))
 	require.NoError(t, NewPodLifecycleController(mgr.Manager, minimalTestConfig))
 	mgr.Start(t)
 

--- a/internal/controllers/synthesis/lifecycle.go
+++ b/internal/controllers/synthesis/lifecycle.go
@@ -152,11 +152,10 @@ func (c *podLifecycleController) Reconcile(ctx context.Context, req ctrl.Request
 	// This will fail if another write has already hit the resource i.e. synthesis completion.
 	// Otherwise it's possible for pod deletion event to land before the synthesis complete event.
 	// In that case a new pod would be created even though the synthesis just completed.
+	//
+	// The UUID is written by the flow control controller - this controller should just wait
+	// until it has "dispatched" this synthesis.
 	if comp.Status.CurrentSynthesis.UUID == "" {
-		comp.Status.CurrentSynthesis.UUID = uuid.NewString()
-		if err := c.client.Status().Update(ctx, comp); err != nil {
-			return ctrl.Result{}, fmt.Errorf("writing started timestamp to status: %w", err)
-		}
 		return ctrl.Result{}, nil
 	}
 

--- a/internal/controllers/synthesis/lifecycle_test.go
+++ b/internal/controllers/synthesis/lifecycle_test.go
@@ -17,6 +17,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	apiv1 "github.com/Azure/eno/api/v1"
+	"github.com/Azure/eno/internal/controllers/flowcontrol"
 	"github.com/Azure/eno/internal/testutil"
 	krmv1 "github.com/Azure/eno/pkg/krm/functions/api/v1"
 )
@@ -45,6 +46,7 @@ func TestCompositionDeletion(t *testing.T) {
 
 	require.NoError(t, NewPodLifecycleController(mgr.Manager, minimalTestConfig))
 	require.NoError(t, NewSliceCleanupController(mgr.Manager))
+	require.NoError(t, flowcontrol.NewSynthesisConcurrencyLimiter(mgr.Manager, 10))
 	mgr.Start(t)
 
 	syn := &apiv1.Synthesizer{}

--- a/internal/controllers/synthesis/pod.go
+++ b/internal/controllers/synthesis/pod.go
@@ -72,7 +72,7 @@ func newPod(cfg *Config, comp *apiv1.Composition, syn *apiv1.Synthesizer) *corev
 				},
 				{
 					Name:  "SYNTHESIS_ATTEMPT",
-					Value: strconv.Itoa(comp.Status.CurrentSynthesis.Attempts),
+					Value: strconv.Itoa(comp.Status.CurrentSynthesis.Attempts + 1), // we write the next attempt _after_ pod creation
 				},
 			},
 			SecurityContext: &corev1.SecurityContext{

--- a/internal/controllers/synthesis/pod.go
+++ b/internal/controllers/synthesis/pod.go
@@ -1,6 +1,8 @@
 package synthesis
 
 import (
+	"strconv"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
@@ -67,6 +69,10 @@ func newPod(cfg *Config, comp *apiv1.Composition, syn *apiv1.Synthesizer) *corev
 				{
 					Name:  "SYNTHESIS_UUID",
 					Value: comp.Status.CurrentSynthesis.UUID,
+				},
+				{
+					Name:  "SYNTHESIS_ATTEMPT",
+					Value: strconv.Itoa(comp.Status.CurrentSynthesis.Attempts),
 				},
 			},
 			SecurityContext: &corev1.SecurityContext{

--- a/internal/controllers/synthesis/slicecleanup.go
+++ b/internal/controllers/synthesis/slicecleanup.go
@@ -94,18 +94,20 @@ func shouldDeleteSlice(comp *apiv1.Composition, slice *apiv1.ResourceSlice) bool
 	if comp.Status.CurrentSynthesis != nil && slice.Spec.CompositionGeneration > comp.Status.CurrentSynthesis.ObservedCompositionGeneration {
 		return false // stale informer
 	}
+	isOutdated := slice.Spec.Attempt != 0 && comp.Status.CurrentSynthesis.Attempts > slice.Spec.Attempt
 	isReferencedByComp := synthesisReferencesSlice(comp.Status.CurrentSynthesis, slice) || synthesisReferencesSlice(comp.Status.PreviousSynthesis, slice)
 	isPendingSynthesis := comp.Status.CurrentSynthesis != nil && comp.Status.CurrentSynthesis.Synthesized != nil
 	compIsDeleted := comp.DeletionTimestamp != nil
-	return isPendingSynthesis && compIsDeleted || (!isReferencedByComp && slice.Spec.CompositionGeneration < comp.Generation)
+	return isOutdated || (isPendingSynthesis && compIsDeleted || (!isReferencedByComp && slice.Spec.CompositionGeneration < comp.Generation))
 }
 
 func shouldReleaseSliceFinalizer(comp *apiv1.Composition, slice *apiv1.ResourceSlice) bool {
 	if comp.Status.CurrentSynthesis != nil && slice.Spec.CompositionGeneration > comp.Status.CurrentSynthesis.ObservedCompositionGeneration {
 		return false // stale informer
 	}
+	isOutdated := slice.Spec.Attempt != 0 && comp.Status.CurrentSynthesis.Attempts > slice.Spec.Attempt
 	isPendingSynthesis := comp.Status.CurrentSynthesis != nil && comp.Status.CurrentSynthesis.Synthesized != nil
-	return isPendingSynthesis && (!resourcesRemain(comp, slice) || (!synthesisReferencesSlice(comp.Status.CurrentSynthesis, slice) && !synthesisReferencesSlice(comp.Status.PreviousSynthesis, slice)))
+	return isOutdated || (isPendingSynthesis && (!resourcesRemain(comp, slice) || (!synthesisReferencesSlice(comp.Status.CurrentSynthesis, slice) && !synthesisReferencesSlice(comp.Status.PreviousSynthesis, slice))))
 }
 
 func synthesisReferencesSlice(syn *apiv1.Synthesis, slice *apiv1.ResourceSlice) bool {

--- a/internal/execution/executor.go
+++ b/internal/execution/executor.go
@@ -34,7 +34,7 @@ func (e *Executor) Synthesize(ctx context.Context, env *Env) error {
 	if err != nil {
 		return fmt.Errorf("fetching composition: %w", err)
 	}
-	if comp.Status.CurrentSynthesis == nil || comp.Status.CurrentSynthesis.UUID != env.SynthesisUUID {
+	if comp.Status.CurrentSynthesis == nil || comp.Status.CurrentSynthesis.UUID != env.SynthesisUUID || comp.Status.CurrentSynthesis.Attempts != env.SynthesisAttempt {
 		// This pod is no longer needed, wait for the controller to clean it up
 		return nil
 	}
@@ -61,7 +61,7 @@ func (e *Executor) Synthesize(ctx context.Context, env *Env) error {
 		return err
 	}
 
-	return e.updateComposition(ctx, comp, syn, sliceRefs, revs, output)
+	return e.updateComposition(ctx, env, comp, syn, sliceRefs, revs, output)
 }
 
 func (e *Executor) buildPodInput(ctx context.Context, comp *apiv1.Composition, syn *apiv1.Synthesizer) (*krmv1.ResourceList, []apiv1.InputRevisions, error) {
@@ -181,7 +181,7 @@ func (e *Executor) writeResourceSlice(ctx context.Context, slice *apiv1.Resource
 	})
 }
 
-func (e *Executor) updateComposition(ctx context.Context, oldComp *apiv1.Composition, syn *apiv1.Synthesizer, refs []*apiv1.ResourceSliceRef, revs []apiv1.InputRevisions, rl *krmv1.ResourceList) error {
+func (e *Executor) updateComposition(ctx context.Context, env *Env, oldComp *apiv1.Composition, syn *apiv1.Synthesizer, refs []*apiv1.ResourceSliceRef, revs []apiv1.InputRevisions, rl *krmv1.ResourceList) error {
 	logger := logr.FromContextOrDiscard(ctx)
 	return retry.RetryOnConflict(retry.DefaultBackoff, func() error {
 		comp := &apiv1.Composition{}
@@ -191,7 +191,7 @@ func (e *Executor) updateComposition(ctx context.Context, oldComp *apiv1.Composi
 		}
 
 		synthesis := comp.Status.CurrentSynthesis
-		if synthesis == nil || synthesis.Synthesized != nil || synthesis.ObservedCompositionGeneration != oldComp.Generation {
+		if synthesis == nil || synthesis.UUID != env.SynthesisUUID || synthesis.Attempts != env.SynthesisAttempt {
 			logger.V(0).Info("synthesis is no longer relevant - discarding its output")
 			return nil
 		}

--- a/internal/execution/executor_test.go
+++ b/internal/execution/executor_test.go
@@ -3,14 +3,18 @@ package execution
 import (
 	"context"
 	"testing"
+	"time"
 
 	apiv1 "github.com/Azure/eno/api/v1"
 	krmv1 "github.com/Azure/eno/pkg/krm/functions/api/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/util/retry"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
@@ -323,69 +327,7 @@ func TestUUIDMismatch(t *testing.T) {
 	assert.Nil(t, comp.Status.CurrentSynthesis.Synthesized)
 }
 
-func TestAttemptMismatch(t *testing.T) {
-	ctx := context.Background()
-	scheme := runtime.NewScheme()
-	require.NoError(t, apiv1.SchemeBuilder.AddToScheme(scheme))
-
-	cli := fake.NewClientBuilder().
-		WithScheme(scheme).
-		WithStatusSubresource(&apiv1.ResourceSlice{}, &apiv1.Composition{}).
-		Build()
-
-	syn := &apiv1.Synthesizer{}
-	syn.Name = "test-synth"
-	err := cli.Create(ctx, syn)
-	require.NoError(t, err)
-
-	comp := &apiv1.Composition{}
-	comp.Name = "test-comp"
-	comp.Namespace = "default"
-	comp.Spec.Synthesizer.Name = syn.Name
-	err = cli.Create(ctx, comp)
-	require.NoError(t, err)
-
-	comp.Status.CurrentSynthesis = &apiv1.Synthesis{UUID: "test-uuid"}
-	err = cli.Status().Update(ctx, comp)
-	require.NoError(t, err)
-
-	e := &Executor{
-		Reader: cli,
-		Writer: cli,
-		Handler: func(ctx context.Context, s *apiv1.Synthesizer, rl *krmv1.ResourceList) (*krmv1.ResourceList, error) {
-			out := &unstructured.Unstructured{
-				Object: map[string]any{
-					"apiVersion": "v1",
-					"kind":       "ConfigMap",
-					"metadata": map[string]string{
-						"name":      "test",
-						"namespace": "default",
-					},
-					"data": map[string]string{"foo": "bar"},
-				},
-			}
-			return &krmv1.ResourceList{
-				Items:   []*unstructured.Unstructured{out},
-				Results: []*krmv1.Result{{Message: "foo", Severity: "error"}},
-			}, nil
-		},
-	}
-	env := &Env{
-		CompositionName:      comp.Name,
-		CompositionNamespace: comp.Namespace,
-		SynthesisUUID:        comp.Status.CurrentSynthesis.UUID,
-		SynthesisAttempt:     123,
-	}
-
-	err = e.Synthesize(ctx, env)
-	require.NoError(t, err)
-
-	err = cli.Get(ctx, client.ObjectKeyFromObject(comp), comp)
-	require.NoError(t, err)
-	assert.Nil(t, comp.Status.CurrentSynthesis.Synthesized)
-}
-
-func TestAttemptMismatchDuringSynthesis(t *testing.T) {
+func TestCompletionMismatchDuringSynthesis(t *testing.T) {
 	ctx := context.Background()
 	scheme := runtime.NewScheme()
 	require.NoError(t, apiv1.SchemeBuilder.AddToScheme(scheme))
@@ -416,11 +358,25 @@ func TestAttemptMismatchDuringSynthesis(t *testing.T) {
 		CompositionNamespace: comp.Namespace,
 		SynthesisUUID:        comp.Status.CurrentSynthesis.UUID,
 	}
+	originalSynthTime := metav1.NewTime(time.Now().Round(time.Second).Local())
 	e := &Executor{
 		Reader: cli,
 		Writer: cli,
 		Handler: func(ctx context.Context, s *apiv1.Synthesizer, rl *krmv1.ResourceList) (*krmv1.ResourceList, error) {
-			env.SynthesisAttempt = 123
+			// Act as if another synthesizer pod with the same synthesis uuid but different attempt has updated the status concurrently
+			err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+				require.NoError(t, cli.Get(ctx, client.ObjectKeyFromObject(comp), comp))
+				comp.Status.CurrentSynthesis.Synthesized = ptr.To(originalSynthTime)
+				return cli.Status().Update(ctx, comp)
+			})
+			require.NoError(t, err)
+
+			// Wait for that write to hit the informer cache
+			assert.Eventually(t, func() bool {
+				cli.Get(ctx, client.ObjectKeyFromObject(comp), comp)
+				return comp.Status.CurrentSynthesis.Synthesized != nil
+			}, time.Second*2, time.Millisecond*10)
+
 			out := &unstructured.Unstructured{
 				Object: map[string]any{
 					"apiVersion": "v1",
@@ -444,5 +400,5 @@ func TestAttemptMismatchDuringSynthesis(t *testing.T) {
 
 	err = cli.Get(ctx, client.ObjectKeyFromObject(comp), comp)
 	require.NoError(t, err)
-	assert.Nil(t, comp.Status.CurrentSynthesis.Synthesized)
+	assert.Equal(t, originalSynthTime, *comp.Status.CurrentSynthesis.Synthesized)
 }

--- a/internal/execution/handler.go
+++ b/internal/execution/handler.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"os"
 	"os/exec"
+	"strconv"
 
 	apiv1 "github.com/Azure/eno/api/v1"
 	krmv1 "github.com/Azure/eno/pkg/krm/functions/api/v1"
@@ -15,13 +16,16 @@ type Env struct {
 	CompositionName      string
 	CompositionNamespace string
 	SynthesisUUID        string
+	SynthesisAttempt     int
 }
 
 func LoadEnv() *Env {
+	attempt, _ := strconv.Atoi(os.Getenv("SYNTHESIS_ATTEMPT"))
 	return &Env{
 		CompositionName:      os.Getenv("COMPOSITION_NAME"),
 		CompositionNamespace: os.Getenv("COMPOSITION_NAMESPACE"),
 		SynthesisUUID:        os.Getenv("SYNTHESIS_UUID"),
+		SynthesisAttempt:     attempt,
 	}
 }
 

--- a/internal/resource/slicing.go
+++ b/internal/resource/slicing.go
@@ -77,6 +77,7 @@ func Slice(comp *apiv1.Composition, previous []*apiv1.ResourceSlice, outputs []*
 			}}
 			if comp.Status.CurrentSynthesis != nil {
 				slice.Spec.SynthesisUUID = comp.Status.CurrentSynthesis.UUID
+				slice.Spec.Attempt = comp.Status.CurrentSynthesis.Attempts
 			}
 			slice.Spec.CompositionGeneration = comp.Generation
 			slices = append(slices, slice)

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -357,6 +357,9 @@ func WithFakeExecutor(t *testing.T, mgr *Manager, sh execution.SynthesizerHandle
 				env.CompositionNamespace = e.Value
 			case "SYNTHESIS_UUID":
 				env.SynthesisUUID = e.Value
+			case "SYNTHESIS_ATTEMPT":
+				val, _ := strconv.Atoi(e.Value)
+				env.SynthesisAttempt = val
 			}
 		}
 

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -367,7 +367,9 @@ func WithFakeExecutor(t *testing.T, mgr *Manager, sh execution.SynthesizerHandle
 		}
 		err = e.Synthesize(ctx, env)
 		if err != nil {
-			return reconcile.Result{}, err
+			// Returning an error from the synth would eventually result in a timeout.
+			// To avoid waiting that long in the tests we can just delete the pod after the first try.
+			return reconcile.Result{}, mgr.GetClient().Delete(ctx, pod)
 		}
 
 		err = mgr.GetClient().Get(ctx, client.ObjectKeyFromObject(pod), pod)


### PR DESCRIPTION
- Limits synthesis concurrency
- Releases resource slices from previous synthesis attempts to prevent accumulation during retry loops
- Replaces some full status updates with patches in cases where retrying conflicts adds meaningful overhead and other concurrency controls are in place