### PR TITLE
Synthesis priority bugfix

### DIFF
--- a/go.work.sum
+++ b/go.work.sum
@@ -400,6 +400,7 @@ golang.org/x/net v0.0.0-20211123203042-d83791d6bcd9/go.mod h1:9nx3DQGgdP8bBQD5qx
 golang.org/x/net v0.21.0/go.mod h1:bIjVDfnllIU7BJ2DNgfnXvpSvtn8VRwhlsaeUTyUS44=
 golang.org/x/net v0.22.0/go.mod h1:JKghWKKOSdJwpW2GEx0Ja7fmaKnMsbu+MWVZTokSYmg=
 golang.org/x/net v0.25.0/go.mod h1:JkAGAh7GEvH74S6FOH42FLoXpXbE/aqXSrIQjXgsiwM=
+golang.org/x/net v0.26.0/go.mod h1:5YKkiSynbBIh3p6iOc/vibscux0x38BZDkn8sCUPxHE=
 golang.org/x/net v0.28.0/go.mod h1:yqtgsTWOOnlGLG9GFRrK3++bGOUEkNBoHZc8MEDWPNg=
 golang.org/x/net v0.30.0/go.mod h1:2wGyMJ5iFasEhkwi13ChkO/t1ECNC4X4eBKkVFyYFlU=
 golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=

--- a/internal/controllers/scheduling/controller.go
+++ b/internal/controllers/scheduling/controller.go
@@ -113,7 +113,7 @@ func (c *controller) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		}
 
 		next := newOp(&synth, &comp)
-		if next != nil && (op == nil || op.Less(next)) {
+		if next != nil && (op == nil || next.Less(op)) {
 			op = next
 		}
 	}
@@ -138,15 +138,14 @@ func (c *controller) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 
 	if err := c.dispatchOp(ctx, op); err != nil {
 		if errors.IsInvalid(err) {
-			logger.V(0).Info("conflict while dispatching synthesis")
-			return ctrl.Result{}, nil
+			return ctrl.Result{}, fmt.Errorf("conflict while dispatching synthesis")
 		}
 		return ctrl.Result{}, fmt.Errorf("dispatching synthesis operation: %w", err)
 	}
 
 	op.Dispatched = time.Now()
 	c.lastApplied = op
-	logger.V(0).Info("dispatched synthesis")
+	logger.V(0).Info("dispatched synthesis", "synthesisUUID", op.id)
 
 	return ctrl.Result{}, nil
 }

--- a/internal/controllers/scheduling/controller_test.go
+++ b/internal/controllers/scheduling/controller_test.go
@@ -413,7 +413,7 @@ func TestSerializationGracePeriod(t *testing.T) {
 	ctx := testutil.NewContext(t)
 	cli := testutil.NewClient(t)
 
-	c := &controller{client: cli, concurrencyLimit: 1, cacheGracePeriod: time.Millisecond * 100}
+	c := &controller{client: cli, concurrencyLimit: 2, cacheGracePeriod: time.Millisecond * 100}
 
 	synth := &apiv1.Synthesizer{}
 	synth.Name = "test-synth"
@@ -469,32 +469,50 @@ func TestDispatchOrder(t *testing.T) {
 	synth := &apiv1.Synthesizer{}
 	synth.Name = "test-synth"
 	synth.Namespace = "default"
+	synth.Generation = 2
 	require.NoError(t, cli.Create(ctx, synth))
 
 	// Waiting for the new synth
 	comp := &apiv1.Composition{}
-	comp.Name = "test-comp-1"
 	comp.Namespace = "default"
 	comp.Finalizers = []string{"eno.azure.io/cleanup"}
 	comp.Generation = 2
 	comp.Spec.Synthesizer.Name = synth.Name
-	comp.Status.CurrentSynthesis = &apiv1.Synthesis{UUID: "foo", ObservedCompositionGeneration: 1, Synthesized: ptr.To(metav1.Now())}
+	comp.Status.CurrentSynthesis = &apiv1.Synthesis{
+		UUID:                          "foo",
+		ObservedCompositionGeneration: comp.Generation,
+		ObservedSynthesizerGeneration: synth.Generation,
+		Synthesized:                   ptr.To(metav1.Now()),
+	}
+
+	comp1 := comp.DeepCopy()
+	comp1.Name = "test-comp-1"
+	comp1.Status.CurrentSynthesis.ObservedCompositionGeneration--
+	require.NoError(t, cli.Create(ctx, comp1))
+	require.NoError(t, cli.Status().Update(ctx, comp1))
 
 	comp2 := comp.DeepCopy()
 	comp2.Name = "test-comp-2"
-	comp2.Status.CurrentSynthesis.ObservedSynthesizerGeneration = synth.Generation
-	require.NoError(t, cli.Create(ctx, comp))
+	comp2.Status.CurrentSynthesis.ObservedSynthesizerGeneration--
 	require.NoError(t, cli.Create(ctx, comp2))
-
-	require.NoError(t, cli.Status().Update(ctx, comp))
 	require.NoError(t, cli.Status().Update(ctx, comp2))
 
 	// Dispatch one of the syntheses
 	_, err := c.Reconcile(ctx, ctrl.Request{})
 	require.NoError(t, err)
 
-	require.NoError(t, cli.Get(ctx, client.ObjectKeyFromObject(comp), comp))
-	assert.True(t, comp.Synthesizing())
+	require.NoError(t, cli.Get(ctx, client.ObjectKeyFromObject(comp1), comp1))
+	assert.True(t, comp1.Synthesizing())
+
+	require.NoError(t, cli.Get(ctx, client.ObjectKeyFromObject(comp2), comp2))
+	assert.False(t, comp2.Synthesizing())
+
+	// Serialize the synthesizer rollout into "composition time"
+	_, err = c.Reconcile(ctx, ctrl.Request{})
+	require.NoError(t, err)
+
+	require.NoError(t, cli.Get(ctx, client.ObjectKeyFromObject(comp1), comp1))
+	assert.True(t, comp1.Synthesizing())
 
 	require.NoError(t, cli.Get(ctx, client.ObjectKeyFromObject(comp2), comp2))
 	assert.False(t, comp2.Synthesizing())
@@ -503,8 +521,8 @@ func TestDispatchOrder(t *testing.T) {
 	_, err = c.Reconcile(ctx, ctrl.Request{})
 	require.NoError(t, err)
 
-	require.NoError(t, cli.Get(ctx, client.ObjectKeyFromObject(comp), comp))
-	assert.True(t, comp.Synthesizing())
+	require.NoError(t, cli.Get(ctx, client.ObjectKeyFromObject(comp1), comp1))
+	assert.True(t, comp1.Synthesizing())
 
 	require.NoError(t, cli.Get(ctx, client.ObjectKeyFromObject(comp2), comp2))
 	assert.True(t, comp2.Synthesizing())


### PR DESCRIPTION
Fixes a priority sorting bug in the scheduling controller, slightly refactors for clarity, and improves fuzz test coverage for the `newOp` function.