### PR TITLE
Made sure that negative latency is not commited to logs

### DIFF
--- a/internal/controllers/aggregation/slice.go
+++ b/internal/controllers/aggregation/slice.go
@@ -98,7 +98,9 @@ func (s *sliceController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 
 		if synthed := comp.Status.CurrentSynthesis.Synthesized; synthed != nil {
 			latency := maxReadyTime.Sub(synthed.Time)
-			logger.V(0).Info("composition became ready", "latency", latency.Milliseconds())
+			if latency.Milliseconds() > 0 {
+				logger.V(0).Info("composition became ready", "latency", latency.Milliseconds())
+			}
 		}
 	} else {
 		comp.Status.CurrentSynthesis.Ready = nil


### PR DESCRIPTION
It does produce some weird artifacts like having 2 different latency items to be put into the logs that are usually “twins” such as the 68K, below . Along with the number always being “round” ending in XY,000’s.
 
Removing latency that are negative when having multiple compositions being deleted at the same time 