### PR TITLE
Fix dispatch race

### DIFF
--- a/.github/workflows/k8scompat.yaml
+++ b/.github/workflows/k8scompat.yaml
@@ -49,6 +49,6 @@ jobs:
           echo "DOWNSTREAM_KUBEBUILDER_ASSETS=$($setupEnvtestCmd use -p path 1.${{ matrix.downstreamApiserverMinorVersion }}.x)" >> $GITHUB_ENV
 
       - name: Run tests
-        run: go test -v -count=2 ./internal/controllers/reconciliation
+        run: go test -v ./internal/controllers/reconciliation
         env:
           DOWNSTREAM_VERSION_MINOR: "${{ matrix.downstreamApiserverMinorVersion }}"

--- a/.github/workflows/k8scompat.yaml
+++ b/.github/workflows/k8scompat.yaml
@@ -49,6 +49,6 @@ jobs:
           echo "DOWNSTREAM_KUBEBUILDER_ASSETS=$($setupEnvtestCmd use -p path 1.${{ matrix.downstreamApiserverMinorVersion }}.x)" >> $GITHUB_ENV
 
       - name: Run tests
-        run: go test -v ./internal/controllers/reconciliation
+        run: go test -v -count=2 ./internal/controllers/reconciliation
         env:
           DOWNSTREAM_VERSION_MINOR: "${{ matrix.downstreamApiserverMinorVersion }}"

--- a/internal/controllers/flowcontrol/synthesis.go
+++ b/internal/controllers/flowcontrol/synthesis.go
@@ -72,8 +72,10 @@ func (c *synthesisConcurrencyLimiter) Reconcile(ctx context.Context, req ctrl.Re
 	logger = logger.WithValues("compositionName", next.Name, "compositionNamespace", next.Namespace, "compositionGeneration", next.Generation)
 
 	// Dispatch the next pending synthesis
+	path := "/status/currentSynthesis/uuid"
 	patch := []map[string]any{
-		{"op": "add", "path": "/status/currentSynthesis/uuid", "value": uuid.NewString()},
+		{"op": "test", "path": path, "value": nil},
+		{"op": "add", "path": path, "value": uuid.NewString()},
 	}
 	patchJS, err := json.Marshal(&patch)
 	if err != nil {


### PR DESCRIPTION
It's possible for the same synthesis to be dispatch multiple times i.e. have its uuid changed. This manifests in different deadlock states, all of which seem to eventually recover assuming reasonable synthesis timeouts. So no real impact IMO just annoying test flakes.