### PR TITLE
helmshim: call write() for default output writer only in RenderChart func

### DIFF
--- a/pkg/helmshim/helm.go
+++ b/pkg/helmshim/helm.go
@@ -58,7 +58,10 @@ func RenderChart(opts ...RenderOption) error {
 			return err
 		}
 	}
+
+	var usingDefaultWriter bool
 	if o.Writer == nil {
+		usingDefaultWriter = true
 		o.Writer = function.NewDefaultOutputWriter()
 	}
 
@@ -95,7 +98,11 @@ func RenderChart(opts ...RenderOption) error {
 		o.Writer.Add(m)
 	}
 
-	return o.Writer.Write()
+	if usingDefaultWriter {
+		return o.Writer.Write()
+	}
+
+	return nil
 }
 
 func inputsToValues(i *function.InputReader) (map[string]any, error) {

--- a/pkg/helmshim/helm_test.go
+++ b/pkg/helmshim/helm_test.go
@@ -2,6 +2,7 @@ package helmshim
 
 import (
 	"bytes"
+	"os"
 	"testing"
 
 	"github.com/Azure/eno/pkg/function"
@@ -16,10 +17,35 @@ func TestRenderChart(t *testing.T) {
 	input := bytes.NewBufferString(`{ "items": [{ "apiVersion": "v1", "kind": "ConfigMap", "metadata": { "name": "test-cm", "annotations": { "eno.azure.io/input-key": "foo" } } }] }`)
 	i, err := function.NewInputReader(input)
 	require.NoError(t, err)
-
 	err = RenderChart(WithInputReader(i), WithOutputWriter(o), WithChartPath("fixtures/basic-chart"))
 	require.NoError(t, err)
+	o.Write()
 	assert.Equal(t, "{\"apiVersion\":\"config.kubernetes.io/v1\",\"kind\":\"ResourceList\",\"items\":[{\"apiVersion\":\"v1\",\"data\":{\"input\":\"{\\\"apiVersion\\\":\\\"v1\\\",\\\"kind\\\":\\\"ConfigMap\\\",\\\"metadata\\\":{\\\"annotations\\\":{\\\"eno.azure.io/input-key\\\":\\\"foo\\\"},\\\"name\\\":\\\"test-cm\\\"}}\",\"inputResourceName\":\"test-cm\",\"some\":\"value\"},\"kind\":\"ConfigMap\",\"metadata\":{\"name\":null}},{\"apiVersion\":\"somegroup.io/v9001\",\"kind\":\"ATypeNotKnownByTheScheme\",\"metadata\":{\"name\":\"foo\"}}]}\n", output.String())
+}
+
+func TestRenderChartWithDefaultOutputWriter(t *testing.T) {
+	// Save the original stdout and redirect it to a pipe.
+	oldStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	input := bytes.NewBufferString(`{ "items": [{ "apiVersion": "v1", "kind": "ConfigMap", "metadata": { "name": "test-cm", "annotations": { "eno.azure.io/input-key": "foo" } } }] }`)
+	i, err := function.NewInputReader(input)
+	require.NoError(t, err)
+	// Do not provide an output writer and use the default output writer.
+	err = RenderChart(WithInputReader(i), WithChartPath("fixtures/basic-chart"))
+	require.NoError(t, err)
+
+	// Close the writer and capture the output from reader.
+	w.Close()
+	var buf bytes.Buffer
+	buf.ReadFrom(r)
+	output := buf.String()
+	// Restore the original stdout.
+	os.Stdout = oldStdout
+
+	// Check the output.
+	assert.Equal(t, "{\"apiVersion\":\"config.kubernetes.io/v1\",\"kind\":\"ResourceList\",\"items\":[{\"apiVersion\":\"v1\",\"data\":{\"input\":\"{\\\"apiVersion\\\":\\\"v1\\\",\\\"kind\\\":\\\"ConfigMap\\\",\\\"metadata\\\":{\\\"annotations\\\":{\\\"eno.azure.io/input-key\\\":\\\"foo\\\"},\\\"name\\\":\\\"test-cm\\\"}}\",\"inputResourceName\":\"test-cm\",\"some\":\"value\"},\"kind\":\"ConfigMap\",\"metadata\":{\"name\":null}},{\"apiVersion\":\"somegroup.io/v9001\",\"kind\":\"ATypeNotKnownByTheScheme\",\"metadata\":{\"name\":\"foo\"}}]}\n", output)
 }
 
 func TestRenderChartWithCustomValues(t *testing.T) {
@@ -36,6 +62,7 @@ func TestRenderChartWithCustomValues(t *testing.T) {
 			return map[string]any{"name": "my-test-cm"}, nil
 		}))
 	require.NoError(t, err)
+	o.Write()
 	assert.Equal(t, "{\"apiVersion\":\"config.kubernetes.io/v1\",\"kind\":\"ResourceList\",\"items\":[{\"apiVersion\":\"v1\",\"data\":{\"input\":\"null\",\"some\":\"value\"},\"kind\":\"ConfigMap\",\"metadata\":{\"name\":\"my-test-cm\"}},{\"apiVersion\":\"somegroup.io/v9001\",\"kind\":\"ATypeNotKnownByTheScheme\",\"metadata\":{\"name\":\"foo\"}}]}\n", output.String())
 }
 
