### PR TITLE
Ignore nil input revisions

### DIFF
--- a/api/v1/composition.go
+++ b/api/v1/composition.go
@@ -180,9 +180,9 @@ func (c *Composition) InputsMismatched() bool {
 		return false // no inputs declare a revision, so we should assume they're in sync
 	}
 
-	// Now given the max, make sure all inputs match it
+	// Now given the max, make sure all inputs with a revision match it
 	for _, rev := range c.Status.InputRevisions {
-		if rev.Revision == nil || *maxRevision != *rev.Revision {
+		if rev.Revision != nil && *maxRevision != *rev.Revision {
 			return true
 		}
 	}

--- a/api/v1/composition_test.go
+++ b/api/v1/composition_test.go
@@ -322,6 +322,19 @@ func TestInputsMismatched(t *testing.T) {
 			Expectation: true,
 		},
 		{
+			Name: "One matching, one nil revision",
+			Input: Composition{
+				Status: CompositionStatus{
+					InputRevisions: []InputRevisions{
+						{Revision: &revision1, ResourceVersion: "1"},
+						{Revision: &revision1, ResourceVersion: "1"},
+						{Revision: nil, ResourceVersion: "1"},
+					},
+				},
+			},
+			Expectation: false,
+		},
+		{
 			Name: "All revisions the same",
 			Input: Composition{
 				Status: CompositionStatus{

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -169,7 +169,8 @@ spec:
 The composition will be resynthesized whenever `test-input`'s `resourceVersion` changes by default, subject to the global cooldown period.
 
 If several inputs are expected to transition in lockstep, use this annotation to override the resource version.
-Synthesis will only happen once all inputs satisfy `revision == max(revisions)` where `revisions` represents the revisions of all resources bound to that composition.
+Synthesis will only happen once all inputs bound to a particular composition have matching revisions.
+Inputs that do not set a revision "fail open" i.e. will not block synthesis.
 
 ```yaml
 annotations:

--- a/go.work.sum
+++ b/go.work.sum
@@ -92,6 +92,7 @@ github.com/lestrrat-go/jwx v1.2.25/go.mod h1:zoNuZymNl5lgdcu6P7K6ie2QRll5HVfF4xw
 github.com/lestrrat-go/option v1.0.0/go.mod h1:5ZHFbivi4xwXxhxY9XHDe2FHo6/Z7WWmtT7T5nBBp3I=
 github.com/linuxkit/virtsock v0.0.0-20201010232012-f8cee7dfc7a3/go.mod h1:3r6x7q95whyfWQpmGZTu3gk3v2YkMi05HEzl7Tf7YEo=
 github.com/lithammer/dedent v1.1.0/go.mod h1:jrXYCQtgg0nJiN+StA2KgR7w6CiQNv9Fd/Z9BP0jIOc=
+github.com/lyft/protoc-gen-star/v2 v2.0.3/go.mod h1:amey7yeodaJhXSbf/TlLvWiqQfLOSpEk//mLlc+axEk=
 github.com/mattn/go-oci8 v0.1.1/go.mod h1:wjDx6Xm9q7dFtHJvIlrI99JytznLw5wQ4R+9mNXJwGI=
 github.com/mattn/go-shellwords v1.0.12/go.mod h1:EZzvwXDESEeg03EKmM+RmDnNOPKG4lLtQsUlTZDWQ8Y=
 github.com/matttproud/golang_protobuf_extensions v1.0.4/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
@@ -130,6 +131,7 @@ github.com/vbatts/tar-split v0.11.2/go.mod h1:vV3ZuO2yWSVsz+pfFzDG/upWH1JhjOiEaW
 github.com/vektah/gqlparser/v2 v2.4.5/go.mod h1:flJWIR04IMQPGz+BXLrORkrARBxv/rtyIAFvd/MceW0=
 github.com/veraison/go-cose v1.0.0-rc.1/go.mod h1:7ziE85vSq4ScFTg6wyoMXjucIGOf4JkFEZi/an96Ct4=
 github.com/vishvananda/netlink v1.2.1-beta.2/go.mod h1:twkDnbuQxJYemMlGd4JFIcuhgX83tXhKS2B/PRMpOho=
+github.com/vishvananda/netns v0.0.0-20210104183010-2eb08e3e575f/go.mod h1:DD4vA1DwXk04H54A1oHXtwZmA0grkVMdPxx/VGLCah0=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
 github.com/xhit/go-str2duration/v2 v2.1.0/go.mod h1:ohY8p+0f07DiV6Em5LKB0s2YpLtXVyJfNt1+BlmyAsU=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
@@ -168,7 +170,6 @@ google.golang.org/genproto v0.0.0-20240213162025-012b6fc9bca9/go.mod h1:mqHbVIp4
 google.golang.org/genproto/googleapis/api v0.0.0-20240318140521-94a12d6c2237/go.mod h1:Z5Iiy3jtmioajWHDGFk7CeugTyHtPvMHA4UTmUkyalE=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20240318140521-94a12d6c2237/go.mod h1:WtryC6hu0hhx87FDGxWCDptyssuo68sk10vYjF+T9fY=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20240617180043-68d350f18fd4/go.mod h1:Ue6ibwXGpU+dqIcODieyLOcgj7z8+IcskoNIgZxtrFY=
-google.golang.org/grpc v1.64.0/go.mod h1:oxjF8E3FBnjp+/gVFYdWacaLDx9na1aqy9oovLpxQYg=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 google.golang.org/protobuf v1.33.0/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=
@@ -176,7 +177,9 @@ gopkg.in/natefinch/lumberjack.v2 v2.2.1/go.mod h1:YD8tP3GAjkrDg1eZH7EGmyESg/lsYs
 gopkg.in/square/go-jose.v2 v2.6.0/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76mk0e1AI=
 k8s.io/code-generator v0.30.2/go.mod h1:RQP5L67QxqgkVquk704CyvWFIq0e6RCMmLTXxjE8dVA=
 k8s.io/component-helpers v0.30.0/go.mod h1:68HlSwXIumMKmCx8cZe1PoafQEYh581/sEpxMrkhmX4=
+k8s.io/cri-api v0.27.1/go.mod h1:+Ts/AVYbIo04S86XbTD73UPp/DkTiYxtsFeOFEu32L0=
 k8s.io/gengo/v2 v2.0.0-20240228010128-51d4e06bde70/go.mod h1:VH3AT8AaQOqiGjMF9p0/IM1Dj+82ZwjfxUP1IxaHE+8=
 k8s.io/kms v0.30.2/go.mod h1:GrMurD0qk3G4yNgGcsCEmepqf9KyyIrTXYR2lyUOJC4=
+k8s.io/metrics v0.30.0/go.mod h1:nSDA8V19WHhCTBhRYuyzJT9yPJBxSpqbyrGCCQ4jPj4=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.29.0/go.mod h1:z7+wmGM2dfIiLRfrC6jb5kV2Mq/sK1ZP303cxzkV5Y4=
 sigs.k8s.io/kustomize/kustomize/v5 v5.0.4-0.20230601165947-6ce0bf390ce3/go.mod h1:/d88dHCvoy7d0AKFT0yytezSGZKjsZBVs9YTkBHSGFk=

--- a/internal/controllers/reconciliation/crud_test.go
+++ b/internal/controllers/reconciliation/crud_test.go
@@ -403,18 +403,7 @@ func TestReconcileInterval(t *testing.T) {
 	// Test subject
 	setupTestSubject(t, mgr)
 	mgr.Start(t)
-
-	// Any syn/comp will do since we faked out the synthesizer pod
-	syn := &apiv1.Synthesizer{}
-	syn.Name = "test-syn"
-	syn.Spec.Image = "create"
-	require.NoError(t, upstream.Create(ctx, syn))
-
-	comp := &apiv1.Composition{}
-	comp.Name = "test-comp"
-	comp.Namespace = "default"
-	comp.Spec.Synthesizer.Name = syn.Name
-	require.NoError(t, upstream.Create(ctx, comp))
+	writeGenericComposition(t, upstream)
 
 	// Wait for resource to be created
 	obj := &corev1.ConfigMap{}
@@ -472,18 +461,7 @@ func TestReconcileCacheRace(t *testing.T) {
 	// Test subject
 	setupTestSubject(t, mgr)
 	mgr.Start(t)
-
-	// Any syn/comp will do since we faked out the synthesizer pod
-	syn := &apiv1.Synthesizer{}
-	syn.Name = "test-syn"
-	syn.Spec.Image = "create"
-	require.NoError(t, upstream.Create(ctx, syn))
-
-	comp := &apiv1.Composition{}
-	comp.Name = "test-comp"
-	comp.Namespace = "default"
-	comp.Spec.Synthesizer.Name = syn.Name
-	require.NoError(t, upstream.Create(ctx, comp))
+	syn, _ := writeGenericComposition(t, upstream)
 
 	// Wait for resource to be created
 	obj := &corev1.ConfigMap{}
@@ -541,18 +519,7 @@ func TestCompositionDeletionOrdering(t *testing.T) {
 	// Test subject
 	setupTestSubject(t, mgr)
 	mgr.Start(t)
-
-	// Any syn/comp will do since we faked out the synthesizer pod
-	syn := &apiv1.Synthesizer{}
-	syn.Name = "test-syn"
-	syn.Spec.Image = "create"
-	require.NoError(t, upstream.Create(ctx, syn))
-
-	comp := &apiv1.Composition{}
-	comp.Name = "test-comp"
-	comp.Namespace = "default"
-	comp.Spec.Synthesizer.Name = syn.Name
-	require.NoError(t, upstream.Create(ctx, comp))
+	_, comp := writeGenericComposition(t, upstream)
 
 	// Wait for resource to be created
 	obj := &corev1.ConfigMap{}
@@ -711,18 +678,7 @@ func TestDisableUpdates(t *testing.T) {
 	// Test subject
 	setupTestSubject(t, mgr)
 	mgr.Start(t)
-
-	// Any syn/comp will do since we faked out the synthesizer pod
-	syn := &apiv1.Synthesizer{}
-	syn.Name = "test-syn"
-	syn.Spec.Image = "create"
-	require.NoError(t, upstream.Create(ctx, syn))
-
-	comp := &apiv1.Composition{}
-	comp.Name = "test-comp"
-	comp.Namespace = "default"
-	comp.Spec.Synthesizer.Name = syn.Name
-	require.NoError(t, upstream.Create(ctx, comp))
+	writeGenericComposition(t, upstream)
 
 	// Wait for resource to be created
 	obj := &corev1.ConfigMap{}
@@ -774,18 +730,7 @@ func TestOrphanedCompositionDeletion(t *testing.T) {
 	// Test subject
 	setupTestSubject(t, mgr)
 	mgr.Start(t)
-
-	// Any syn/comp will do since we faked out the synthesizer pod
-	syn := &apiv1.Synthesizer{}
-	syn.Name = "test-syn"
-	syn.Spec.Image = "create"
-	require.NoError(t, upstream.Create(ctx, syn))
-
-	comp := &apiv1.Composition{}
-	comp.Name = "test-comp"
-	comp.Namespace = "default"
-	comp.Spec.Synthesizer.Name = syn.Name
-	require.NoError(t, upstream.Create(ctx, comp))
+	syn, comp := writeGenericComposition(t, upstream)
 
 	// Wait for composition to become ready
 	testutil.Eventually(t, func() bool {

--- a/internal/controllers/reconciliation/helpers_test.go
+++ b/internal/controllers/reconciliation/helpers_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Azure/eno/internal/controllers/replication"
 	"github.com/Azure/eno/internal/controllers/rollout"
 	"github.com/Azure/eno/internal/controllers/synthesis"
+	"github.com/Azure/eno/internal/controllers/watch"
 	"github.com/Azure/eno/internal/controllers/watchdog"
 	"github.com/Azure/eno/internal/testutil"
 	"github.com/stretchr/testify/require"
@@ -30,6 +31,7 @@ func registerControllers(t *testing.T, mgr *testutil.Manager) {
 	require.NoError(t, rollout.NewSynthesizerController(mgr.Manager))
 	require.NoError(t, flowcontrol.NewSynthesisConcurrencyLimiter(mgr.Manager, 10, 0))
 	require.NoError(t, liveness.NewNamespaceController(mgr.Manager))
+	require.NoError(t, watch.NewController(mgr.Manager))
 }
 
 func writeGenericComposition(t *testing.T, client client.Client) (*apiv1.Synthesizer, *apiv1.Composition) {

--- a/internal/controllers/reconciliation/ordering_test.go
+++ b/internal/controllers/reconciliation/ordering_test.go
@@ -215,3 +215,101 @@ func TestCRDOrdering(t *testing.T) {
 	val, _, _ := unstructured.NestedInt64(cr.Object, "spec", "addedValue")
 	assert.Equal(t, int64(234), val)
 }
+
+// TestInputMismatch proves that synthesis is not blocked by inputs with matching or missing revisions.
+func TestInputMismatch(t *testing.T) {
+	ctx := testutil.NewContext(t)
+	mgr := testutil.NewManager(t)
+	upstream := mgr.GetClient()
+
+	registerControllers(t, mgr)
+	testutil.WithFakeExecutor(t, mgr, func(ctx context.Context, s *apiv1.Synthesizer, input *krmv1.ResourceList) (*krmv1.ResourceList, error) {
+		output := &krmv1.ResourceList{}
+		output.Items = []*unstructured.Unstructured{{
+			Object: map[string]any{
+				"apiVersion": "v1",
+				"kind":       "ConfigMap",
+				"metadata": map[string]any{
+					"name":      "test-obj",
+					"namespace": "default",
+				},
+			},
+		}}
+		return output, nil
+	})
+
+	setupTestSubject(t, mgr)
+	mgr.Start(t)
+
+	cm1 := &corev1.ConfigMap{}
+	cm1.Name = "input1"
+	cm1.Namespace = "default"
+	cm1.Annotations = map[string]string{"eno.azure.io/revision": "123"}
+	require.NoError(t, upstream.Create(ctx, cm1))
+
+	cm2 := &corev1.ConfigMap{}
+	cm2.Name = "input2"
+	cm2.Namespace = "default"
+	cm2.Annotations = map[string]string{"eno.azure.io/revision": "123"}
+	require.NoError(t, upstream.Create(ctx, cm2))
+
+	cm3 := &corev1.ConfigMap{}
+	cm3.Name = "input3"
+	cm3.Namespace = "default"
+	cm3.Annotations = map[string]string{"eno.azure.io/not-revision": "the revision annotation is not set - this should be ignored"}
+	require.NoError(t, upstream.Create(ctx, cm3))
+
+	syn := &apiv1.Synthesizer{}
+	syn.Name = "test-syn"
+	syn.Spec.Image = "create"
+	syn.Spec.Refs = []apiv1.Ref{{
+		Key: "foo",
+		Resource: apiv1.ResourceRef{
+			Version: "v1",
+			Kind:    "ConfigMap",
+		},
+	}, {
+		Key: "bar",
+		Resource: apiv1.ResourceRef{
+			Version: "v1",
+			Kind:    "ConfigMap",
+		},
+	}, {
+		Key: "baz",
+		Resource: apiv1.ResourceRef{
+			Version: "v1",
+			Kind:    "ConfigMap",
+		},
+	}}
+	require.NoError(t, upstream.Create(ctx, syn))
+
+	comp := &apiv1.Composition{}
+	comp.Name = "test-comp"
+	comp.Namespace = "default"
+	comp.Spec.Synthesizer.Name = syn.Name
+	comp.Spec.Bindings = []apiv1.Binding{{
+		Key: "foo",
+		Resource: apiv1.ResourceBinding{
+			Name:      "input1",
+			Namespace: "default",
+		},
+	}, {
+		Key: "bar",
+		Resource: apiv1.ResourceBinding{
+			Name:      "input2",
+			Namespace: "default",
+		},
+	}, {
+		Key: "baz",
+		Resource: apiv1.ResourceBinding{
+			Name:      "input3",
+			Namespace: "default",
+		},
+	}}
+	require.NoError(t, upstream.Create(ctx, comp))
+
+	testutil.Eventually(t, func() bool {
+		err := upstream.Get(ctx, client.ObjectKeyFromObject(comp), comp)
+		return err == nil && comp.Status.CurrentSynthesis != nil && comp.Status.CurrentSynthesis.Synthesized != nil
+	})
+}

--- a/internal/controllers/reconciliation/rollout_test.go
+++ b/internal/controllers/reconciliation/rollout_test.go
@@ -6,22 +6,15 @@ import (
 	"testing"
 
 	apiv1 "github.com/Azure/eno/api/v1"
-	testv1 "github.com/Azure/eno/internal/controllers/reconciliation/fixtures/v1"
 	"github.com/Azure/eno/internal/testutil"
 	krmv1 "github.com/Azure/eno/pkg/krm/functions/api/v1"
 	"github.com/stretchr/testify/require"
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 func TestBulkRollout(t *testing.T) {
-	scheme := runtime.NewScheme()
-	corev1.SchemeBuilder.AddToScheme(scheme)
-	testv1.SchemeBuilder.AddToScheme(scheme)
-
 	ctx := testutil.NewContext(t)
 	mgr := testutil.NewManager(t)
 	upstream := mgr.GetClient()


### PR DESCRIPTION
It doesn't make sense to block synthesis when some inputs don't set a revision. If ordering isn't important, other controllers should be able to just omit the revisions.