### PR TITLE
Fix input revision comparison when some inputs are deferreed

### DIFF
--- a/internal/controllers/synthesis/lifecycle.go
+++ b/internal/controllers/synthesis/lifecycle.go
@@ -413,16 +413,15 @@ func inputRevisionsEqual(synth *apiv1.Synthesizer, a, b []apiv1.InputRevisions) 
 	sort.Slice(b, func(i, j int) bool { return b[i].Key < b[j].Key })
 
 	var equal int
-	for _, ar := range a {
-		for _, br := range b {
-			if ref, exists := refsByKey[ar.Key]; exists && ref.Defer {
-				equal++
-				continue // ignore deferred inputs
-			}
+	for i, ar := range a {
+		br := b[i]
+		if ref, exists := refsByKey[ar.Key]; exists && ref.Defer {
+			equal++
+			continue // ignore deferred inputs
+		}
 
-			if ar.Equal(br) {
-				equal++
-			}
+		if ar.Equal(br) {
+			equal++
 		}
 	}
 

--- a/internal/controllers/synthesis/lifecycle_test.go
+++ b/internal/controllers/synthesis/lifecycle_test.go
@@ -674,14 +674,75 @@ func TestShouldSwapStates(t *testing.T) {
 
 func TestInputRevisionsEqual(t *testing.T) {
 	synth := &apiv1.Synthesizer{}
-	synth.Spec.Refs = []apiv1.Ref{{Key: "foo"}, {Key: "bar", Defer: true}}
+	synth.Spec.Refs = []apiv1.Ref{{Key: "foo"}, {Key: "bar", Defer: true}, {Key: "baz"}}
 
-	assert.True(t, inputRevisionsEqual(synth, []apiv1.InputRevisions{{Key: "foo"}}, []apiv1.InputRevisions{{Key: "foo"}}))
-	assert.False(t, inputRevisionsEqual(synth, []apiv1.InputRevisions{{Key: "foo"}}, []apiv1.InputRevisions{{Key: "foo", ResourceVersion: "not-zero"}}))
-	assert.False(t, inputRevisionsEqual(synth, []apiv1.InputRevisions{{Key: "foo"}}, []apiv1.InputRevisions{{Key: "foo", Revision: ptr.To(123)}}))
-	assert.False(t, inputRevisionsEqual(synth, []apiv1.InputRevisions{{Key: "foo", Revision: ptr.To(234)}}, []apiv1.InputRevisions{{Key: "foo", Revision: ptr.To(123)}}))
-	assert.True(t, inputRevisionsEqual(synth, []apiv1.InputRevisions{{Key: "bar"}}, []apiv1.InputRevisions{{Key: "bar", ResourceVersion: "not-zero"}}))
-	assert.False(t, inputRevisionsEqual(synth, []apiv1.InputRevisions{{Key: "foo"}}, []apiv1.InputRevisions{{Key: "bar"}}))
+	tcs := []struct {
+		name  string
+		a, b  []apiv1.InputRevisions
+		equal bool
+	}{
+		{
+			name:  "just keys",
+			a:     []apiv1.InputRevisions{{Key: "foo"}, {Key: "baz"}},
+			b:     []apiv1.InputRevisions{{Key: "foo"}, {Key: "baz"}},
+			equal: true,
+		},
+		{
+			name:  "resource version mismatch",
+			a:     []apiv1.InputRevisions{{Key: "foo"}, {Key: "baz"}},
+			b:     []apiv1.InputRevisions{{Key: "foo", ResourceVersion: "not-zero"}, {Key: "baz"}},
+			equal: false,
+		},
+		{
+			name:  "revision missong",
+			a:     []apiv1.InputRevisions{{Key: "foo"}, {Key: "baz"}},
+			b:     []apiv1.InputRevisions{{Key: "foo", Revision: ptr.To(123)}, {Key: "baz"}},
+			equal: false,
+		},
+		{
+			name:  "revision mismatch",
+			a:     []apiv1.InputRevisions{{Key: "foo", Revision: ptr.To(234)}, {Key: "baz"}},
+			b:     []apiv1.InputRevisions{{Key: "foo", Revision: ptr.To(123)}, {Key: "baz"}},
+			equal: false,
+		},
+		{
+			name:  "revision match",
+			a:     []apiv1.InputRevisions{{Key: "foo", Revision: ptr.To(123)}, {Key: "baz"}},
+			b:     []apiv1.InputRevisions{{Key: "foo", Revision: ptr.To(123)}, {Key: "baz"}},
+			equal: true,
+		},
+		{
+			name:  "resource version match",
+			a:     []apiv1.InputRevisions{{Key: "foo", ResourceVersion: "not-zero"}, {Key: "baz"}},
+			b:     []apiv1.InputRevisions{{Key: "foo", ResourceVersion: "not-zero"}, {Key: "baz"}},
+			equal: true,
+		},
+		{
+			name:  "mixed resource version and revision",
+			a:     []apiv1.InputRevisions{{Key: "foo", ResourceVersion: "not-zero"}, {Key: "baz"}},
+			b:     []apiv1.InputRevisions{{Key: "foo", Revision: ptr.To(123)}, {Key: "baz"}},
+			equal: false,
+		},
+		{
+			name:  "ignore deferred",
+			a:     []apiv1.InputRevisions{{Key: "foo"}, {Key: "bar"}, {Key: "baz"}},
+			b:     []apiv1.InputRevisions{{Key: "foo"}, {Key: "bar", ResourceVersion: "not-zero"}, {Key: "baz"}},
+			equal: true,
+		},
+		{
+			name:  "mismatched items with deferred",
+			a:     []apiv1.InputRevisions{{Key: "foo"}, {Key: "baz"}},
+			b:     []apiv1.InputRevisions{{Key: "bar"}, {Key: "baz"}},
+			equal: false,
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.equal, inputRevisionsEqual(synth, tc.a, tc.b))
+		})
+	}
+
 }
 
 func TestInputRevisionsEqualOrdering(t *testing.T) {


### PR DESCRIPTION
Currently deferred inputs will cause `equal` to be > len(a)