### PR TITLE
Avoid unnecessary resynthesis when using revision annotations

### DIFF
--- a/api/v1/composition.go
+++ b/api/v1/composition.go
@@ -1,6 +1,8 @@
 package v1
 
 import (
+	"fmt"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -129,6 +131,13 @@ func (i *InputRevisions) Equal(b InputRevisions) bool {
 		return *i.Revision == *b.Revision
 	}
 	return i.ResourceVersion == b.ResourceVersion
+}
+
+func (i *InputRevisions) String() string {
+	if i.Revision != nil {
+		return fmt.Sprintf("revision=%d", i.Revision)
+	}
+	return fmt.Sprintf("resourceVersion=%s", i.ResourceVersion)
 }
 
 func (s *Synthesis) Failed() bool {

--- a/api/v1/composition_test.go
+++ b/api/v1/composition_test.go
@@ -101,6 +101,20 @@ func TestInputRevisionsEqual(t *testing.T) {
 			},
 			Expectation: false,
 		},
+		{
+			Name: "Same Revision, different ResourceVersion",
+			A: InputRevisions{
+				Key:             "key7",
+				Revision:        &revision1,
+				ResourceVersion: "v7",
+			},
+			B: InputRevisions{
+				Key:             "key7",
+				Revision:        &revision1,
+				ResourceVersion: "v8",
+			},
+			Expectation: false,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/controllers/reconciliation/ordering_test.go
+++ b/internal/controllers/reconciliation/ordering_test.go
@@ -7,6 +7,7 @@ import (
 	"slices"
 	"strconv"
 	"testing"
+	"time"
 
 	apiv1 "github.com/Azure/eno/api/v1"
 	testv1 "github.com/Azure/eno/internal/controllers/reconciliation/fixtures/v1"
@@ -398,4 +399,75 @@ func TestInputSynthesizerOrdering(t *testing.T) {
 		return err == nil && comp.Status.CurrentSynthesis != nil && comp.Status.CurrentSynthesis.Synthesized != nil
 	})
 	assert.Equal(t, input.ResourceVersion, comp.Status.InputRevisions[0].ResourceVersion)
+}
+
+func TestInputRevisionDebounce(t *testing.T) {
+	ctx := testutil.NewContext(t)
+	mgr := testutil.NewManager(t)
+	upstream := mgr.GetClient()
+
+	registerControllers(t, mgr)
+	testutil.WithFakeExecutor(t, mgr, func(ctx context.Context, s *apiv1.Synthesizer, input *krmv1.ResourceList) (*krmv1.ResourceList, error) {
+		output := &krmv1.ResourceList{}
+		output.Items = []*unstructured.Unstructured{{
+			Object: map[string]any{
+				"apiVersion": "v1",
+				"kind":       "ConfigMap",
+				"metadata": map[string]any{
+					"name":      "test-obj",
+					"namespace": "default",
+				},
+			},
+		}}
+		return output, nil
+	})
+
+	setupTestSubject(t, mgr)
+	mgr.Start(t)
+
+	input := &corev1.ConfigMap{}
+	input.Name = "input1"
+	input.Namespace = "default"
+	input.Annotations = map[string]string{"eno.azure.io/revision": "9001"}
+	require.NoError(t, upstream.Create(ctx, input))
+
+	syn := &apiv1.Synthesizer{}
+	syn.Name = "test-syn"
+	syn.Spec.Image = "create"
+	syn.Spec.Refs = []apiv1.Ref{{
+		Key: "foo",
+		Resource: apiv1.ResourceRef{
+			Version: "v1",
+			Kind:    "ConfigMap",
+		},
+	}}
+	require.NoError(t, upstream.Create(ctx, syn))
+
+	comp := &apiv1.Composition{}
+	comp.Name = "test-comp"
+	comp.Namespace = "default"
+	comp.Spec.Synthesizer.Name = syn.Name
+	comp.Spec.Bindings = []apiv1.Binding{{
+		Key: "foo",
+		Resource: apiv1.ResourceBinding{
+			Name:      "input1",
+			Namespace: "default",
+		},
+	}}
+	require.NoError(t, upstream.Create(ctx, comp))
+
+	// Wait for initial synthesis
+	testutil.Eventually(t, func() bool {
+		err := upstream.Get(ctx, client.ObjectKeyFromObject(comp), comp)
+		return err == nil && (comp.Status.CurrentSynthesis != nil && comp.Status.CurrentSynthesis.Synthesized != nil)
+	})
+
+	// Increment the input's resource version
+	input.Annotations["foo"] = "bar"
+	require.NoError(t, upstream.Update(ctx, input))
+
+	// It doesn't resynthesize
+	time.Sleep(time.Millisecond * 50)
+	require.NoError(t, upstream.Get(ctx, client.ObjectKeyFromObject(comp), comp))
+	assert.Nil(t, comp.Status.PreviousSynthesis)
 }

--- a/internal/controllers/watch/kind.go
+++ b/internal/controllers/watch/kind.go
@@ -21,7 +21,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
-	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 )
@@ -99,7 +98,7 @@ func (k *KindWatchController) newResourceWatchController(parent *WatchController
 			}
 
 			return k.buildRequests(synth, *comp)
-		})), &predicate.TypedGenerationChangedPredicate[*apiv1.Composition]{}))
+		}))))
 	if err != nil {
 		return nil, err
 	}
@@ -115,7 +114,7 @@ func (k *KindWatchController) newResourceWatchController(parent *WatchController
 			}
 
 			return k.buildRequests(synth, compList.Items...)
-		})), &predicate.TypedGenerationChangedPredicate[*apiv1.Synthesizer]{}))
+		}))))
 	if err != nil {
 		return nil, err
 	}

--- a/internal/controllers/watch/kind.go
+++ b/internal/controllers/watch/kind.go
@@ -21,6 +21,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 )
@@ -98,7 +99,7 @@ func (k *KindWatchController) newResourceWatchController(parent *WatchController
 			}
 
 			return k.buildRequests(synth, *comp)
-		}))))
+		})), &predicate.TypedGenerationChangedPredicate[*apiv1.Composition]{}))
 	if err != nil {
 		return nil, err
 	}
@@ -114,7 +115,7 @@ func (k *KindWatchController) newResourceWatchController(parent *WatchController
 			}
 
 			return k.buildRequests(synth, compList.Items...)
-		}))))
+		})), &predicate.TypedGenerationChangedPredicate[*apiv1.Synthesizer]{}))
 	if err != nil {
 		return nil, err
 	}
@@ -209,7 +210,7 @@ func (k *KindWatchController) Reconcile(ctx context.Context, req ctrl.Request) (
 			if err != nil {
 				return ctrl.Result{}, fmt.Errorf("updating input revisions: %w", err)
 			}
-			logger.V(0).Info("noticed input resource change", "compositionName", comp.Name, "compositionNamespace", comp.Namespace, "ref", key, "deferred", deferred)
+			logger.V(0).Info("noticed input resource change", "compositionName", comp.Name, "compositionNamespace", comp.Namespace, "ref", key, "deferred", deferred, "revisions", revs)
 			return ctrl.Result{}, nil // wait for requeue
 		}
 	}


### PR DESCRIPTION
Currently the revision annotations only block synthesis __until all inputs match__. Once they match, any change to the resource version will result in resynthesis.

Intuitively, I expect the revision annotation to take precedence over the resource version. Meaning that the input is not considered to have changed unless the revision is modified. I suspect others will assume the same.

This has a nice side effect: revisions can be used to filter out input status updates which are unlikely to result in meaningful resynthesis.