### PR TITLE
Fix patch edgecases

### DIFF
--- a/internal/controllers/reconciliation/controller_test.go
+++ b/internal/controllers/reconciliation/controller_test.go
@@ -73,7 +73,7 @@ func TestBuildPatchEmpty(t *testing.T) {
 				"apiVersion": "v1",
 				"kind":       "Pod",
 				"metadata":   map[string]any{"name": "foo", "namespace": "default"},
-				"spec":       map[string]any{"serviceAccountName": "initial"},
+				"spec":       map[string]any{"serviceAccountName": "initial", "containers": nil},
 			},
 		},
 		{
@@ -102,12 +102,14 @@ func TestBuildPatchEmpty(t *testing.T) {
 				"kind":       "Pod",
 				"metadata":   map[string]any{"name": "foo", "namespace": "default"},
 				"status":     map[string]any{"message": "initial"},
+				"spec":       map[string]any{"containers": nil},
 			},
 			Next: map[string]any{
 				"apiVersion": "v1",
 				"kind":       "Pod",
 				"metadata":   map[string]any{"name": "foo", "namespace": "default"},
 				"status":     map[string]any{"message": "updated"},
+				"spec":       map[string]any{"containers": nil},
 			},
 		},
 		{
@@ -133,13 +135,13 @@ func TestBuildPatchEmpty(t *testing.T) {
 				"apiVersion": "v1",
 				"kind":       "Pod",
 				"metadata":   map[string]any{"name": "foo", "namespace": "default"},
-				"spec":       map[string]any{"serviceAccountName": "initial", "initContainers": []any{}},
+				"spec":       map[string]any{"serviceAccountName": "initial", "initContainers": []any{}, "containers": nil},
 			},
 			Next: map[string]any{
 				"apiVersion": "v1",
 				"kind":       "Pod",
 				"metadata":   map[string]any{"name": "foo", "namespace": "default"},
-				"spec":       map[string]any{"initContainers": []any{}, "serviceAccountName": "initial"},
+				"spec":       map[string]any{"initContainers": []any{}, "serviceAccountName": "initial", "containers": nil},
 			},
 		},
 	}
@@ -158,7 +160,7 @@ func TestBuildPatchEmpty(t *testing.T) {
 
 			patch, err = mungePatch(patch, "random-rv")
 			require.NoError(t, err)
-			assert.Nil(t, patch)
+			assert.Empty(t, string(patch))
 			assert.Equal(t, test.Type, kind)
 		})
 	}

--- a/internal/controllers/reconciliation/crud_test.go
+++ b/internal/controllers/reconciliation/crud_test.go
@@ -794,6 +794,9 @@ func TestResourceDefaulting(t *testing.T) {
 								map[string]any{
 									"name":  "foo",
 									"image": "bar",
+									"resources": map[string]any{
+										"memory": "1024Mi", // apiserver will return this as "1Gi"
+									},
 								},
 							},
 						},

--- a/internal/controllers/reconciliation/crud_test.go
+++ b/internal/controllers/reconciliation/crud_test.go
@@ -754,3 +754,64 @@ func TestOrphanedCompositionDeletion(t *testing.T) {
 		return errors.IsNotFound(upstream.Get(ctx, client.ObjectKeyFromObject(comp), comp))
 	})
 }
+
+// TestResourceDefaulting proves that resources which define properties equal to the field's default will eventually converge.
+func TestResourceDefaulting(t *testing.T) {
+	scheme := runtime.NewScheme()
+	corev1.SchemeBuilder.AddToScheme(scheme)
+	testv1.SchemeBuilder.AddToScheme(scheme)
+
+	ctx := testutil.NewContext(t)
+	mgr := testutil.NewManager(t)
+	upstream := mgr.GetClient()
+
+	registerControllers(t, mgr)
+	testutil.WithFakeExecutor(t, mgr, func(ctx context.Context, s *apiv1.Synthesizer, input *krmv1.ResourceList) (*krmv1.ResourceList, error) {
+		output := &krmv1.ResourceList{}
+		output.Items = []*unstructured.Unstructured{{
+			Object: map[string]any{
+				"apiVersion": "apps/v1",
+				"kind":       "Deployment",
+				"metadata": map[string]any{
+					"name":      "test-obj",
+					"namespace": "default",
+				},
+				"spec": map[string]any{
+					"paused": false, // will fail the test if defaulting isn't handled correctly
+					"selector": map[string]any{
+						"matchLabels": map[string]any{
+							"foo": "bar",
+						},
+					},
+					"template": map[string]any{
+						"metadata": map[string]any{
+							"labels": map[string]any{
+								"foo": "bar",
+							},
+						},
+						"spec": map[string]any{
+							"containers": []any{
+								map[string]any{
+									"name":  "foo",
+									"image": "bar",
+								},
+							},
+						},
+					},
+				},
+			},
+		}}
+		return output, nil
+	})
+
+	// Test subject
+	setupTestSubject(t, mgr)
+	mgr.Start(t)
+	_, comp := writeGenericComposition(t, upstream)
+
+	// It should be able to become ready
+	testutil.Eventually(t, func() bool {
+		err := upstream.Get(ctx, client.ObjectKeyFromObject(comp), comp)
+		return err == nil && comp.Status.CurrentSynthesis != nil && comp.Status.CurrentSynthesis.Ready != nil && comp.Status.CurrentSynthesis.ObservedCompositionGeneration == comp.Generation
+	})
+}


### PR DESCRIPTION
Values that change on the server side should not cause the patch to be continuously applied. There are two known cases where this can occur: bools explicitly set to false, and resource quantities.