### PR TITLE
Hack to allow PDBs to progress

### DIFF
--- a/internal/controllers/reconciliation/controller.go
+++ b/internal/controllers/reconciliation/controller.go
@@ -12,6 +12,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/jsonmergepatch"
 	"k8s.io/apimachinery/pkg/util/strategicpatch"
@@ -333,7 +334,9 @@ func (c *Controller) buildPatch(ctx context.Context, prev, next *reconstitution.
 	if err != nil {
 		return nil, "", fmt.Errorf("getting merge metadata: %w", err)
 	}
-	if model == nil {
+
+	pdbGVK := schema.GroupVersionKind{Group: "policy", Version: "v1", Kind: "PodDisruptionBudget"}
+	if model == nil || (next != nil && next.GVK == pdbGVK) {
 		patch, err := jsonmergepatch.CreateThreeWayJSONMergePatch(prevJS, nextJS, currentJS)
 		if err != nil {
 			return nil, "", reconcile.TerminalError(err)

--- a/internal/controllers/reconciliation/controller.go
+++ b/internal/controllers/reconciliation/controller.go
@@ -335,6 +335,8 @@ func (c *Controller) buildPatch(ctx context.Context, prev, next *reconstitution.
 		return nil, "", fmt.Errorf("getting merge metadata: %w", err)
 	}
 
+	// FIXME: This is a very nasty hack which should not be needed once we have
+	// support for semantic equality checks.
 	pdbGVK := schema.GroupVersionKind{Group: "policy", Version: "v1", Kind: "PodDisruptionBudget"}
 	if model == nil || (next != nil && next.GVK == pdbGVK) {
 		patch, err := jsonmergepatch.CreateThreeWayJSONMergePatch(prevJS, nextJS, currentJS)


### PR DESCRIPTION
This is needed because the label selector field on the [PDB spec](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#poddisruptionbudgetspec-v1-policy) has a patch strategy of "replace" meaning that the computed patch will never be empty even if the objects are the same, meaning that we'll never mark the resource as reconciled.