### PR TITLE
Fix deletion race

### DIFF
--- a/internal/controllers/reconciliation/controller.go
+++ b/internal/controllers/reconciliation/controller.go
@@ -236,7 +236,7 @@ func (c *Controller) reconcileResource(ctx context.Context, comp *apiv1.Composit
 		reconciliationActions.WithLabelValues("delete").Inc()
 		err := c.upstreamClient.Delete(ctx, current)
 		if err != nil {
-			return false, client.IgnoreNotFound(fmt.Errorf("deleting resource: %w", err))
+			return true, client.IgnoreNotFound(fmt.Errorf("deleting resource: %w", err))
 		}
 		logger.V(0).Info("deleted resource")
 		return true, nil

--- a/internal/controllers/reconciliation/edgecase_test.go
+++ b/internal/controllers/reconciliation/edgecase_test.go
@@ -144,7 +144,6 @@ func TestEmptySynthesis(t *testing.T) {
 }
 
 func TestLargeNamespaceDeletion(t *testing.T) {
-	// TODO: We know that the patch fn is being applied, and is correct. Probably the patch isn't making it to the server.
 	ctx := testutil.NewContext(t)
 	mgr := testutil.NewManager(t)
 	upstream := mgr.GetClient()

--- a/internal/controllers/reconciliation/edgecase_test.go
+++ b/internal/controllers/reconciliation/edgecase_test.go
@@ -144,6 +144,7 @@ func TestEmptySynthesis(t *testing.T) {
 }
 
 func TestLargeNamespaceDeletion(t *testing.T) {
+	// TODO: We know that the patch fn is being applied, and is correct. Probably the patch isn't making it to the server.
 	ctx := testutil.NewContext(t)
 	mgr := testutil.NewManager(t)
 	upstream := mgr.GetClient()
@@ -231,5 +232,5 @@ func TestLargeNamespaceDeletion(t *testing.T) {
 		}
 
 		return false
-	}, time.Minute*3, time.Second)
+	}, time.Minute*6, time.Second)
 }

--- a/internal/controllers/reconciliation/edgecase_test.go
+++ b/internal/controllers/reconciliation/edgecase_test.go
@@ -2,9 +2,12 @@ package reconciliation
 
 import (
 	"context"
+	"fmt"
 	"sync/atomic"
 	"testing"
+	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -138,4 +141,95 @@ func TestEmptySynthesis(t *testing.T) {
 	testutil.Eventually(t, func() bool {
 		return errors.IsNotFound(upstream.Get(ctx, client.ObjectKeyFromObject(comp), comp))
 	})
+}
+
+func TestLargeNamespaceDeletion(t *testing.T) {
+	ctx := testutil.NewContext(t)
+	mgr := testutil.NewManager(t)
+	upstream := mgr.GetClient()
+
+	registerControllers(t, mgr)
+	ns := &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "v1",
+			"kind":       "Namespace",
+			"metadata": map[string]any{
+				"name": "test",
+			},
+		},
+	}
+	testutil.WithFakeExecutor(t, mgr, func(ctx context.Context, s *apiv1.Synthesizer, input *krmv1.ResourceList) (*krmv1.ResourceList, error) {
+		output := &krmv1.ResourceList{}
+		output.Items = []*unstructured.Unstructured{ns}
+
+		for i := 0; i < 500; i++ {
+			cm := &unstructured.Unstructured{
+				Object: map[string]any{
+					"apiVersion": "v1",
+					"kind":       "ConfigMap",
+					"metadata": map[string]any{
+						"name":      fmt.Sprintf("test-%d", i),
+						"namespace": ns.GetName(),
+					},
+				},
+			}
+			output.Items = append(output.Items, cm)
+		}
+
+		return output, nil
+	})
+
+	setupTestSubject(t, mgr)
+	mgr.Start(t)
+	_, comp := writeGenericComposition(t, upstream)
+
+	testutil.Eventually(t, func() bool {
+		err := upstream.Get(ctx, client.ObjectKeyFromObject(comp), comp)
+		return err == nil && comp.Status.CurrentSynthesis != nil && comp.Status.CurrentSynthesis.Ready != nil
+	})
+
+	go func() {
+		for i := 0; i < 500; i++ {
+			cm := &unstructured.Unstructured{
+				Object: map[string]any{
+					"apiVersion": "v1",
+					"kind":       "ConfigMap",
+					"metadata": map[string]any{
+						"name":      fmt.Sprintf("test-%d", i),
+						"namespace": ns.GetName(),
+					},
+				},
+			}
+			t.Logf("deleting configmap %s", cm.GetName())
+			err := mgr.DownstreamClient.Delete(ctx, cm)
+			require.NoError(t, client.IgnoreNotFound(err))
+			time.Sleep(time.Millisecond * 3)
+		}
+	}()
+
+	require.NoError(t, upstream.Delete(ctx, comp))
+
+	assert.Eventually(t, func() bool {
+		err := upstream.Get(ctx, client.ObjectKeyFromObject(comp), comp)
+		if errors.IsNotFound(err) {
+			return true
+		}
+
+		list := &apiv1.ResourceSliceList{}
+		require.NoError(t, upstream.List(ctx, list))
+		missing := []string{}
+		for _, item := range list.Items {
+			for i, res := range item.Status.Resources {
+				if !res.Deleted {
+					missing = append(missing, fmt.Sprintf("test-%d", i))
+				}
+			}
+		}
+		t.Logf("composition deleting=%t missing=%d", comp.DeletionTimestamp != nil, len(missing))
+		if len(missing) < 100 {
+			t.Logf("the missing resources: %+s", missing)
+		}
+
+		return false
+	}, time.Minute*3, time.Second)
 }

