### PR TITLE
Make sure that the rollout controller honors input revisions

### DIFF
--- a/internal/controllers/rollout/synthesizer.go
+++ b/internal/controllers/rollout/synthesizer.go
@@ -66,8 +66,14 @@ func (c *synthController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 		// - They are already on the latest version of the synthesizer
 		// - They are currently being synthesized or deleted
 		// - They are already pending resynthesis
-		// - They are already in sync with the latest inputs
-		if comp.Status.CurrentSynthesis == nil || comp.Status.CurrentSynthesis.Synthesized == nil || comp.DeletionTimestamp != nil || comp.Status.PendingResynthesis != nil || isInSync(&comp, syn) {
+		// - They are already in sync with the latest synth
+		// - Their input revisions are not in lockstep
+		if comp.Status.CurrentSynthesis == nil ||
+			comp.Status.CurrentSynthesis.Synthesized == nil ||
+			comp.DeletionTimestamp != nil ||
+			comp.Status.PendingResynthesis != nil ||
+			isInSync(&comp, syn) ||
+			comp.InputsMismatched(syn) {
 			continue
 		}
 


### PR DESCRIPTION
We should only roll out synthesizer changes to `Compositions` that are _ready_ to take them. This change ensures that we take into account the status of the bound inputs to compute the readiness.