### PR TITLE
Allow extra bindings

### DIFF
--- a/api/v1/composition.go
+++ b/api/v1/composition.go
@@ -133,8 +133,19 @@ func (s *Synthesis) Failed() bool {
 	return false
 }
 
-func (c *Composition) InputsExist() bool {
+func (c *Composition) InputsExist(syn *Synthesizer) bool {
+	refs := map[string]struct{}{}
+	for _, ref := range syn.Spec.Refs {
+		refs[ref.Key] = struct{}{}
+	}
+
 	for _, binding := range c.Spec.Bindings {
+		if _, ok := refs[binding.Key]; !ok {
+			// Ignore missing resources if the synthesizer doesn't require them
+			// This is important for forwards compatibility- compositions can bind to refs that don't exist, but will in future synths
+			continue
+		}
+
 		var found bool
 		for _, rev := range c.Status.InputRevisions {
 			if binding.Key == rev.Key {

--- a/api/v1/composition_test.go
+++ b/api/v1/composition_test.go
@@ -192,6 +192,20 @@ func TestCompositionInputsExist(t *testing.T) {
 			Expectation: true,
 		},
 		{
+			Name: "Bindings with matching revisions but missing ref",
+			Comp: Composition{
+				Spec: CompositionSpec{Bindings: []Binding{
+					{Key: "key1"},
+					{Key: "key5"},
+				}},
+				Status: CompositionStatus{InputRevisions: []InputRevisions{
+					{Key: "key1"},
+					{Key: "key5"},
+				}},
+			},
+			Expectation: true,
+		},
+		{
 			Name: "Bindings with non-matching revisions",
 			Comp: Composition{
 				Spec: CompositionSpec{Bindings: []Binding{
@@ -243,7 +257,9 @@ func TestCompositionInputsExist(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.Name, func(t *testing.T) {
-			result := tt.Comp.InputsExist()
+			s := &Synthesizer{}
+			s.Spec.Refs = []Ref{{Key: "key1"}, {Key: "key2"}, {Key: "key3"}}
+			result := tt.Comp.InputsExist(s)
 			assert.Equal(t, tt.Expectation, result)
 		})
 	}

--- a/internal/controllers/synthesis/lifecycle.go
+++ b/internal/controllers/synthesis/lifecycle.go
@@ -328,7 +328,7 @@ func shouldSwapStates(synth *apiv1.Synthesizer, comp *apiv1.Composition) bool {
 	// - synthesis is not already pending
 	// - all bound input resources exist
 	syn := comp.Status.CurrentSynthesis
-	return comp.InputsExist() && (syn == nil || syn.ObservedCompositionGeneration != comp.Generation || (!inputRevisionsEqual(synth, comp.Status.InputRevisions, syn.InputRevisions) && syn.Synthesized != nil))
+	return comp.InputsExist(synth) && (syn == nil || syn.ObservedCompositionGeneration != comp.Generation || (!inputRevisionsEqual(synth, comp.Status.InputRevisions, syn.InputRevisions) && syn.Synthesized != nil))
 }
 
 func shouldBackOffPodCreation(comp *apiv1.Composition) bool {

--- a/internal/controllers/synthesis/lifecycle_test.go
+++ b/internal/controllers/synthesis/lifecycle_test.go
@@ -525,7 +525,9 @@ func TestShouldSwapStates(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.Name, func(t *testing.T) {
-			assert.Equal(t, tc.Expectation, shouldSwapStates(&apiv1.Synthesizer{}, &tc.Composition))
+			syn := &apiv1.Synthesizer{}
+			syn.Spec.Refs = []apiv1.Ref{{Key: "foo"}}
+			assert.Equal(t, tc.Expectation, shouldSwapStates(syn, &tc.Composition))
 		})
 	}
 }


### PR DESCRIPTION
No-op bindings i.e. ones that don't correspond to a ref should not block synthesis in cases where the bound resource doesn't exist. This is important for forwards compatibility: compositions should be able to define bindings before a new version of the synth requires it.