### PR TITLE
Remove possible concurrent map access

### DIFF
--- a/internal/reconstitution/cache.go
+++ b/internal/reconstitution/cache.go
@@ -202,7 +202,6 @@ func (c *Cache) buildResources(ctx context.Context, comp *apiv1.Composition, ite
 				return nil, nil, fmt.Errorf("building resource at index %d of slice %s: %w", i, slice.Name, err)
 			}
 			resources.ByRef[res.Ref] = res
-			c.byIndex[sliceIndex{Index: i, SliceName: slice.Name, Namespace: slice.Namespace}] = res
 			resources.ByGroupKind[res.GVK.GroupKind()] = append(resources.ByGroupKind[res.GVK.GroupKind()], res)
 
 			current, _ := resources.ByReadinessGroup.Get(res.ReadinessGroup)

--- a/internal/reconstitution/cache.go
+++ b/internal/reconstitution/cache.go
@@ -175,6 +175,11 @@ func (c *Cache) fill(ctx context.Context, comp *apiv1.Composition, synthesis *ap
 	synKey := SynthesisRef{CompositionName: comp.Name, Namespace: comp.Namespace, UUID: synthesis.UUID}
 	c.resources[synKey] = resources
 
+	for _, resource := range resources.ByRef {
+		// TODO: Where do these get cleaned up?
+		c.byIndex[sliceIndex{Index: resource.ManifestRef.Index, SliceName: resource.ManifestRef.Slice.Name, Namespace: resource.ManifestRef.Slice.Namespace}] = resource
+	}
+
 	compNSN := types.NamespacedName{Name: comp.Name, Namespace: comp.Namespace}
 	c.synthesisUUIDsByComposition[compNSN] = append(c.synthesisUUIDsByComposition[compNSN], synKey.UUID)
 


### PR DESCRIPTION
There's a very rare test flake caused by concurrent map access in the reconstitution cache.