### PR TITLE
Include warning messages in status summary

### DIFF
--- a/internal/controllers/aggregation/composition.go
+++ b/internal/controllers/aggregation/composition.go
@@ -84,6 +84,17 @@ func (c *compositionController) aggregate(synth *apiv1.Synthesizer, comp *apiv1.
 		}
 	}
 
+	// Fall back to using the first warning as the error message if no terminal error is given.
+	// It's still useful to see error messages in the summary - even if they aren't fatal.
+	if copy.Error == "" {
+		for _, result := range comp.Status.CurrentSynthesis.Results {
+			if result.Severity == krmv1.ResultSeverityWarning {
+				copy.Error = result.Message
+				break
+			}
+		}
+	}
+
 	copy.Status = "Synthesizing"
 	if !comp.InputsExist(synth) {
 		copy.Status = "MissingInputs"

--- a/internal/controllers/aggregation/composition_test.go
+++ b/internal/controllers/aggregation/composition_test.go
@@ -150,6 +150,30 @@ func TestCompositionSimplification(t *testing.T) {
 		},
 		{
 			Input: apiv1.CompositionStatus{
+				CurrentSynthesis: &apiv1.Synthesis{
+					UUID:    "uuid",
+					Ready:   ptr.To(metav1.Now()),
+					Results: []apiv1.Result{{Message: "foo", Severity: "warning"}, {Message: "foo", Severity: "error"}},
+				}},
+			Expected: apiv1.SimplifiedStatus{
+				Status: "Ready",
+				Error:  "foo",
+			},
+		},
+		{
+			Input: apiv1.CompositionStatus{
+				CurrentSynthesis: &apiv1.Synthesis{
+					UUID:    "uuid",
+					Ready:   ptr.To(metav1.Now()),
+					Results: []apiv1.Result{{Message: "foo", Severity: "warning"}, {Message: "bar", Severity: "warning"}},
+				}},
+			Expected: apiv1.SimplifiedStatus{
+				Status: "Ready",
+				Error:  "foo",
+			},
+		},
+		{
+			Input: apiv1.CompositionStatus{
 				PendingResynthesis: ptr.To(metav1.Now()),
 				CurrentSynthesis: &apiv1.Synthesis{
 					UUID:  "uuid",


### PR DESCRIPTION
Setting an `error` severity result signals a terminal, non-retryable error. But plenty of errors are retyable and still interesting/useful for operators. So, aside from the slight mismatch of warning/error terminology, it makes sense to aggregate warning results into the `error` table printer column.