### PR TITLE
Shuffle correctly

### DIFF
--- a/internal/controllers/rollout/synthesizer.go
+++ b/internal/controllers/rollout/synthesizer.go
@@ -55,7 +55,7 @@ func (c *synthController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 	}
 
 	// randomize list to avoid always rolling out changes in the same order
-	rand.Shuffle(len(compList.Items), func(i, j int) { compList.Items[i] = compList.Items[j] })
+	rand.Shuffle(len(compList.Items), func(i, j int) { compList.Items[i], compList.Items[j] = compList.Items[j], compList.Items[i] })
 
 	for _, comp := range compList.Items {
 		comp := comp

--- a/internal/controllers/watch/kind.go
+++ b/internal/controllers/watch/kind.go
@@ -183,7 +183,7 @@ func (k *KindWatchController) Reconcile(ctx context.Context, req ctrl.Request) (
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("listing synthesizers: %w", err)
 	}
-	rand.Shuffle(len(list.Items), func(i, j int) { list.Items[i] = list.Items[j] })
+	rand.Shuffle(len(list.Items), func(i, j int) { list.Items[i], list.Items[j] = list.Items[j], list.Items[i] })
 
 	for _, synth := range list.Items {
 		list := &apiv1.CompositionList{}

--- a/internal/controllers/watch/watch.go
+++ b/internal/controllers/watch/watch.go
@@ -48,7 +48,7 @@ func (c *WatchController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 
 	// It's important to randomize the order over which we iterate the synths,
 	// otherwise one bad resource reference can block the loop
-	rand.Shuffle(len(synths.Items), func(i, j int) { synths.Items[i] = synths.Items[j] })
+	rand.Shuffle(len(synths.Items), func(i, j int) { synths.Items[i], synths.Items[j] = synths.Items[j], synths.Items[i] })
 
 	// Start any missing controllers
 	synthsByRef := map[apiv1.ResourceRef]struct{}{}


### PR DESCRIPTION
We don't shuffle lists correctly. Strangely enough this only actually matters in one case: the watch controller.

The watch controller watches synthesizers and spawns "kind watch" controllers for each kind they reference. Once things converge the loop will drop its work item and wait for something to change. Because synthesizers rarely change, dropping the work item when it shouldn't be is a 100% chance of deadlock.

The way in which we shuffle incorrectly sometimes causes elements to be represented in the slice multiple times. So if there are three synthesizers, one of which is not yet in sync, but only the other two are represented in the slice, everything is in sync from the controller's perspective.

Most controllers recover from this quickly enough since compositions are chatty during synthesis. But the watch controller is unlikely to recover until the controllers are rolled.