### PR TITLE
Rename InputsInLockstep to InputsOutOfLockstep

### DIFF
--- a/api/v1/composition.go
+++ b/api/v1/composition.go
@@ -167,8 +167,10 @@ func (c *Composition) InputsExist(syn *Synthesizer) bool {
 	return true
 }
 
-// InputsInLockstep returns false when one or more inputs that specify a revision do not match the others.
-func (c *Composition) InputsInLockstep(synth *Synthesizer) bool {
+// InputsOutOfLockstep returns true when one or more inputs that specify a revision do not match the others.
+// It also returns true if any revision is derived from a synthesizer generation
+// older than the provided synthesizer.
+func (c *Composition) InputsOutOfLockstep(synth *Synthesizer) bool {
 	// First, the the max revision across all bindings
 	var maxRevision *int
 	for _, rev := range c.Status.InputRevisions {

--- a/api/v1/composition_test.go
+++ b/api/v1/composition_test.go
@@ -402,7 +402,7 @@ func TestInputsInLockstep(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.Name, func(t *testing.T) {
-			result := tt.Input.InputsInLockstep(&tt.Synth)
+			result := tt.Input.InputsOutOfLockstep(&tt.Synth)
 			assert.Equal(t, tt.Expectation, result)
 		})
 	}

--- a/internal/controllers/aggregation/composition.go
+++ b/internal/controllers/aggregation/composition.go
@@ -111,7 +111,7 @@ func (c *compositionController) aggregate(synth *apiv1.Synthesizer, comp *apiv1.
 	if comp.Status.PendingResynthesis != nil {
 		copy.Status = "WaitingForCooldown"
 	}
-	if comp.InputsInLockstep(synth) {
+	if comp.InputsOutOfLockstep(synth) {
 		copy.Status = "MismatchedInputs"
 	}
 

--- a/internal/controllers/rollout/synthesizer.go
+++ b/internal/controllers/rollout/synthesizer.go
@@ -77,7 +77,7 @@ func (c *synthController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 			comp.DeletionTimestamp != nil ||
 			comp.Status.PendingResynthesis != nil ||
 			isInSync(&comp, syn) ||
-			comp.InputsInLockstep(syn) ||
+			comp.InputsOutOfLockstep(syn) ||
 			comp.ShouldIgnoreSideEffects() {
 			continue
 		}

--- a/internal/controllers/synthesis/lifecycle.go
+++ b/internal/controllers/synthesis/lifecycle.go
@@ -374,7 +374,7 @@ func shouldSwapStates(synth *apiv1.Synthesizer, comp *apiv1.Composition) bool {
 	return (syn == nil ||
 		syn.ObservedCompositionGeneration != comp.Generation ||
 		(!inputRevisionsEqual(synth, comp.Status.InputRevisions, syn.InputRevisions) && syn.Synthesized != nil && !comp.ShouldIgnoreSideEffects())) &&
-		(comp.DeletionTimestamp != nil || (comp.InputsExist(synth) && !comp.InputsInLockstep(synth)))
+		(comp.DeletionTimestamp != nil || (comp.InputsExist(synth) && !comp.InputsOutOfLockstep(synth)))
 }
 
 func shouldBackOffPodCreation(comp *apiv1.Composition) bool {


### PR DESCRIPTION
Current naming is the opposite to what the function does