### PR TITLE
Optionally block patches until composition deletion

### DIFF
--- a/docs/advanced-synthesis.md
+++ b/docs/advanced-synthesis.md
@@ -55,3 +55,20 @@ patch:
   ops:
     - { "op": "add", "path": "/metadata/deletionTimestamp", "value": "anything" }
 ```
+
+Used alongside the `only-during-deletion` annotation, resources can be easily cleaned up when removing the controller that created them.
+
+```yaml
+apiVersion: eno.azure.io/v1
+kind: Patch
+metadata:
+  name: resource-cleanup
+  namespace: default
+  annotations:
+    eno.azure.io/only-during-deletion: "true"
+patch:
+  apiVersion: v1
+  kind: ConfigMap
+  ops:
+    - { "op": "add", "path": "/metadata/deletionTimestamp", "value": "anything" }
+```

--- a/internal/resource/resource.go
+++ b/internal/resource/resource.go
@@ -44,16 +44,17 @@ type Resource struct {
 	lastSeenMeta
 	lastReconciledMeta
 
-	Ref               Ref
-	Manifest          *apiv1.Manifest
-	ManifestRef       ManifestRef
-	ReconcileInterval *metav1.Duration
-	GVK               schema.GroupVersionKind
-	SliceDeleted      bool
-	ReadinessChecks   readiness.Checks
-	Patch             jsonpatch.Patch
-	DisableUpdates    bool
-	ReadinessGroup    int
+	Ref                Ref
+	Manifest           *apiv1.Manifest
+	ManifestRef        ManifestRef
+	ReconcileInterval  *metav1.Duration
+	GVK                schema.GroupVersionKind
+	SliceDeleted       bool
+	ReadinessChecks    readiness.Checks
+	Patch              jsonpatch.Patch
+	OnlyDuringDeletion bool
+	DisableUpdates     bool
+	ReadinessGroup     int
 
 	// DefinedGroupKind is set on CRDs to represent the resource type they define.
 	DefinedGroupKind *schema.GroupKind
@@ -201,6 +202,10 @@ func NewResource(ctx context.Context, renv *readiness.Env, slice *apiv1.Resource
 	}
 	res.ReadinessGroup = int(rg)
 	delete(anno, readinessGroupKey)
+
+	const onlyDuringDeletionKey = "eno.azure.io/only-during-deletion"
+	res.OnlyDuringDeletion = res.Patch != nil && anno[onlyDuringDeletionKey] == "true"
+	delete(anno, onlyDuringDeletionKey)
 
 	for key, value := range anno {
 		if !strings.HasPrefix(key, "eno.azure.io/readiness") {


### PR DESCRIPTION
Resolves #232

There's a common use case in which Eno deploys a controller which then creates some resources that aren't managed by Eno. So if Eno removes the controller, those resources will never be cleaned up.

An easy way to handle this: allow patches to be deferred until the composition is deleted. Deletion patches can then be defined to remove any known state that might be left behind by the controller.