### PR TITLE
Fix reconciler composition selector flags

### DIFF
--- a/cmd/eno-controller/main.go
+++ b/cmd/eno-controller/main.go
@@ -118,6 +118,11 @@ func runController() error {
 		return fmt.Errorf("constructing pod lifecycle controller: %w", err)
 	}
 
+	err = synthesis.NewSliceCleanupController(mgr)
+	if err != nil {
+		return fmt.Errorf("constructing resource slice cleanup controller: %w", err)
+	}
+
 	err = watchdog.NewController(mgr, watchdogThres)
 	if err != nil {
 		return fmt.Errorf("constructing watchdog controller: %w", err)
@@ -136,6 +141,11 @@ func runController() error {
 	err = aggregation.NewCompositionController(mgr)
 	if err != nil {
 		return fmt.Errorf("constructing composition status aggregation controller: %w", err)
+	}
+
+	err = aggregation.NewSliceController(mgr)
+	if err != nil {
+		return fmt.Errorf("constructing status aggregation controller: %w", err)
 	}
 
 	err = watch.NewController(mgr)

--- a/cmd/eno-reconciler/main.go
+++ b/cmd/eno-reconciler/main.go
@@ -13,10 +13,8 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	ctrl "sigs.k8s.io/controller-runtime"
 
-	"github.com/Azure/eno/internal/controllers/aggregation"
 	"github.com/Azure/eno/internal/controllers/liveness"
 	"github.com/Azure/eno/internal/controllers/reconciliation"
-	"github.com/Azure/eno/internal/controllers/synthesis"
 	"github.com/Azure/eno/internal/flowcontrol"
 	"github.com/Azure/eno/internal/k8s"
 	"github.com/Azure/eno/internal/manager"
@@ -88,16 +86,6 @@ func run() error {
 	mgr, err := manager.NewReconciler(logger, mgrOpts)
 	if err != nil {
 		return fmt.Errorf("constructing manager: %w", err)
-	}
-
-	err = aggregation.NewSliceController(mgr)
-	if err != nil {
-		return fmt.Errorf("constructing status aggregation controller: %w", err)
-	}
-
-	err = synthesis.NewSliceCleanupController(mgr)
-	if err != nil {
-		return fmt.Errorf("constructing resource slice cleanup controller: %w", err)
 	}
 
 	if namespaceCleanup {

--- a/internal/controllers/reconciliation/symphony_test.go
+++ b/internal/controllers/reconciliation/symphony_test.go
@@ -233,6 +233,7 @@ func TestOrphanedNamespaceSymphony(t *testing.T) {
 	testutil.Eventually(t, func() bool {
 		return errors.IsNotFound(upstream.Get(ctx, client.ObjectKeyFromObject(symph), symph))
 	})
-	require.NoError(t, upstream.List(ctx, slices))
-	require.Empty(t, slices.Items)
+	testutil.Eventually(t, func() bool {
+		return upstream.List(ctx, slices) == nil && len(slices.Items) == 0
+	})
 }

--- a/internal/controllers/synthesis/slicecleanup.go
+++ b/internal/controllers/synthesis/slicecleanup.go
@@ -3,6 +3,7 @@ package synthesis
 import (
 	"context"
 	"fmt"
+	"reflect"
 	"time"
 
 	apiv1 "github.com/Azure/eno/api/v1"
@@ -16,7 +17,8 @@ import (
 )
 
 type sliceCleanupController struct {
-	client client.Client
+	client        client.Client
+	noCacheReader client.Reader
 }
 
 func NewSliceCleanupController(mgr ctrl.Manager) error {
@@ -25,7 +27,8 @@ func NewSliceCleanupController(mgr ctrl.Manager) error {
 		Watches(&apiv1.Composition{}, manager.NewCompositionToResourceSliceHandler(mgr.GetClient())).
 		WithLogConstructor(manager.NewLogConstructor(mgr, "resourceSliceCleanupController")).
 		Complete(&sliceCleanupController{
-			client: mgr.GetClient(),
+			client:        mgr.GetClient(),
+			noCacheReader: mgr.GetAPIReader(),
 		})
 }
 
@@ -39,36 +42,20 @@ func (c *sliceCleanupController) Reconcile(ctx context.Context, req ctrl.Request
 	}
 
 	owner := metav1.GetControllerOf(slice)
-
-	// We only get the composition if it exists
-	// It shouldn't be possible that it doesn't exist, but still worth handling in case anyone creates an ad-hoc resource slice for some reason (it won't do anything tho)
-	var doNotDelete bool
-	var holdFinalizer bool
 	if owner != nil {
-		comp := &apiv1.Composition{}
-		comp.Name = owner.Name
-		comp.Namespace = slice.Namespace
-		err = c.client.Get(ctx, client.ObjectKeyFromObject(comp), comp)
-		if errors.IsNotFound(err) && time.Since(slice.CreationTimestamp.Time) < time.Minute {
-			logger.V(1).Info("didn't find a composition for this resource slice - ignoring because resource slice is new so informer may just be stale")
-			return ctrl.Result{RequeueAfter: time.Minute}, nil
-		}
-		if client.IgnoreNotFound(err) != nil {
-			return ctrl.Result{}, fmt.Errorf("getting composition: %w", err)
-		}
-		if err == nil {
-			logger = logger.WithValues("compositionName", comp.Name,
-				"compositionNamespace", comp.Namespace,
-				"synthesisID", comp.Status.GetCurrentSynthesisUUID())
-			doNotDelete = !shouldDeleteSlice(comp, slice)
-			holdFinalizer = !shouldReleaseSliceFinalizer(comp, slice)
-		}
+		logger = logger.WithValues("compositionName", owner.Name, "compositionNamespace", req.Namespace)
 	}
 
-	// Release the finalizer once all resources in the current slices have been deleted to make sure we don't orphan any resources.
-	// Also release the finalizer if the composition somehow doesn't exist since that implies we've lost control anyway.
+	decision, err := c.buildCleanupDecision(ctx, slice, owner)
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("building cleanup decision: %w", err)
+	}
+	if decision.DeferBy != nil {
+		return ctrl.Result{RequeueAfter: *decision.DeferBy}, nil
+	}
+
 	if slice.DeletionTimestamp != nil || owner == nil {
-		if holdFinalizer {
+		if decision.HoldFinalizer {
 			return ctrl.Result{}, nil
 		}
 		if !controllerutil.RemoveFinalizer(slice, "eno.azure.io/cleanup") {
@@ -81,15 +68,79 @@ func (c *sliceCleanupController) Reconcile(ctx context.Context, req ctrl.Request
 		logger.V(0).Info("released unused resource slice")
 		return ctrl.Result{}, nil
 	}
-
-	if doNotDelete {
+	if decision.DoNotDelete {
 		return ctrl.Result{}, nil
 	}
+
 	if err := c.client.Delete(ctx, slice); err != nil {
 		return ctrl.Result{}, fmt.Errorf("deleting resource slice: %w", err)
 	}
 	logger.V(0).Info("deleted unused resource slice")
 	return ctrl.Result{}, nil
+}
+
+func (c *sliceCleanupController) buildCleanupDecision(ctx context.Context, slice *apiv1.ResourceSlice, owner *metav1.OwnerReference) (cleanupDecision, error) {
+	logger := logr.FromContextOrDiscard(ctx)
+	if owner == nil {
+		logger.V(1).Info("resource slice can be deleted because it does not have an owner")
+		return cleanupDecision{}, nil // delete
+	}
+
+	// Bail out early if the cache suggests that we shouldn't delete the resource slice
+	informerDecision, err := checkCompositionState(ctx, c.client, slice, owner)
+	if err != nil {
+		return cleanupDecision{}, err
+	}
+	if informerDecision.DoNotDelete && informerDecision.HoldFinalizer {
+		return informerDecision, nil
+	}
+
+	// Don't run the actual (non-cached) check if the resource is too new - the cache is probably just stale
+	age := time.Since(slice.CreationTimestamp.Time)
+	if age < time.Second*5 {
+		logger.V(1).Info("refusing to delete resource slice because it's too new", "age", age.Milliseconds())
+		return cleanupDecision{DeferBy: &age}, nil
+	}
+
+	// Check the state against apiserver without any caching before making a final decision
+	apiDecision, err := checkCompositionState(ctx, c.noCacheReader, slice, owner)
+	if err != nil {
+		return cleanupDecision{}, err
+	}
+	if !reflect.DeepEqual(informerDecision, apiDecision) {
+		// We trust the apiserver decision even if it doesn't align with the cache,
+		// although this is should rarely happen and might be reason for concern
+		logger.Info("cleanup decisions derived from informer cache and non-caching client do not agree!", "cache", informerDecision.String(), "noCache", apiDecision.String())
+	}
+
+	return apiDecision, nil
+}
+
+func checkCompositionState(ctx context.Context, reader client.Reader, slice *apiv1.ResourceSlice, owner *metav1.OwnerReference) (cleanupDecision, error) {
+	comp := &apiv1.Composition{}
+	comp.Name = owner.Name
+	comp.Namespace = slice.Namespace
+	err := reader.Get(ctx, client.ObjectKeyFromObject(comp), comp)
+	if errors.IsNotFound(err) {
+		return cleanupDecision{}, nil // delete
+	}
+	if err != nil {
+		return cleanupDecision{}, fmt.Errorf("getting composition: %w", err)
+	}
+	return cleanupDecision{
+		DoNotDelete:   !shouldDeleteSlice(comp, slice),
+		HoldFinalizer: !shouldReleaseSliceFinalizer(comp, slice),
+	}, nil
+}
+
+type cleanupDecision struct {
+	DoNotDelete   bool
+	HoldFinalizer bool
+	DeferBy       *time.Duration
+}
+
+func (c *cleanupDecision) String() string {
+	return fmt.Sprintf("DoNotDelete=%t,HoldFinalizer=%t", c.DoNotDelete, c.HoldFinalizer)
 }
 
 func shouldDeleteSlice(comp *apiv1.Composition, slice *apiv1.ResourceSlice) bool {

--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -14,6 +14,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/workqueue"
+	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -111,7 +112,6 @@ func newMgr(logger logr.Logger, opts *Options, isController, isReconciler bool) 
 	}
 
 	if isReconciler {
-		// TODO: Dedicated test for composition namespace isolation.
 		if opts.CompositionNamespace != cache.AllNamespaces {
 			mgrOpts.Cache.ByObject[&apiv1.Composition{}] = cache.ByObject{
 				Namespaces: map[string]cache.Config{
@@ -125,21 +125,20 @@ func newMgr(logger logr.Logger, opts *Options, isController, isReconciler bool) 
 				Label: opts.CompositionSelector,
 			}
 		}
+	}
 
-		yespls := true
-		mgrOpts.Cache.ByObject[&apiv1.ResourceSlice{}] = cache.ByObject{
-			UnsafeDisableDeepCopy: &yespls,
-			Transform: func(obj any) (any, error) {
-				slice, ok := obj.(*apiv1.ResourceSlice)
-				if !ok {
-					return obj, nil
-				}
-				for i := range slice.Spec.Resources {
-					slice.Spec.Resources[i].Manifest = "" // remove big manifest that we don't need
-				}
-				return slice, nil
-			},
-		}
+	mgrOpts.Cache.ByObject[&apiv1.ResourceSlice{}] = cache.ByObject{
+		UnsafeDisableDeepCopy: ptr.To(true),
+		Transform: func(obj any) (any, error) {
+			slice, ok := obj.(*apiv1.ResourceSlice)
+			if !ok {
+				return obj, nil
+			}
+			for i := range slice.Spec.Resources {
+				slice.Spec.Resources[i].Manifest = "" // remove big manifest that we don't need
+			}
+			return slice, nil
+		},
 	}
 
 	mgr, err := ctrl.NewManager(opts.Rest, mgrOpts)
@@ -177,9 +176,7 @@ func newMgr(logger logr.Logger, opts *Options, isController, isReconciler bool) 
 		if err != nil {
 			return nil, err
 		}
-	}
 
-	if isReconciler {
 		err = mgr.GetFieldIndexer().IndexField(context.Background(), &apiv1.ResourceSlice{}, IdxResourceSlicesByComposition, indexController())
 		if err != nil {
 			return nil, err

--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -111,9 +111,9 @@ func newMgr(logger logr.Logger, opts *Options, isController, isReconciler bool) 
 		}
 	}
 
-	mgrOpts.Cache.ByObject[&apiv1.Composition{}] = opts.cacheOptions()
+	mgrOpts.Cache.ByObject[&apiv1.Composition{}] = newCacheOptions(opts.CompositionNamespace, opts.CompositionSelector)
 
-	sliceCacheOpts := opts.cacheOptions()
+	sliceCacheOpts := newCacheOptions(opts.CompositionNamespace, labels.Everything())
 	sliceCacheOpts.UnsafeDisableDeepCopy = ptr.To(true)
 	sliceCacheOpts.Transform = func(obj any) (any, error) {
 		slice, ok := obj.(*apiv1.ResourceSlice)

--- a/internal/manager/options.go
+++ b/internal/manager/options.go
@@ -7,6 +7,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/leaderelection"
 )
 
@@ -37,4 +38,19 @@ func (o *Options) Bind(set *flag.FlagSet) {
 	set.StringVar(&o.LeaderElectionID, "leader-election-id", "", "Determines the name of the resource that leader election will use for holding the leader lock")
 	set.DurationVar(&o.ElectionLeaseDuration, "leader-election-lease-duration", time.Second*90, "")
 	set.DurationVar(&o.ElectionLeaseRenewDeadline, "leader-election-lease-renew-deadline", time.Second*60, "")
+}
+
+func (o *Options) cacheOptions() cache.ByObject {
+	if o.CompositionNamespace == cache.AllNamespaces {
+		return cache.ByObject{
+			Label: o.CompositionSelector,
+		}
+	}
+	return cache.ByObject{
+		Namespaces: map[string]cache.Config{
+			o.CompositionNamespace: {
+				LabelSelector: o.CompositionSelector,
+			},
+		},
+	}
 }

--- a/internal/manager/options.go
+++ b/internal/manager/options.go
@@ -40,17 +40,13 @@ func (o *Options) Bind(set *flag.FlagSet) {
 	set.DurationVar(&o.ElectionLeaseRenewDeadline, "leader-election-lease-renew-deadline", time.Second*60, "")
 }
 
-func (o *Options) cacheOptions() cache.ByObject {
-	if o.CompositionNamespace == cache.AllNamespaces {
-		return cache.ByObject{
-			Label: o.CompositionSelector,
-		}
+func newCacheOptions(ns string, selector labels.Selector) cache.ByObject {
+	if ns == cache.AllNamespaces {
+		return cache.ByObject{Label: selector}
 	}
 	return cache.ByObject{
 		Namespaces: map[string]cache.Config{
-			o.CompositionNamespace: {
-				LabelSelector: o.CompositionSelector,
-			},
+			ns: {LabelSelector: selector},
 		},
 	}
 }


### PR DESCRIPTION
eno-reconciler processes that use selectors to restrict compositions they are responsible for reconciling will happily delete all resource slices __not__ matched by the selector - not a great failure mode lol.

The fix for `--composition-namespace` is easy - only watch resource slices in the composition's namespace. But `--composition-label-selector` is tricky since it matches on _composition_ labels, which don't necessarily match resource slices.

The simplest fix is to move the slice cleanup controller from the reconciler to the eno-controller process so it will always have a coherent view of the entire cluster. Historically, the controller/reconciler divide was designed such that the controller doesn't need to watch/cache resource slices, so the downside of this change is added overhead from the new informer. But practically speaking it just isn't an issue (we're talking about tens of MBs of memory worst case).

This change also adds an extra check to the resource slice cleanup controller to avoid any potential issues caused by stale informers: re-run the cleanup logic against a non-cached version of the composition. Since resource slices are so important to Eno, added safety justifies the overhead of a few get requests to apiserver.