--- a/internal/controllers/reconciliation/edgecase_test.go
+++ b/internal/controllers/reconciliation/edgecase_test.go
@@ -202,8 +202,7 @@ func TestLargeNamespaceDeletion(t *testing.T) {
 				},
 			}
 			t.Logf("deleting configmap %s", cm.GetName())
-			err := mgr.DownstreamClient.Delete(ctx, cm)
-			require.NoError(t, client.IgnoreNotFound(err))
+			mgr.DownstreamClient.Delete(ctx, cm)
 			time.Sleep(time.Millisecond * 3)
 		}
 	}()

--- a/internal/controllers/reconciliation/edgecase_test.go
+++ b/internal/controllers/reconciliation/edgecase_test.go
@@ -208,4 +208,9 @@ func TestLargeNamespaceDeletion(t *testing.T) {
 	}()
 
 	require.NoError(t, upstream.Delete(ctx, comp))
+
+	testutil.Eventually(t, func() bool {
+		err := upstream.Get(ctx, client.ObjectKeyFromObject(comp), comp)
+		return errors.IsNotFound(err)
+	})
 }

--- a/internal/controllers/reconciliation/edgecase_test.go
+++ b/internal/controllers/reconciliation/edgecase_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -209,8 +210,8 @@ func TestLargeNamespaceDeletion(t *testing.T) {
 
 	require.NoError(t, upstream.Delete(ctx, comp))
 
-	testutil.Eventually(t, func() bool {
+	assert.Eventually(t, func() bool {
 		err := upstream.Get(ctx, client.ObjectKeyFromObject(comp), comp)
 		return errors.IsNotFound(err)
-	})
+	}, time.Minute*3, time.Second)
 }


### PR DESCRIPTION
It's possible for a resource to be deleted by an outside process between the time Eno gets the current state and attempts to delete it. In this case the client's delete func will return a 404 error, which we ignore. Since all errors from that function return `modified=false`, the controller doesn't requeue, so unless the resource has a reconciliation interval its status won't converge until the next Eno reconciler restart.
