### PR TITLE
Clean up Pods for compositions that no longer exist

### DIFF
--- a/internal/controllers/synthesis/lifecycle.go
+++ b/internal/controllers/synthesis/lifecycle.go
@@ -335,7 +335,7 @@ func (c *podLifecycleController) deletePod(ctx context.Context, comp types.Names
 			continue
 		}
 		err := c.client.Delete(ctx, &pod)
-		if err != nil {
+		if client.IgnoreNotFound(err) != nil {
 			return fmt.Errorf("deleting Pod %s: %w", pod.Name, err)
 		}
 		logger.V(0).Info("deleted synthesizer pod", "podName", pod.Name, "reason", "CompositionDoesNotExist")

--- a/internal/controllers/synthesis/lifecycle_test.go
+++ b/internal/controllers/synthesis/lifecycle_test.go
@@ -101,7 +101,7 @@ func TestCompositionDeletion(t *testing.T) {
 	})
 }
 
-func TestNonExistetnComposition(t *testing.T) {
+func TestNonExistentComposition(t *testing.T) {
 	ctx := testutil.NewContext(t)
 	mgr := testutil.NewManager(t)
 	cli := mgr.GetClient()
@@ -116,6 +116,10 @@ func TestNonExistetnComposition(t *testing.T) {
 		"eno.azure.io/composition-name":      "some-comp",
 		"eno.azure.io/composition-namespace": "default",
 	}
+	pod.Spec.Containers = []corev1.Container{{
+		Name:  "executor",
+		Image: "some-image-tag",
+	}}
 	pnn := client.ObjectKeyFromObject(pod)
 
 	require.NoError(t, cli.Create(ctx, pod))

--- a/internal/controllers/synthesis/lifecycle_test.go
+++ b/internal/controllers/synthesis/lifecycle_test.go
@@ -101,6 +101,30 @@ func TestCompositionDeletion(t *testing.T) {
 	})
 }
 
+func TestNonExistetnComposition(t *testing.T) {
+	ctx := testutil.NewContext(t)
+	mgr := testutil.NewManager(t)
+	cli := mgr.GetClient()
+
+	require.NoError(t, NewPodLifecycleController(mgr.Manager, minimalTestConfig))
+	mgr.Start(t)
+
+	pod := &corev1.Pod{}
+	pod.Name = "some-synthesis-pod"
+	pod.Namespace = "default"
+	pod.Labels = map[string]string{
+		"eno.azure.io/composition-name":      "some-comp",
+		"eno.azure.io/composition-namespace": "default",
+	}
+	pnn := client.ObjectKeyFromObject(pod)
+
+	require.NoError(t, cli.Create(ctx, pod))
+	testutil.Eventually(t, func() bool {
+		err := cli.Get(ctx, pnn, pod)
+		return errors.IsNotFound(err)
+	})
+}
+
 var shouldDeletePodTests = []struct {
 	Name               string
 	Pods               []corev1.Pod

--- a/internal/manager/indices.go
+++ b/internal/manager/indices.go
@@ -59,6 +59,10 @@ func PodByCompIdxValueFromComp(comp client.Object) string {
 	return comp.GetName() + "/" + comp.GetNamespace()
 }
 
+func PodByCompIdxValueFromNamespacedName(nn types.NamespacedName) string {
+	return nn.Name + "/" + nn.Namespace
+}
+
 func indexController() client.IndexerFunc {
 	return func(o client.Object) []string {
 		owner := metav1.GetControllerOf(o)


### PR DESCRIPTION
We should clean up Pods if compositions no longer exist. This scenario is possible if Comps are force deleted without honoring finalizers.