### PR TITLE
Less aggressive orphaned resource cleanup

### DIFF
--- a/cmd/eno-reconciler/main.go
+++ b/cmd/eno-reconciler/main.go
@@ -89,7 +89,7 @@ func run() error {
 	}
 
 	if namespaceCleanup {
-		err = liveness.NewNamespaceController(mgr, namespaceCreationGracePeriod)
+		err = liveness.NewNamespaceController(mgr, 5, namespaceCreationGracePeriod)
 		if err != nil {
 			return fmt.Errorf("constructing namespace liveness controller: %w", err)
 		}

--- a/internal/controllers/liveness/namespace_test.go
+++ b/internal/controllers/liveness/namespace_test.go
@@ -48,7 +48,7 @@ func testMissingNamespace(t *testing.T, orphan client.Object) {
 	mgr := testutil.NewManager(t, testutil.WithCompositionNamespace(ns.Name))
 	cli := mgr.GetClient()
 
-	require.NoError(t, NewNamespaceController(mgr.Manager, time.Second))
+	require.NoError(t, NewNamespaceController(mgr.Manager, 2, time.Second))
 	mgr.Start(t)
 
 	require.NoError(t, cli.Create(ctx, ns))

--- a/internal/controllers/reconciliation/helpers_test.go
+++ b/internal/controllers/reconciliation/helpers_test.go
@@ -30,7 +30,7 @@ func registerControllers(t *testing.T, mgr *testutil.Manager) {
 	require.NoError(t, rollout.NewController(mgr.Manager, time.Millisecond))
 	require.NoError(t, rollout.NewSynthesizerController(mgr.Manager))
 	require.NoError(t, flowcontrol.NewSynthesisConcurrencyLimiter(mgr.Manager, 10, 0))
-	require.NoError(t, liveness.NewNamespaceController(mgr.Manager, time.Second))
+	require.NoError(t, liveness.NewNamespaceController(mgr.Manager, 3, time.Second))
 	require.NoError(t, watch.NewController(mgr.Manager))
 }
 


### PR DESCRIPTION
It's unlikely but possible that namespace deletion hits the informer cache before CR deletion. So we either need to make non-caching calls before recreating the namespace of orphaned resources, or just wait for informers to catch up.

This is already such a rare case, I think the risk of making apiserver calls is unnecessary and just waiting on the informers is sufficient.