### PR TITLE
Better orphan'd resource cleanup

### DIFF
--- a/cmd/eno-reconciler/main.go
+++ b/cmd/eno-reconciler/main.go
@@ -33,12 +33,13 @@ func main() {
 func run() error {
 	ctx := ctrl.SetupSignalHandler()
 	var (
-		writeBatchInterval   time.Duration
-		debugLogging         bool
-		remoteKubeconfigFile string
-		remoteQPS            float64
-		compositionSelector  string
-		compositionNamespace string
+		writeBatchInterval           time.Duration
+		debugLogging                 bool
+		remoteKubeconfigFile         string
+		remoteQPS                    float64
+		compositionSelector          string
+		compositionNamespace         string
+		namespaceCreationGracePeriod time.Duration
 
 		mgrOpts = &manager.Options{
 			Rest: ctrl.GetConfigOrDie(),
@@ -56,6 +57,7 @@ func run() error {
 	flag.DurationVar(&recOpts.ReadinessPollInterval, "readiness-poll-interval", time.Second*5, "Interval at which non-ready resources will be checked for readiness")
 	flag.StringVar(&compositionSelector, "composition-label-selector", labels.Everything().String(), "Optional label selector for compositions to be reconciled")
 	flag.StringVar(&compositionNamespace, "composition-namespace", metav1.NamespaceAll, "Optional namespace to limit compositions that will be reconciled")
+	flag.DurationVar(&namespaceCreationGracePeriod, "ns-creation-grace-period", time.Second, "A namespace is assumed to be missing if it doesn't exist once one of its resources has existed for this long")
 	mgrOpts.Bind(flag.CommandLine)
 	flag.Parse()
 
@@ -96,7 +98,7 @@ func run() error {
 		return fmt.Errorf("constructing resource slice cleanup controller: %w", err)
 	}
 
-	err = liveness.NewNamespaceController(mgr)
+	err = liveness.NewNamespaceController(mgr, namespaceCreationGracePeriod)
 	if err != nil {
 		return fmt.Errorf("constructing namespace liveness controller: %w", err)
 	}

--- a/docs/symphony.md
+++ b/docs/symphony.md
@@ -79,14 +79,3 @@ spec:
             name: a-different-input
             namespace: default
 ```
-
-## Deletion Behavior
-
-Symphonies are high-level resources designed to always converge, even in the face of rare split-brain states.
-
-Force deleting namespaces leaves resources in a strange state in which they exist but cannot be updated.
-Symphonies recover from this state by carefully recreating the namespace and forcibly removing internal finalizers.
-
-Because of this it's possible that managed resources will not be cleaned up if they exist outside of the orphaned namespace.
-Worst case, managed resources might be recreated by the Eno reconciler if it outpaces kube-controller-manager's namespace controller.
-Beware of this if you plan to use symphony resources to manage resources outside of the symphony's own namespace.

--- a/internal/controllers/liveness/namespace_test.go
+++ b/internal/controllers/liveness/namespace_test.go
@@ -2,6 +2,7 @@ package liveness
 
 import (
 	"testing"
+	"time"
 
 	apiv1 "github.com/Azure/eno/api/v1"
 	"github.com/Azure/eno/internal/testutil"
@@ -47,7 +48,7 @@ func testMissingNamespace(t *testing.T, orphan client.Object) {
 	mgr := testutil.NewManager(t, testutil.WithCompositionNamespace(ns.Name))
 	cli := mgr.GetClient()
 
-	require.NoError(t, NewNamespaceController(mgr.Manager))
+	require.NoError(t, NewNamespaceController(mgr.Manager, time.Millisecond*200))
 	mgr.Start(t)
 
 	require.NoError(t, cli.Create(ctx, ns))

--- a/internal/controllers/liveness/namespace_test.go
+++ b/internal/controllers/liveness/namespace_test.go
@@ -48,7 +48,7 @@ func testMissingNamespace(t *testing.T, orphan client.Object) {
 	mgr := testutil.NewManager(t, testutil.WithCompositionNamespace(ns.Name))
 	cli := mgr.GetClient()
 
-	require.NoError(t, NewNamespaceController(mgr.Manager, time.Millisecond*200))
+	require.NoError(t, NewNamespaceController(mgr.Manager, time.Second))
 	mgr.Start(t)
 
 	require.NoError(t, cli.Create(ctx, ns))

--- a/internal/controllers/reconciliation/helpers_test.go
+++ b/internal/controllers/reconciliation/helpers_test.go
@@ -30,7 +30,7 @@ func registerControllers(t *testing.T, mgr *testutil.Manager) {
 	require.NoError(t, rollout.NewController(mgr.Manager, time.Millisecond))
 	require.NoError(t, rollout.NewSynthesizerController(mgr.Manager))
 	require.NoError(t, flowcontrol.NewSynthesisConcurrencyLimiter(mgr.Manager, 10, 0))
-	require.NoError(t, liveness.NewNamespaceController(mgr.Manager))
+	require.NoError(t, liveness.NewNamespaceController(mgr.Manager, time.Millisecond*200))
 	require.NoError(t, watch.NewController(mgr.Manager))
 }
 

--- a/internal/controllers/reconciliation/helpers_test.go
+++ b/internal/controllers/reconciliation/helpers_test.go
@@ -30,7 +30,7 @@ func registerControllers(t *testing.T, mgr *testutil.Manager) {
 	require.NoError(t, rollout.NewController(mgr.Manager, time.Millisecond))
 	require.NoError(t, rollout.NewSynthesizerController(mgr.Manager))
 	require.NoError(t, flowcontrol.NewSynthesisConcurrencyLimiter(mgr.Manager, 10, 0))
-	require.NoError(t, liveness.NewNamespaceController(mgr.Manager, time.Millisecond*200))
+	require.NoError(t, liveness.NewNamespaceController(mgr.Manager, time.Second))
 	require.NoError(t, watch.NewController(mgr.Manager))
 }
 


### PR DESCRIPTION
Currently Eno will recreate missing namespaces in order to finish deleting any symphonies that still reference them. This behavior was symphony specific, which kind of makes sense given its role in the Eno ecosystem.

The problem is resources that _could in the future be_ related to a symphony, but are not yet. Specifically: resource slices. It's possible that synthesis was in-progress when the namespace was force-deleted, and that resource slices have been written but not yet associated with the composition.

I propose that we just enable the cleanup logic for all resources. There isn't any real reason for it to be exclusive to symphonies - just try to recreate the namespace any time it's still missing after 1 second.