### PR TITLE
Tune leader election

### DIFF
--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -94,6 +94,8 @@ func newMgr(logger logr.Logger, opts *Options, isController, isReconciler bool) 
 		LeaderElectionNamespace:    opts.LeaderElectionNamespace,
 		LeaderElectionResourceLock: opts.LeaderElectionResourceLock,
 		LeaderElectionID:           opts.LeaderElectionID,
+		LeaseDuration:              &opts.ElectionLeaseDuration,
+		RenewDeadline:              &opts.ElectionLeaseRenewDeadline,
 	}
 
 	if isController {

--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -90,12 +90,13 @@ func newMgr(logger logr.Logger, opts *Options, isController, isReconciler bool) 
 		Cache: cache.Options{
 			ByObject: make(map[client.Object]cache.ByObject),
 		},
-		LeaderElection:             opts.LeaderElection,
-		LeaderElectionNamespace:    opts.LeaderElectionNamespace,
-		LeaderElectionResourceLock: opts.LeaderElectionResourceLock,
-		LeaderElectionID:           opts.LeaderElectionID,
-		LeaseDuration:              &opts.ElectionLeaseDuration,
-		RenewDeadline:              &opts.ElectionLeaseRenewDeadline,
+		LeaderElection:                opts.LeaderElection,
+		LeaderElectionNamespace:       opts.LeaderElectionNamespace,
+		LeaderElectionResourceLock:    opts.LeaderElectionResourceLock,
+		LeaderElectionID:              opts.LeaderElectionID,
+		LeaseDuration:                 &opts.ElectionLeaseDuration,
+		RenewDeadline:                 &opts.ElectionLeaseRenewDeadline,
+		LeaderElectionReleaseOnCancel: true,
 	}
 
 	if isController {

--- a/internal/manager/options.go
+++ b/internal/manager/options.go
@@ -3,6 +3,7 @@ package manager
 import (
 	"flag"
 	"os"
+	"time"
 
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/rest"
@@ -11,6 +12,9 @@ import (
 
 type Options struct {
 	leaderelection.Options
+	ElectionLeaseDuration      time.Duration
+	ElectionLeaseRenewDeadline time.Duration
+
 	Rest                    *rest.Config
 	HealthProbeAddr         string
 	MetricsAddr             string
@@ -31,4 +35,6 @@ func (o *Options) Bind(set *flag.FlagSet) {
 	set.StringVar(&o.LeaderElectionNamespace, "leader-election-namespace", os.Getenv("POD_NAMESPACE"), "Determines the namespace in which the leader election resource will be created")
 	set.StringVar(&o.LeaderElectionResourceLock, "leader-election-resource-lock", "", "Determines which resource lock to use for leader election")
 	set.StringVar(&o.LeaderElectionID, "leader-election-id", "", "Determines the name of the resource that leader election will use for holding the leader lock")
+	set.DurationVar(&o.ElectionLeaseDuration, "leader-election-lease-duration", time.Second*90, "")
+	set.DurationVar(&o.ElectionLeaseRenewDeadline, "leader-election-lease-renew-deadline", time.Second*60, "")
 }


### PR DESCRIPTION
Extends the leader election defaults and exposes them as CLI flags.

Also causes the processes to release the lease when shutting down gracefully to avoid waiting the full lease TTL for a new leader to be elected.