### PR TITLE
Avoid assignments to nil maps when coalescing metadata

### DIFF
--- a/internal/controllers/replication/symphony.go
+++ b/internal/controllers/replication/symphony.go
@@ -265,13 +265,21 @@ func sortSynthesizerRefs(refs []apiv1.SynthesizerRef) {
 func coalesceMetadata(variation *apiv1.Variation, existing *apiv1.Composition) bool {
 	var metaChanged bool
 	for key, val := range variation.Labels {
-		if existing.Labels == nil || existing.Labels[key] != val {
+		if existing.Labels == nil {
+			existing.Labels = map[string]string{}
+			metaChanged = true
+		}
+		if existing.Labels[key] != val {
 			metaChanged = true
 		}
 		existing.Labels[key] = val
 	}
 	for key, val := range variation.Annotations {
-		if existing.Annotations == nil || existing.Annotations[key] != val {
+		if existing.Annotations == nil {
+			existing.Annotations = map[string]string{}
+			metaChanged = true
+		}
+		if existing.Annotations[key] != val {
 			metaChanged = true
 		}
 		existing.Annotations[key] = val

--- a/internal/controllers/replication/symphony.go
+++ b/internal/controllers/replication/symphony.go
@@ -264,21 +264,21 @@ func sortSynthesizerRefs(refs []apiv1.SynthesizerRef) {
 
 func coalesceMetadata(variation *apiv1.Variation, existing *apiv1.Composition) bool {
 	var metaChanged bool
+
+	if existing.Labels == nil {
+		existing.Labels = map[string]string{}
+	}
 	for key, val := range variation.Labels {
-		if existing.Labels == nil {
-			existing.Labels = map[string]string{}
-			metaChanged = true
-		}
 		if existing.Labels[key] != val {
 			metaChanged = true
 		}
 		existing.Labels[key] = val
 	}
+
+	if existing.Annotations == nil {
+		existing.Annotations = map[string]string{}
+	}
 	for key, val := range variation.Annotations {
-		if existing.Annotations == nil {
-			existing.Annotations = map[string]string{}
-			metaChanged = true
-		}
 		if existing.Annotations[key] != val {
 			metaChanged = true
 		}

--- a/internal/controllers/replication/symphony_test.go
+++ b/internal/controllers/replication/symphony_test.go
@@ -314,15 +314,12 @@ func TestCoalesceMetadata(t *testing.T) {
 				Annotations: map[string]string{},
 			},
 			existing: &apiv1.Composition{
-				ObjectMeta: metav1.ObjectMeta{
-					Labels:      map[string]string{},
-					Annotations: map[string]string{},
-				},
+				ObjectMeta: metav1.ObjectMeta{},
 			},
 			expectedLabels: map[string]string{
 				"label1": "value1",
 			},
-			expectedAnnos:  map[string]string{},
+			expectedAnnos:  nil,
 			expectedChange: true,
 		},
 		{
@@ -356,12 +353,9 @@ func TestCoalesceMetadata(t *testing.T) {
 				},
 			},
 			existing: &apiv1.Composition{
-				ObjectMeta: metav1.ObjectMeta{
-					Labels:      map[string]string{},
-					Annotations: map[string]string{},
-				},
+				ObjectMeta: metav1.ObjectMeta{},
 			},
-			expectedLabels: map[string]string{},
+			expectedLabels: nil,
 			expectedAnnos: map[string]string{
 				"anno1": "value1",
 			},

--- a/internal/controllers/replication/symphony_test.go
+++ b/internal/controllers/replication/symphony_test.go
@@ -319,7 +319,7 @@ func TestCoalesceMetadata(t *testing.T) {
 			expectedLabels: map[string]string{
 				"label1": "value1",
 			},
-			expectedAnnos:  nil,
+			expectedAnnos:  map[string]string{},
 			expectedChange: true,
 		},
 		{
@@ -355,7 +355,7 @@ func TestCoalesceMetadata(t *testing.T) {
 			existing: &apiv1.Composition{
 				ObjectMeta: metav1.ObjectMeta{},
 			},
-			expectedLabels: nil,
+			expectedLabels: map[string]string{},
 			expectedAnnos: map[string]string{
 				"anno1": "value1",
 			},


### PR DESCRIPTION
Initialize the maps when they're nil.