@@ -52,7 +79,7 @@ func TestRenderChartWithHelmHook(t *testing.T) {
 		WithValuesFunc(func(ir *function.InputReader) (map[string]any, error) {
 			return map[string]any{"name": "my-test-cm"}, nil
 		}))
-
 	require.NoError(t, err)
+	o.Write()
 	assert.Equal(t, "{\"apiVersion\":\"config.kubernetes.io/v1\",\"kind\":\"ResourceList\",\"items\":[{\"apiVersion\":\"somegroup.io/v9001\",\"kind\":\"ATypeNotKnownByTheScheme\",\"metadata\":{\"name\":\"foo\"}},{\"apiVersion\":\"v1\",\"data\":{\"some\":\"value\"},\"kind\":\"ConfigMap\",\"metadata\":{\"annotations\":{\"helm.sh/hook\":\"post-install,post-upgrade\",\"helm.sh/hook-delete-policy\":\"before-hook-creation\",\"helm.sh/hook-weight\":\"1\"},\"name\":\"my-test-cm\"}}]}\n", output.String())
 }

--- a/pkg/helmshim/helm_test.go
+++ b/pkg/helmshim/helm_test.go
@@ -19,7 +19,8 @@ func TestRenderChart(t *testing.T) {
 	require.NoError(t, err)
 	err = RenderChart(WithInputReader(i), WithOutputWriter(o), WithChartPath("fixtures/basic-chart"))
 	require.NoError(t, err)
-	o.Write()
+	err = o.Write()
+	require.NoError(t, err)
 	assert.Equal(t, "{\"apiVersion\":\"config.kubernetes.io/v1\",\"kind\":\"ResourceList\",\"items\":[{\"apiVersion\":\"v1\",\"data\":{\"input\":\"{\\\"apiVersion\\\":\\\"v1\\\",\\\"kind\\\":\\\"ConfigMap\\\",\\\"metadata\\\":{\\\"annotations\\\":{\\\"eno.azure.io/input-key\\\":\\\"foo\\\"},\\\"name\\\":\\\"test-cm\\\"}}\",\"inputResourceName\":\"test-cm\",\"some\":\"value\"},\"kind\":\"ConfigMap\",\"metadata\":{\"name\":null}},{\"apiVersion\":\"somegroup.io/v9001\",\"kind\":\"ATypeNotKnownByTheScheme\",\"metadata\":{\"name\":\"foo\"}}]}\n", output.String())
 }
 
@@ -62,7 +63,8 @@ func TestRenderChartWithCustomValues(t *testing.T) {
 			return map[string]any{"name": "my-test-cm"}, nil
 		}))
 	require.NoError(t, err)
-	o.Write()
+	err = o.Write()
+	require.NoError(t, err)
 	assert.Equal(t, "{\"apiVersion\":\"config.kubernetes.io/v1\",\"kind\":\"ResourceList\",\"items\":[{\"apiVersion\":\"v1\",\"data\":{\"input\":\"null\",\"some\":\"value\"},\"kind\":\"ConfigMap\",\"metadata\":{\"name\":\"my-test-cm\"}},{\"apiVersion\":\"somegroup.io/v9001\",\"kind\":\"ATypeNotKnownByTheScheme\",\"metadata\":{\"name\":\"foo\"}}]}\n", output.String())
 }
 
@@ -80,6 +82,7 @@ func TestRenderChartWithHelmHook(t *testing.T) {
 			return map[string]any{"name": "my-test-cm"}, nil
 		}))
 	require.NoError(t, err)
