### PR TITLE
Simplify watchdog metrics

### DIFF
--- a/internal/controllers/watchdog/controller.go
+++ b/internal/controllers/watchdog/controller.go
@@ -6,6 +6,7 @@ import (
 
 	apiv1 "github.com/Azure/eno/api/v1"
 	"github.com/Azure/eno/internal/manager"
+	"github.com/prometheus/client_golang/prometheus"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -35,78 +36,39 @@ func (c *watchdogController) Reconcile(ctx context.Context, req ctrl.Request) (c
 		return ctrl.Result{}, err
 	}
 
-	var inputsMissing int
-	var notInLockstep int
-	var withoutSynthesizers int
-	var pendingInit int
-	var pending int
-	var unready int
-	var terminal int
-	for _, comp := range list.Items {
-		if c.hasNoSynthesizer(&comp, ctx) {
-			withoutSynthesizers++
-		}
-		if c.waitingOnInputs(&comp, ctx) {
-			inputsMissing++
-		}
-		if c.getNotInLockstep(&comp, ctx) {
-			notInLockstep++
-		}
-		if c.pendingInitialReconciliation(&comp) {
-			pendingInit++
-		}
-		if c.pendingReconciliation(&comp) {
-			pending++
-		}
-		if c.pendingReadiness(&comp) {
-			unready++
-		}
-		if c.inTerminalError(&comp) {
-			terminal++
-		}
+	accumulators := []*accumulator{
+		{
+			Predicate: c.waitingOnInputs,
+			Sink:      inputsMissing,
+		},
+		{
+			Predicate: c.pendingReconciliation,
+			Sink:      stuckReconciling,
+		},
+		{
+			Predicate: c.pendingReadiness,
+			Sink:      nonready,
+		},
+		{
+			Predicate: c.inTerminalError,
+			Sink:      terminalErrors,
+		},
 	}
 
-	waitingOnInputs.Set(float64(inputsMissing))
-	inputsNotInLockstep.Set(float64(notInLockstep))
-	compositionsWithoutSynthesizers.Set(float64(withoutSynthesizers))
-	pendingInitialReconciliation.Set(float64(pendingInit))
-	stuckReconciling.Set(float64(pending))
-	pendingReadiness.Set(float64(unready))
-	terminalErrors.Set(float64(terminal))
+	for _, comp := range list.Items {
+		for _, a := range accumulators {
+			a.Visit(&comp)
+		}
+	}
 
 	return ctrl.Result{}, nil
 }
 
-func (c *watchdogController) getSynthesizer(comp *apiv1.Composition, ctx context.Context) (*apiv1.Synthesizer, error) {
+func (c *watchdogController) waitingOnInputs(comp *apiv1.Composition) bool {
 	syn := &apiv1.Synthesizer{}
 	syn.Name = comp.Spec.Synthesizer.Name
-	err := c.client.Get(ctx, client.ObjectKeyFromObject(syn), syn)
-	return syn, err
-}
-
-func (c *watchdogController) hasNoSynthesizer(comp *apiv1.Composition, ctx context.Context) bool {
-	_, err := c.getSynthesizer(comp, ctx)
-	return err != nil
-}
-
-func (c *watchdogController) getInputsExist(comp *apiv1.Composition, ctx context.Context) bool {
-	syn, err := c.getSynthesizer(comp, ctx)
-	return (err != nil) || comp.InputsExist(syn)
-}
-
-func (c *watchdogController) getNotInLockstep(comp *apiv1.Composition, ctx context.Context) bool {
-	syn, err := c.getSynthesizer(comp, ctx)
-	return (err != nil) || comp.InputsOutOfLockstep(syn)
-}
-
-func (c *watchdogController) waitingOnInputs(comp *apiv1.Composition, ctx context.Context) bool {
-	return !c.getInputsExist(comp, ctx) && time.Since(comp.CreationTimestamp.Time) > c.threshold
-}
-
-func (c *watchdogController) pendingInitialReconciliation(comp *apiv1.Composition) bool {
-	return !synthesisHasReconciled(comp.Status.CurrentSynthesis) &&
-		!synthesisHasReconciled(comp.Status.PreviousSynthesis) &&
-		time.Since(comp.CreationTimestamp.Time) > c.threshold
+	err := c.client.Get(context.Background(), client.ObjectKeyFromObject(syn), syn)
+	return err == nil && (!comp.InputsExist(syn) || !comp.InputsOutOfLockstep(syn))
 }
 
 func (c *watchdogController) pendingReconciliation(comp *apiv1.Composition) bool {
@@ -118,7 +80,6 @@ func (c *watchdogController) pendingReconciliation(comp *apiv1.Composition) bool
 
 func (c *watchdogController) pendingReadiness(comp *apiv1.Composition) bool {
 	return !synthesisIsReady(comp.Status.CurrentSynthesis) &&
-		!synthesisIsReady(comp.Status.PreviousSynthesis) &&
 		c.timeSinceReconcilePastThreshold(comp)
 }
 
@@ -133,3 +94,21 @@ func (c *watchdogController) timeSinceReconcilePastThreshold(comp *apiv1.Composi
 
 func synthesisHasReconciled(syn *apiv1.Synthesis) bool { return syn != nil && syn.Reconciled != nil }
 func synthesisIsReady(syn *apiv1.Synthesis) bool       { return syn != nil && syn.Ready != nil }
+
+type accumulator struct {
+	Predicate func(*apiv1.Composition) bool
+	Sink      *prometheus.GaugeVec
+	init      bool
+}
+
+func (a *accumulator) Visit(source *apiv1.Composition) {
+	if !a.init {
+		a.Sink.Reset()
+		a.init = true
+	}
+	if a.Predicate(source) {
+		a.Sink.WithLabelValues(source.Spec.Synthesizer.Name).Add(1)
+	} else {
+		a.Sink.WithLabelValues(source.Spec.Synthesizer.Name).Add(0)
+	}
+}

--- a/internal/controllers/watchdog/controller.go
+++ b/internal/controllers/watchdog/controller.go
@@ -68,7 +68,7 @@ func (c *watchdogController) waitingOnInputs(comp *apiv1.Composition) bool {
 	syn := &apiv1.Synthesizer{}
 	syn.Name = comp.Spec.Synthesizer.Name
 	err := c.client.Get(context.Background(), client.ObjectKeyFromObject(syn), syn)
-	return err == nil && (!comp.InputsExist(syn) || !comp.InputsOutOfLockstep(syn))
+	return err == nil && (!comp.InputsExist(syn) || comp.InputsOutOfLockstep(syn))
 }
 
 func (c *watchdogController) pendingReconciliation(comp *apiv1.Composition) bool {

--- a/internal/controllers/watchdog/metrics.go
+++ b/internal/controllers/watchdog/metrics.go
@@ -6,56 +6,35 @@ import (
 )
 
 var (
-	waitingOnInputs = prometheus.NewGauge(
+	inputsMissing = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "eno_compositions_inputs_missing_total",
-			Help: "Number of compositions that are missing input resources",
-		},
+			Help: "Number of compositions that are unable to be synthesized due to the state of their inputs",
+		}, []string{"synthesizer"},
 	)
 
-	inputsNotInLockstep = prometheus.NewGauge(
-		prometheus.GaugeOpts{
-			Name: "eno_compositions_inputs_not_in_lockstep_total",
-			Help: "Number of compositions that have input resources that are not in lockstep with the composition's current state",
-		},
-	)
-
-	compositionsWithoutSynthesizers = prometheus.NewGauge(
-		prometheus.GaugeOpts{
-			Name: "eno_compositions_without_synthesizers_total",
-			Help: "Number of compositions that do not have synthesizers",
-		},
-	)
-
-	pendingInitialReconciliation = prometheus.NewGauge(
-		prometheus.GaugeOpts{
-			Name: "eno_compositions_pending_initial_reconciliation",
-			Help: "Number of compositions that have not been reconciled since a period after their creation",
-		},
-	)
-
-	stuckReconciling = prometheus.NewGauge(
+	stuckReconciling = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "eno_compositions_stuck_reconciling_total",
 			Help: "Number of compositions that have not been reconciled since a period after their current synthesis was initialized",
-		},
+		}, []string{"synthesizer"},
 	)
 
-	pendingReadiness = prometheus.NewGauge(
+	nonready = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "eno_compositions_nonready_total",
 			Help: "Number of compositions that have not become ready since a period after their reconciliation",
-		},
+		}, []string{"synthesizer"},
 	)
 
-	terminalErrors = prometheus.NewGauge(
+	terminalErrors = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "eno_compositions_terminal_error_total",
 			Help: "Number of compositions that terminally failed synthesis and will not be retried",
-		},
+		}, []string{"synthesizer"},
 	)
 )
 
 func init() {
-	metrics.Registry.MustRegister(waitingOnInputs, inputsNotInLockstep, compositionsWithoutSynthesizers, pendingInitialReconciliation, stuckReconciling, pendingReadiness, terminalErrors)
+	metrics.Registry.MustRegister(inputsMissing, stuckReconciling, nonready, terminalErrors)
 }


### PR DESCRIPTION
- Refactor how the metrics are evaluated
- Add label for synthesizer name
- Consolidate input-related metrics
- Remove redundant metrics