### PR TITLE
Add munge func to output writer

### DIFF
--- a/pkg/function/outputs_test.go
+++ b/pkg/function/outputs_test.go
@@ -7,11 +7,12 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 func TestOutputWriter(t *testing.T) {
 	out := bytes.NewBuffer(nil)
-	w := NewOutputWriter(out)
+	w := NewOutputWriter(out, nil)
 
 	cm := &corev1.ConfigMap{}
 	cm.Name = "test-cm"
@@ -24,4 +25,18 @@ func TestOutputWriter(t *testing.T) {
 	assert.Equal(t, "{\"apiVersion\":\"config.kubernetes.io/v1\",\"kind\":\"ResourceList\",\"items\":[{\"metadata\":{\"creationTimestamp\":null,\"name\":\"test-cm\"}}]}\n", out.String())
 
 	require.Error(t, w.Add(nil))
+}
+
+func TestOutputWriterMunge(t *testing.T) {
+	out := bytes.NewBuffer(nil)
+	w := NewOutputWriter(out, func(u *unstructured.Unstructured) {
+		unstructured.SetNestedField(u.Object, "value from munge function", "data", "extra-val")
+	})
+
+	cm := &corev1.ConfigMap{}
+	cm.Name = "test-cm"
+
+	require.NoError(t, w.Add(cm))
+	require.NoError(t, w.Write())
+	assert.Equal(t, "{\"apiVersion\":\"config.kubernetes.io/v1\",\"kind\":\"ResourceList\",\"items\":[{\"data\":{\"extra-val\":\"value from munge function\"},\"metadata\":{\"creationTimestamp\":null,\"name\":\"test-cm\"}}]}\n", out.String())
 }


### PR DESCRIPTION
Some synthesizers may have their own internal structure (e.g. the helm shim) while some logically separate code performs final transformation(s) - adding annotations, etc.