### PR TITLE
Fix input revision comparison bug

### DIFF
--- a/api/v1/composition.go
+++ b/api/v1/composition.go
@@ -167,7 +167,8 @@ func (c *Composition) InputsExist(syn *Synthesizer) bool {
 	return true
 }
 
-func (c *Composition) InputsMismatched(synth *Synthesizer) bool {
+// InputsInLockstep returns false when one or more inputs that specify a revision do not match the others.
+func (c *Composition) InputsInLockstep(synth *Synthesizer) bool {
 	// First, the the max revision across all bindings
 	var maxRevision *int
 	for _, rev := range c.Status.InputRevisions {

--- a/api/v1/composition_test.go
+++ b/api/v1/composition_test.go
@@ -267,7 +267,7 @@ func TestCompositionInputsExist(t *testing.T) {
 	}
 }
 
-func TestInputsMismatched(t *testing.T) {
+func TestInputsInLockstep(t *testing.T) {
 	revision1 := 1
 	revision2 := 2
 
@@ -402,7 +402,7 @@ func TestInputsMismatched(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.Name, func(t *testing.T) {
-			result := tt.Input.InputsMismatched(&tt.Synth)
+			result := tt.Input.InputsInLockstep(&tt.Synth)
 			assert.Equal(t, tt.Expectation, result)
 		})
 	}

--- a/internal/controllers/aggregation/composition.go
+++ b/internal/controllers/aggregation/composition.go
@@ -111,7 +111,7 @@ func (c *compositionController) aggregate(synth *apiv1.Synthesizer, comp *apiv1.
 	if comp.Status.PendingResynthesis != nil {
 		copy.Status = "WaitingForCooldown"
 	}
-	if comp.InputsMismatched(synth) {
+	if comp.InputsInLockstep(synth) {
 		copy.Status = "MismatchedInputs"
 	}
 

--- a/internal/controllers/rollout/synthesizer.go
+++ b/internal/controllers/rollout/synthesizer.go
@@ -77,7 +77,7 @@ func (c *synthController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 			comp.DeletionTimestamp != nil ||
 			comp.Status.PendingResynthesis != nil ||
 			isInSync(&comp, syn) ||
-			comp.InputsMismatched(syn) ||
+			comp.InputsInLockstep(syn) ||
 			comp.ShouldIgnoreSideEffects() {
 			continue
 		}

--- a/internal/controllers/synthesis/lifecycle.go
+++ b/internal/controllers/synthesis/lifecycle.go
@@ -406,6 +406,9 @@ func inputRevisionsEqual(synth *apiv1.Synthesizer, a, b []apiv1.InputRevisions) 
 		refsByKey[ref.Key] = ref
 	}
 
+	// It's important that ordering isn't strict since input revisions may
+	// either be ordered by the corresponding refs, or appended to the slice
+	// as they are discovered by the watch controller
 	sort.Slice(a, func(i, j int) bool { return a[i].Key < a[j].Key })
 	sort.Slice(b, func(i, j int) bool { return b[i].Key < b[j].Key })
 

--- a/internal/controllers/synthesis/lifecycle.go
+++ b/internal/controllers/synthesis/lifecycle.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"sort"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -404,6 +405,9 @@ func inputRevisionsEqual(synth *apiv1.Synthesizer, a, b []apiv1.InputRevisions) 
 		ref := ref
 		refsByKey[ref.Key] = ref
 	}
+
+	sort.Slice(a, func(i, j int) bool { return a[i].Key < a[j].Key })
+	sort.Slice(b, func(i, j int) bool { return b[i].Key < b[j].Key })
 
 	var equal int
 	for _, ar := range a {

--- a/internal/controllers/synthesis/lifecycle.go
+++ b/internal/controllers/synthesis/lifecycle.go
@@ -373,7 +373,7 @@ func shouldSwapStates(synth *apiv1.Synthesizer, comp *apiv1.Composition) bool {
 	return (syn == nil ||
 		syn.ObservedCompositionGeneration != comp.Generation ||
 		(!inputRevisionsEqual(synth, comp.Status.InputRevisions, syn.InputRevisions) && syn.Synthesized != nil && !comp.ShouldIgnoreSideEffects())) &&
-		(comp.DeletionTimestamp != nil || (comp.InputsExist(synth) && !comp.InputsMismatched(synth)))
+		(comp.DeletionTimestamp != nil || (comp.InputsExist(synth) && !comp.InputsInLockstep(synth)))
 }
 
 func shouldBackOffPodCreation(comp *apiv1.Composition) bool {

--- a/internal/controllers/synthesis/lifecycle_test.go
+++ b/internal/controllers/synthesis/lifecycle_test.go
@@ -683,3 +683,14 @@ func TestInputRevisionsEqual(t *testing.T) {
 	assert.True(t, inputRevisionsEqual(synth, []apiv1.InputRevisions{{Key: "bar"}}, []apiv1.InputRevisions{{Key: "bar", ResourceVersion: "not-zero"}}))
 	assert.False(t, inputRevisionsEqual(synth, []apiv1.InputRevisions{{Key: "foo"}}, []apiv1.InputRevisions{{Key: "bar"}}))
 }
+
+func TestInputRevisionsEqualOrdering(t *testing.T) {
+	synth := &apiv1.Synthesizer{}
+	synth.Spec.Refs = []apiv1.Ref{{Key: "foo"}, {Key: "bar"}}
+
+	assert.True(t, inputRevisionsEqual(synth, []apiv1.InputRevisions{
+		{Key: "bar"}, {Key: "foo"},
+	}, []apiv1.InputRevisions{
+		{Key: "foo"}, {Key: "bar"},
+	}))
+}


### PR DESCRIPTION
Values are appended the status.inputRevisions slice [as they're discovered](https://github.com/Azure/eno/blob/1529fc2aeaac61a4d19e8471caf44e739f03c25d/internal/controllers/watch/kind.go#L250), but corresponding values are appended to `status.currentSynthesis.inputRevisions` [by the order of their refs](https://github.com/Azure/eno/blob/1529fc2aeaac61a4d19e8471caf44e739f03c25d/internal/execution/executor.go#L109). 

So compositions will enter a synthesis loop if inputs aren't seen by the watch controller in the same order that they're defined as refs.

This can be fixed easily by ignoring order, it wasn't significant anyway. The PR also renames `InputsMismatched` since I found the naming to be... opaque in retrospect.