### PR TITLE
Remove reconciliation resource version cache

### DIFF
--- a/internal/controllers/reconciliation/controller.go
+++ b/internal/controllers/reconciliation/controller.go
@@ -207,7 +207,7 @@ func (c *Controller) Reconcile(ctx context.Context, req *reconstitution.Request)
 
 	deleted := current == nil ||
 		current.GetDeletionTimestamp() != nil ||
-		(resource.Deleted() && comp.Annotations["eno.azure.io/deletion-stratgy"] == "orphan") // orphaning should be reflected on the status.
+		(resource.Deleted() && comp.Annotations["eno.azure.io/deletion-strategy"] == "orphan") // orphaning should be reflected on the status.
 	c.writeBuffer.PatchStatusAsync(ctx, &resource.ManifestRef, patchResourceState(deleted, ready))
 	if ready == nil {
 		return ctrl.Result{RequeueAfter: wait.Jitter(c.readinessPollInterval, 0.1)}, nil

--- a/internal/controllers/reconciliation/helpers_test.go
+++ b/internal/controllers/reconciliation/helpers_test.go
@@ -35,6 +35,10 @@ func registerControllers(t *testing.T, mgr *testutil.Manager) {
 }
 
 func writeGenericComposition(t *testing.T, client client.Client) (*apiv1.Synthesizer, *apiv1.Composition) {
+	return writeComposition(t, client, false)
+}
+
+func writeComposition(t *testing.T, client client.Client, orphan bool) (*apiv1.Synthesizer, *apiv1.Composition) {
 	syn := &apiv1.Synthesizer{}
 	syn.Name = "test-syn"
 	syn.Spec.Image = "create"
@@ -44,6 +48,9 @@ func writeGenericComposition(t *testing.T, client client.Client) (*apiv1.Synthes
 	comp.Name = "test-comp"
 	comp.Namespace = "default"
 	comp.Spec.Synthesizer.Name = syn.Name
+	if orphan {
+		comp.Annotations = map[string]string{"eno.azure.io/deletion-strategy": "orphan"}
+	}
 	require.NoError(t, client.Create(context.Background(), comp))
 
 	return syn, comp

--- a/internal/resource/resource.go
+++ b/internal/resource/resource.go
@@ -43,7 +43,6 @@ type ManifestRef struct {
 
 // Resource is the controller's internal representation of a single resource out of a ResourceSlice.
 type Resource struct {
-	lastSeenMeta
 	lastReconciledMeta
 
 	Ref               Ref
@@ -255,29 +254,6 @@ type patchMeta struct {
 	APIVersion string          `json:"apiVersion"`
 	Kind       string          `json:"kind"`
 	Ops        jsonpatch.Patch `json:"ops"`
-}
-
-type lastSeenMeta struct {
-	lock            sync.Mutex
-	resourceVersion string
-}
-
-func (l *lastSeenMeta) ObserveVersion(rv string) {
-	l.lock.Lock()
-	defer l.lock.Unlock()
-	l.resourceVersion = rv
-}
-
-func (l *lastSeenMeta) HasBeenSeen() bool {
-	l.lock.Lock()
-	defer l.lock.Unlock()
-	return l.resourceVersion != ""
-}
-
-func (l *lastSeenMeta) MatchesLastSeen(rv string) bool {
-	l.lock.Lock()
-	defer l.lock.Unlock()
-	return l.resourceVersion == rv
 }
 
 type lastReconciledMeta struct {


### PR DESCRIPTION
Simplify this code to make it easier to reason about, also fixes a bug where resources were being marked as deleted in the resourceslice status on every resource version cache hit.