### PR TITLE
Fix the deadlock between rollout and self healing controller

### DIFF
--- a/internal/controllers/selfhealing/slice.go
+++ b/internal/controllers/selfhealing/slice.go
@@ -144,6 +144,10 @@ func newCompositionHandler() handler.EventHandler {
 			logr.FromContextOrDiscard(ctx).V(0).Info("unexpected type given to newCompositionHandler")
 			return
 		}
+		if comp.ShouldIgnoreSideEffects() {
+			logr.FromContextOrDiscard(ctx).V(0).Info("skip missing resource slice check for composition that is ignoring side effects", "compositionName", comp.Name)
+			return
+		}
 
 		rli.Add(reconcile.Request{NamespacedName: types.NamespacedName{Namespace: comp.Namespace, Name: comp.Name}})
 	}


### PR DESCRIPTION
There is a deadlock issue when specify composition should ignore side effect. 

Initially, the resource slice self-healing controller detects that no resource slice exists and sets the composition's pending re-synthesis time to trigger the re-creation of the resource slice. Subsequently, the rollout controller removes the pending re-synthesis time upon finding that the composition is configured to ignore side effects.

The self-healing controller then receives the composition update event and still finding no resource slice, sets the pending re-synthesis time again to re-create the resource slice. The rollout controller receives the subsequent update event and removes the pending re-synthesis time again to ignore side effects.