### PR TITLE
Misc. slice cleanup bugfix

### DIFF
--- a/internal/controllers/synthesis/slicecleanup.go
+++ b/internal/controllers/synthesis/slicecleanup.go
@@ -98,7 +98,7 @@ func shouldDeleteSlice(comp *apiv1.Composition, slice *apiv1.ResourceSlice) bool
 	}
 
 	var (
-		hasBeenRetried     = slice.Spec.Attempt != 0 && comp.Status.CurrentSynthesis.Attempts > slice.Spec.Attempt
+		hasBeenRetried     = slice.Spec.Attempt != 0 && comp.Status.CurrentSynthesis.Attempts > slice.Spec.Attempt && slice.Spec.SynthesisUUID == comp.Status.CurrentSynthesis.UUID
 		isReferencedByComp = synthesisReferencesSlice(comp.Status.CurrentSynthesis, slice) || synthesisReferencesSlice(comp.Status.PreviousSynthesis, slice)
 		isSynthesized      = comp.Status.CurrentSynthesis.Synthesized != nil
 		compIsDeleted      = comp.DeletionTimestamp != nil
@@ -106,7 +106,7 @@ func shouldDeleteSlice(comp *apiv1.Composition, slice *apiv1.ResourceSlice) bool
 	)
 
 	// We can only safely delete resource slices when either:
-	// - Another retry of the same synthesis has already started (TODO)
+	// - Another retry of the same synthesis has already started
 	// - Synthesis is complete and the composition is being deleted
 	// - The slice was derived from an older composition
 	return hasBeenRetried || (isSynthesized && compIsDeleted) || (!isReferencedByComp && fromOldComposition)

--- a/internal/controllers/synthesis/slicecleanup.go
+++ b/internal/controllers/synthesis/slicecleanup.go
@@ -96,13 +96,20 @@ func shouldDeleteSlice(comp *apiv1.Composition, slice *apiv1.ResourceSlice) bool
 	if comp.Status.CurrentSynthesis == nil || slice.Spec.CompositionGeneration > comp.Status.CurrentSynthesis.ObservedCompositionGeneration {
 		return false // stale informer
 	}
-	hasBeenRetried := slice.Spec.Attempt != 0 && comp.Status.CurrentSynthesis != nil && comp.Status.CurrentSynthesis.Attempts > slice.Spec.Attempt
-	isReferencedByComp := synthesisReferencesSlice(comp.Status.CurrentSynthesis, slice) || synthesisReferencesSlice(comp.Status.PreviousSynthesis, slice)
-	isSynthesized := comp.Status.CurrentSynthesis != nil && comp.Status.CurrentSynthesis.Synthesized != nil
-	compIsDeleted := comp.DeletionTimestamp != nil
-	fromOldComposition := slice.Spec.CompositionGeneration < comp.Generation
-	fromOldSynthesis := comp.Status.CurrentSynthesis != nil && comp.Status.CurrentSynthesis.UUID != slice.Spec.SynthesisUUID
-	return hasBeenRetried || (isSynthesized && compIsDeleted) || (!isReferencedByComp && fromOldComposition && fromOldSynthesis)
+
+	var (
+		hasBeenRetried     = slice.Spec.Attempt != 0 && comp.Status.CurrentSynthesis.Attempts > slice.Spec.Attempt
+		isReferencedByComp = synthesisReferencesSlice(comp.Status.CurrentSynthesis, slice) || synthesisReferencesSlice(comp.Status.PreviousSynthesis, slice)
+		isSynthesized      = comp.Status.CurrentSynthesis.Synthesized != nil
+		compIsDeleted      = comp.DeletionTimestamp != nil
+		fromOldComposition = slice.Spec.CompositionGeneration < comp.Status.CurrentSynthesis.ObservedCompositionGeneration
+	)
+
+	// We can only safely delete resource slices when either:
+	// - Another retry of the same synthesis has already started (TODO)
+	// - Synthesis is complete and the composition is being deleted
+	// - The slice was derived from an older composition
+	return hasBeenRetried || (isSynthesized && compIsDeleted) || (!isReferencedByComp && fromOldComposition)
 }
 
 func shouldReleaseSliceFinalizer(comp *apiv1.Composition, slice *apiv1.ResourceSlice) bool {

--- a/internal/controllers/synthesis/slicecleanup_test.go
+++ b/internal/controllers/synthesis/slicecleanup_test.go
@@ -95,7 +95,30 @@ func TestShouldDeleteSlice(t *testing.T) {
 			expected: false,
 		},
 		{
-			name: "slice is outdated",
+			name: "another attempt started for a different synthesis, old one still references the slice",
+			comp: &apiv1.Composition{
+				Status: apiv1.CompositionStatus{
+					CurrentSynthesis: &apiv1.Synthesis{
+						Attempts: 5,
+						UUID:     "the-next-one",
+					},
+					PreviousSynthesis: &apiv1.Synthesis{
+						ResourceSlices: []*apiv1.ResourceSliceRef{{Name: "test-slice"}},
+					},
+				},
+			},
+			slice: &apiv1.ResourceSlice{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-slice",
+				},
+				Spec: apiv1.ResourceSliceSpec{
+					Attempt: 3,
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "another attempt started for the same synthesis",
 			comp: &apiv1.Composition{
 				Status: apiv1.CompositionStatus{
 					CurrentSynthesis: &apiv1.Synthesis{

--- a/internal/controllers/synthesis/slicecleanup_test.go
+++ b/internal/controllers/synthesis/slicecleanup_test.go
@@ -192,12 +192,12 @@ func TestShouldDeleteSlice(t *testing.T) {
 			name: "synthesis terminated, newer composition generation, different synthesis",
 			comp: &apiv1.Composition{
 				ObjectMeta: metav1.ObjectMeta{
-					Generation: 2,
+					Generation: 3,
 				},
 				Status: apiv1.CompositionStatus{
 					CurrentSynthesis: &apiv1.Synthesis{
 						Synthesized:                   &metav1.Time{Time: time.Now()},
-						ObservedCompositionGeneration: 1,
+						ObservedCompositionGeneration: 2,
 					},
 				},
 			},
@@ -214,11 +214,11 @@ func TestShouldDeleteSlice(t *testing.T) {
 			name: "synthesis in-progress, newer composition generation, different synthesis",
 			comp: &apiv1.Composition{
 				ObjectMeta: metav1.ObjectMeta{
-					Generation: 2,
+					Generation: 3,
 				},
 				Status: apiv1.CompositionStatus{
 					CurrentSynthesis: &apiv1.Synthesis{
-						ObservedCompositionGeneration: 1,
+						ObservedCompositionGeneration: 2,
 					},
 				},
 			},


### PR DESCRIPTION
There are two cases where the slice cleanup logic deletes slices that are still in-use:

- The current synthesis has made more retry attempts than was required when synthesizing the slices referenced by the previous one
- The composition's generation has been incremented but a new synthesis has not yet been written

This PR fixes both cases and carefully refactors the code.