### PR TITLE
Trigger build/publish on release published event

### DIFF
--- a/.github/workflows/build-publish-mcr.yaml
+++ b/.github/workflows/build-publish-mcr.yaml
@@ -2,7 +2,6 @@
 # automatically pushed to the trusted registry, Microsoft Container Registry(MCR).
 name: Building and Pushing to MCR
 on:
-on:
   release:
     types: [published]
 

--- a/.github/workflows/build-publish-mcr.yaml
+++ b/.github/workflows/build-publish-mcr.yaml
@@ -2,11 +2,9 @@
 # automatically pushed to the trusted registry, Microsoft Container Registry(MCR).
 name: Building and Pushing to MCR
 on:
-  workflow_dispatch:
-    inputs:
-      releaseTag:
-        description: 'Release tag to publish images, defaults to the latest one'
-        type: string
+on:
+  release:
+    types: [published]
 
 permissions:
   id-token: write # This is required for requesting the JWT
@@ -19,7 +17,7 @@ jobs:
   prepare-variables:
     runs-on: ubuntu-latest
     outputs:
-      release_tag: ${{ steps.vars.outputs.release_tag }}
+      release_tag: ${{ github.event.release.tag_name }}
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
The image build/publish workflow will run automatically when publish a new release