### PR TITLE
chore: fix README and dev/deploy.yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Next, create a minimum viable Eno configuration to make sure everything works.
 This manifest will create a configmap called "some-config" in the default namespace.
 
 ```bash
-kubectl apply -f "https://raw.githubusercontent.com/Azure/eno/main/examples/minimal.yaml"
+kubectl apply -f "https://raw.githubusercontent.com/Azure/eno/refs/heads/main/examples/minimal/example.yaml"
 
 # The configmap should be created by Eno soon after
 kubectl get cm some-config -o=yaml

--- a/dev/deploy.yaml
+++ b/dev/deploy.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:


### PR DESCRIPTION
- current readme link is a 404
- without the new doc indicator in dev/deploy.yaml, the `manifest.yaml` from the release doesn't separate the deployment and the synthesizer CRD so the synthesizer CRD isn't deployed when running `kubectl apply -f "https://github.com/Azure/eno/releases/download/${TAG}/manifest.yaml"`

example of synthesizer CRD missing when running the commands from the README

```
➜  ~ kubectl apply -f "https://github.com/Azure/eno/releases/download/${TAG}/manifest.yaml"
customresourcedefinition.apiextensions.k8s.io/compositions.eno.azure.io created
customresourcedefinition.apiextensions.k8s.io/resourceslices.eno.azure.io created
customresourcedefinition.apiextensions.k8s.io/symphonies.eno.azure.io created
deployment.apps/eno-controller created
deployment.apps/eno-reconciler created
serviceaccount/eno created
clusterrolebinding.rbac.authorization.k8s.io/eno-cluster-admin created

➜  ~ k get crds | grep eno
compositions.eno.azure.io                             2025-01-06T15:15:01Z
resourceslices.eno.azure.io                           2025-01-06T15:15:01Z
symphonies.eno.azure.io                               2025-01-06T15:15:01Z
```