### PR TITLE
Handle kubelet partitions

### DIFF
--- a/cmd/eno-controller/main.go
+++ b/cmd/eno-controller/main.go
@@ -65,6 +65,7 @@ func runController() error {
 	flag.StringVar(&synconf.PodNamespace, "synthesizer-pod-namespace", os.Getenv("POD_NAMESPACE"), "Namespace to create synthesizer pods in. Defaults to POD_NAMESPACE.")
 	flag.StringVar(&synconf.ExecutorImage, "executor-image", os.Getenv("EXECUTOR_IMAGE"), "Reference to the image that will be used to execute synthesizers. Defaults to EXECUTOR_IMAGE.")
 	flag.StringVar(&synconf.PodServiceAccount, "synthesizer-pod-service-account", "", "Service account name to be assigned to synthesizer Pods.")
+	flag.DurationVar(&synconf.ContainerCreationTimeout, "container-creation-ttl", time.Second*3, "Timeout when waiting for kubelet to ack scheduled pods. Protects tail latency from kubelet network partitions")
 	flag.BoolVar(&debugLogging, "debug", true, "Enable debug logging")
 	flag.DurationVar(&watchdogThres, "watchdog-threshold", time.Minute*5, "How long before the watchdog considers a mid-transition resource to be stuck")
 	flag.DurationVar(&rolloutCooldown, "rollout-cooldown", time.Minute, "How long before an update to a related resource (synthesizer, bindings, etc.) will trigger a second composition's re-synthesis")

--- a/internal/controllers/synthesis/lifecycle.go
+++ b/internal/controllers/synthesis/lifecycle.go
@@ -33,6 +33,8 @@ type Config struct {
 
 	NodeAffinityKey   string
 	NodeAffinityValue string
+
+	ContainerCreationTimeout time.Duration
 }
 
 type podLifecycleController struct {
@@ -109,7 +111,7 @@ func (c *podLifecycleController) Reconcile(ctx context.Context, req ctrl.Request
 		logger = logger.WithValues("synthesizerName", syn.Name, "synthesizerGeneration", syn.Generation)
 	}
 
-	logger, toDelete, exists := shouldDeletePod(logger, comp, syn, pods)
+	logger, toDelete, exists := shouldDeletePod(logger, comp, syn, pods, c.config.ContainerCreationTimeout)
 	if toDelete != nil {
 		if err := c.client.Delete(ctx, toDelete); err != nil {
 			return ctrl.Result{}, client.IgnoreNotFound(fmt.Errorf("deleting pod: %w", err))
@@ -257,23 +259,26 @@ func (c *podLifecycleController) reconcileDeletedComposition(ctx context.Context
 	return ctrl.Result{}, nil
 }
 
-func shouldDeletePod(logger logr.Logger, comp *apiv1.Composition, syn *apiv1.Synthesizer, pods *corev1.PodList) (logr.Logger, *corev1.Pod, bool /* exists */) {
+func shouldDeletePod(logger logr.Logger, comp *apiv1.Composition, syn *apiv1.Synthesizer, pods *corev1.PodList, creationTTL time.Duration) (logr.Logger, *corev1.Pod, bool /* exists */) {
 	if len(pods.Items) == 0 {
 		return logger, nil, false
 	}
 
-	// Only create pods when the previous one is deleting or non-existant
+	// Allow a single extra pod to be created while the previous one is terminating
+	// in order to break potential deadlocks while avoiding a thundering herd of pods
 	var onePodDeleting bool
 	for _, pod := range pods.Items {
-		pod := pod
-
-		// Allow a single extra pod to be created while the previous one is terminating
-		// in order to break potential deadlocks while avoiding a thundering herd of pods
 		if pod.DeletionTimestamp != nil {
 			if onePodDeleting {
 				return logger, nil, true
 			}
 			onePodDeleting = true
+		}
+	}
+
+	for _, pod := range pods.Items {
+		pod := pod
+		if pod.DeletionTimestamp != nil {
 			continue
 		}
 
@@ -303,11 +308,22 @@ func shouldDeletePod(logger logr.Logger, comp *apiv1.Composition, syn *apiv1.Syn
 		}
 
 		// Synthesis is done
+		if comp.Status.CurrentSynthesis != nil && comp.Status.CurrentSynthesis.PodCreation != nil {
+			logger = logger.WithValues("latency", time.Since(comp.Status.CurrentSynthesis.PodCreation.Time).Abs().Milliseconds())
+		}
 		if comp.Status.CurrentSynthesis != nil && comp.Status.CurrentSynthesis.Synthesized != nil {
-			if comp.Status.CurrentSynthesis.PodCreation != nil {
-				logger = logger.WithValues("latency", time.Since(comp.Status.CurrentSynthesis.PodCreation.Time).Abs().Milliseconds())
-			}
 			logger = logger.WithValues("reason", "Success")
+			return logger, &pod, true
+		}
+
+		// Delete pods if they have been scheduled but not picked up by that node's kubelet
+		// This can happen when the node is Ready but recently partitioned from apiserver
+		//
+		// Clock jitter is a risk since the scheduled timestamp is written by the scheduler
+		// So we only enforce this timeout when a new pod can be created immediately
+		// i.e. when another pod for this synthesis isn't already terminating
+		if scheduledTime := getPodScheduledTime(&pod); onePodDeleting && scheduledTime != nil && len(pod.Status.ContainerStatuses) == 0 && time.Since(*scheduledTime) > creationTTL {
+			logger = logger.WithValues("reason", "ContainerCreationTimeout")
 			return logger, &pod, true
 		}
 
@@ -426,4 +442,17 @@ func inputRevisionsEqual(synth *apiv1.Synthesizer, a, b []apiv1.InputRevisions) 
 	}
 
 	return equal == len(a)
+}
+
+func getPodScheduledTime(pod *corev1.Pod) *time.Time {
+	for _, cond := range pod.Status.Conditions {
+		if cond.Type != corev1.PodScheduled {
+			continue
+		}
+		if cond.Status == corev1.ConditionFalse {
+			return nil
+		}
+		return &cond.LastTransitionTime.Time
+	}
+	return nil
 }

--- a/internal/controllers/synthesis/lifecycle.go
+++ b/internal/controllers/synthesis/lifecycle.go
@@ -322,8 +322,8 @@ func shouldDeletePod(logger logr.Logger, comp *apiv1.Composition, syn *apiv1.Syn
 		// Clock jitter is a risk since the scheduled timestamp is written by the scheduler
 		// So we only enforce this timeout when a new pod can be created immediately
 		// i.e. when another pod for this synthesis isn't already terminating
-		if scheduledTime := getPodScheduledTime(&pod); onePodDeleting && scheduledTime != nil && len(pod.Status.ContainerStatuses) == 0 && time.Since(*scheduledTime) > creationTTL {
-			logger = logger.WithValues("reason", "ContainerCreationTimeout")
+		if scheduledTime := getPodScheduledTime(&pod); !onePodDeleting && scheduledTime != nil && len(pod.Status.ContainerStatuses) == 0 && time.Since(*scheduledTime) > creationTTL {
+			logger = logger.WithValues("reason", "ContainerCreationTimeout", "scheduledTime", scheduledTime.UnixMilli())
 			return logger, &pod, true
 		}
 

--- a/internal/controllers/synthesis/lifecycle_test.go
+++ b/internal/controllers/synthesis/lifecycle_test.go
@@ -231,11 +231,6 @@ var shouldDeletePodTests = []struct {
 		Name: "container-timeout",
 		Pods: []corev1.Pod{{
 			ObjectMeta: metav1.ObjectMeta{
-				CreationTimestamp: metav1.Now(),
-				DeletionTimestamp: ptr.To(metav1.Now()),
-			},
-		}, {
-			ObjectMeta: metav1.ObjectMeta{
 				CreationTimestamp: metav1.NewTime(time.Now().Add(-time.Minute * 2)),
 				Labels:            map[string]string{},
 			},
@@ -261,11 +256,6 @@ var shouldDeletePodTests = []struct {
 	{
 		Name: "container-timeout-negative",
 		Pods: []corev1.Pod{{
-			ObjectMeta: metav1.ObjectMeta{
-				CreationTimestamp: metav1.Now(),
-				DeletionTimestamp: ptr.To(metav1.Now()),
-			},
-		}, {
 			ObjectMeta: metav1.ObjectMeta{
 				CreationTimestamp: metav1.NewTime(time.Now().Add(-time.Minute * 2)),
 				Labels:            map[string]string{},
@@ -297,11 +287,6 @@ var shouldDeletePodTests = []struct {
 		Name: "container-timeout-not-scheduled",
 		Pods: []corev1.Pod{{
 			ObjectMeta: metav1.ObjectMeta{
-				CreationTimestamp: metav1.Now(),
-				DeletionTimestamp: ptr.To(metav1.Now()),
-			},
-		}, {
-			ObjectMeta: metav1.ObjectMeta{
 				CreationTimestamp: metav1.NewTime(time.Now().Add(-time.Minute * 2)),
 				Labels:            map[string]string{},
 			},
@@ -324,6 +309,28 @@ var shouldDeletePodTests = []struct {
 		Name: "container-timeout-not-scheduled-but-somehow-created",
 		Pods: []corev1.Pod{{
 			ObjectMeta: metav1.ObjectMeta{
+				CreationTimestamp: metav1.NewTime(time.Now().Add(-time.Minute * 2)),
+				Labels:            map[string]string{},
+			},
+			Status: corev1.PodStatus{ContainerStatuses: []corev1.ContainerStatus{{}}},
+		}},
+		Composition: &apiv1.Composition{
+			Status: apiv1.CompositionStatus{
+				CurrentSynthesis: &apiv1.Synthesis{},
+			},
+		},
+		Synth: &apiv1.Synthesizer{
+			Spec: apiv1.SynthesizerSpec{
+				PodTimeout: ptr.To(metav1.Duration{Duration: time.Hour}),
+			},
+		},
+		PodShouldExist:     true,
+		PodShouldBeDeleted: false,
+	},
+	{
+		Name: "container-timeout-another-pod-deleting",
+		Pods: []corev1.Pod{{
+			ObjectMeta: metav1.ObjectMeta{
 				CreationTimestamp: metav1.Now(),
 				DeletionTimestamp: ptr.To(metav1.Now()),
 			},
@@ -332,7 +339,11 @@ var shouldDeletePodTests = []struct {
 				CreationTimestamp: metav1.NewTime(time.Now().Add(-time.Minute * 2)),
 				Labels:            map[string]string{},
 			},
-			Status: corev1.PodStatus{ContainerStatuses: []corev1.ContainerStatus{{}}},
+			Status: corev1.PodStatus{Conditions: []corev1.PodCondition{{
+				Type:               corev1.PodScheduled,
+				Status:             corev1.ConditionTrue,
+				LastTransitionTime: metav1.NewTime(time.Now().Add(-time.Minute * 2)),
+			}}},
 		}},
 		Composition: &apiv1.Composition{
 			Status: apiv1.CompositionStatus{

--- a/internal/controllers/synthesis/lifecycle_test.go
+++ b/internal/controllers/synthesis/lifecycle_test.go
@@ -359,6 +359,32 @@ var shouldDeletePodTests = []struct {
 		PodShouldBeDeleted: false,
 	},
 	{
+		Name: "container-timeout-too-many-retries",
+		Pods: []corev1.Pod{{
+			ObjectMeta: metav1.ObjectMeta{
+				CreationTimestamp: metav1.NewTime(time.Now().Add(-time.Minute * 2)),
+				Labels:            map[string]string{},
+			},
+			Status: corev1.PodStatus{Conditions: []corev1.PodCondition{{
+				Type:               corev1.PodScheduled,
+				Status:             corev1.ConditionTrue,
+				LastTransitionTime: metav1.NewTime(time.Now().Add(-time.Minute * 2)),
+			}}},
+		}},
+		Composition: &apiv1.Composition{
+			Status: apiv1.CompositionStatus{
+				CurrentSynthesis: &apiv1.Synthesis{Attempts: 4},
+			},
+		},
+		Synth: &apiv1.Synthesizer{
+			Spec: apiv1.SynthesizerSpec{
+				PodTimeout: ptr.To(metav1.Duration{Duration: time.Hour}),
+			},
+		},
+		PodShouldExist:     true,
+		PodShouldBeDeleted: false,
+	},
+	{
 		Name: "pod-timeout",
 		Pods: []corev1.Pod{{
 			ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
Sadly, k8s doesn't have a good mechanism for handling new pods on nodes that recently updated their lease (are still Ready) before being partitioned from apiserver. Pods will sit around until the node becomes NotReady and is eventually reflected in the pod status.

Synthesis tail latency suffers in this case so it's worth implementing our own timeouts on the relevant phase of the pod lifecycle: the window between being scheduled and ack'd by kubelet.