### PR TITLE
Fix readiness groups lookup

### DIFF
--- a/internal/reconstitution/cache.go
+++ b/internal/reconstitution/cache.go
@@ -77,10 +77,6 @@ func (c *Cache) RangeByReadinessGroup(ctx context.Context, comp *SynthesisRef, g
 	c.mut.Lock()
 	defer c.mut.Unlock()
 
-	if group == 0 && !dir {
-		return nil
-	}
-
 	resources, ok := c.resources[*comp]
 	if !ok {
 		return nil
@@ -91,18 +87,9 @@ func (c *Cache) RangeByReadinessGroup(ctx context.Context, comp *SynthesisRef, g
 		return nil // the given group must have a resource, otherwise we wouldn't be looking it up
 	}
 
-	// If we're adjacent...
-	if dir {
-		if node.Right != nil {
-			return node.Right.Value
-		}
-	} else {
-		if node.Left != nil {
-			return node.Left.Value
-		}
-	}
-
-	// ...otherwise we need to find it
+	// Always look up the range explicitly, can't rely on adjacency because the
+	// tree could be rebalanced such that the childern are not parent + 1 or
+	// parent - 1 even if those nodes exist.
 	if dir {
 		node, ok = resources.ByReadinessGroup.Ceiling(group + 1)
 	} else {


### PR DESCRIPTION
We used to represent readiness groups as unsigned integers, and the lookup logic had an optimization for the descending range starting at 0. This led always to always (incorrectly) returning no resources when looking up the previous readiness group before the default one.

We had another optimization based on tree node adjacency. However, we can't rely on it because this is a perfectly valid red-black tree:

<img width="378" alt="image" src="https://github.com/user-attachments/assets/7f3db89c-843e-4772-8dfa-cf595d27f816">

Where the adjacent nodes are not necessarily parent + 1 and parent - 1 even if those nodes exist.