-	o.Write()
+	err = o.Write()
+	require.NoError(t, err)
 	assert.Equal(t, "{\"apiVersion\":\"config.kubernetes.io/v1\",\"kind\":\"ResourceList\",\"items\":[{\"apiVersion\":\"somegroup.io/v9001\",\"kind\":\"ATypeNotKnownByTheScheme\",\"metadata\":{\"name\":\"foo\"}},{\"apiVersion\":\"v1\",\"data\":{\"some\":\"value\"},\"kind\":\"ConfigMap\",\"metadata\":{\"annotations\":{\"helm.sh/hook\":\"post-install,post-upgrade\",\"helm.sh/hook-delete-policy\":\"before-hook-creation\",\"helm.sh/hook-weight\":\"1\"},\"name\":\"my-test-cm\"}}]}\n", output.String())
 }

--- a/pkg/helmshim/helm_test.go
+++ b/pkg/helmshim/helm_test.go
@@ -2,16 +2,12 @@ package helmshim
 
 import (
 	"bytes"
-	"os"
 	"testing"
 
 	"github.com/Azure/eno/pkg/function"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
-
-// package level stdout for testing without modifying the global stdout
-var stdout = os.Stdout
 
 func TestRenderChart(t *testing.T) {
 	output := bytes.NewBuffer(nil)
@@ -25,37 +21,6 @@ func TestRenderChart(t *testing.T) {
 	err = o.Write()
 	require.NoError(t, err)
 	assert.Equal(t, "{\"apiVersion\":\"config.kubernetes.io/v1\",\"kind\":\"ResourceList\",\"items\":[{\"apiVersion\":\"v1\",\"data\":{\"input\":\"{\\\"apiVersion\\\":\\\"v1\\\",\\\"kind\\\":\\\"ConfigMap\\\",\\\"metadata\\\":{\\\"annotations\\\":{\\\"eno.azure.io/input-key\\\":\\\"foo\\\"},\\\"name\\\":\\\"test-cm\\\"}}\",\"inputResourceName\":\"test-cm\",\"some\":\"value\"},\"kind\":\"ConfigMap\",\"metadata\":{\"name\":null}},{\"apiVersion\":\"somegroup.io/v9001\",\"kind\":\"ATypeNotKnownByTheScheme\",\"metadata\":{\"name\":\"foo\"}}]}\n", output.String())
-}
-
-func TestRenderChartWithDefaultOutputWriter(t *testing.T) {
-	// Save the original stdout and redirect it to a pipe.
-	oldStdout := stdout
-	r, w, _ := os.Pipe()
-	stdout = w
-	// Ensure the original stdout is restored even the test fails.
-	defer func() {
-		stdout = oldStdout
-	}()
-
-	input := bytes.NewBufferString(`{ "items": [{ "apiVersion": "v1", "kind": "ConfigMap", "metadata": { "name": "test-cm", "annotations": { "eno.azure.io/input-key": "foo" } } }] }`)
-	i, err := function.NewInputReader(input)
-	require.NoError(t, err)
-	// Create output writer with the stdout to simulate the default output writer with os.Stdout.
-	o := function.NewOutputWriter(stdout, nil)
-
-	err = RenderChart(WithInputReader(i), WithOutputWriter(o), WithChartPath("fixtures/basic-chart"))
-	require.NoError(t, err)
-	err = o.Write()
-	require.NoError(t, err)
-
-	// Close the writer and capture the output from reader.
-	w.Close()
-	var buf bytes.Buffer
-	buf.ReadFrom(r)
-	output := buf.String()
-
-	// Check the output.
-	assert.Equal(t, "{\"apiVersion\":\"config.kubernetes.io/v1\",\"kind\":\"ResourceList\",\"items\":[{\"apiVersion\":\"v1\",\"data\":{\"input\":\"{\\\"apiVersion\\\":\\\"v1\\\",\\\"kind\\\":\\\"ConfigMap\\\",\\\"metadata\\\":{\\\"annotations\\\":{\\\"eno.azure.io/input-key\\\":\\\"foo\\\"},\\\"name\\\":\\\"test-cm\\\"}}\",\"inputResourceName\":\"test-cm\",\"some\":\"value\"},\"kind\":\"ConfigMap\",\"metadata\":{\"name\":null}},{\"apiVersion\":\"somegroup.io/v9001\",\"kind\":\"ATypeNotKnownByTheScheme\",\"metadata\":{\"name\":\"foo\"}}]}\n", output)
 }
 
 func TestRenderChartWithCustomValues(t *testing.T) {


### PR DESCRIPTION
Call write() for default output writer only in RenderChart func. If the client provides an output writer, it should handle write() itself for flexibility.