### PR TITLE
Unblock composition deletion when inputs are missing

### DIFF
--- a/internal/controllers/synthesis/lifecycle.go
+++ b/internal/controllers/synthesis/lifecycle.go
@@ -326,9 +326,9 @@ func shouldSwapStates(synth *apiv1.Synthesizer, comp *apiv1.Composition) bool {
 	// - the bound input resources have changed
 	// AND
 	// - synthesis is not already pending
-	// - all bound input resources exist
+	// - all bound input resources exist (or composition is being deleted)
 	syn := comp.Status.CurrentSynthesis
-	return comp.InputsExist(synth) && (syn == nil || syn.ObservedCompositionGeneration != comp.Generation || (!inputRevisionsEqual(synth, comp.Status.InputRevisions, syn.InputRevisions) && syn.Synthesized != nil))
+	return (comp.DeletionTimestamp != nil || comp.InputsExist(synth)) && (syn == nil || syn.ObservedCompositionGeneration != comp.Generation || (!inputRevisionsEqual(synth, comp.Status.InputRevisions, syn.InputRevisions) && syn.Synthesized != nil))
 }
 
 func shouldBackOffPodCreation(comp *apiv1.Composition) bool {

--- a/internal/controllers/synthesis/lifecycle_test.go
+++ b/internal/controllers/synthesis/lifecycle_test.go
@@ -522,6 +522,44 @@ func TestShouldSwapStates(t *testing.T) {
 				},
 			},
 		},
+		{
+			Name:        "non-matching input synthesis deleting",
+			Expectation: true,
+			Composition: apiv1.Composition{
+				ObjectMeta: metav1.ObjectMeta{
+					DeletionTimestamp: ptr.To(metav1.Now()),
+					Generation:        2,
+				},
+				Spec: apiv1.CompositionSpec{
+					Bindings: []apiv1.Binding{{Key: "foo"}},
+				},
+				Status: apiv1.CompositionStatus{
+					CurrentSynthesis: &apiv1.Synthesis{
+						InputRevisions: []apiv1.InputRevisions{{
+							Key: "foo",
+						}},
+					},
+					InputRevisions: []apiv1.InputRevisions{{
+						Key:             "foo",
+						ResourceVersion: "new",
+					}},
+				},
+			},
+		},
+		{
+			Name:        "missing input synthesis deleting",
+			Expectation: true,
+			Composition: apiv1.Composition{
+				ObjectMeta: metav1.ObjectMeta{
+					DeletionTimestamp: ptr.To(metav1.Now()),
+					Generation:        2,
+				},
+				Spec: apiv1.CompositionSpec{
+					Bindings: []apiv1.Binding{{Key: "foo"}},
+				},
+				Status: apiv1.CompositionStatus{},
+			},
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.Name, func(t *testing.T) {


### PR DESCRIPTION
We should not wait for the inputs to exist when a composition is being deleted.