### PR TITLE
Use composition as deletion signal instead of resource slices

### DIFF
--- a/api/v1/composition.go
+++ b/api/v1/composition.go
@@ -243,3 +243,7 @@ func (c *Composition) ShouldForceResynthesis() bool {
 	val, ok := c.GetAnnotations()[forceResynthesisAnnotation]
 	return ok && val == c.Status.GetCurrentSynthesisUUID()
 }
+
+func (c *Composition) ShouldOrphanResources() bool {
+	return c.Annotations["eno.azure.io/deletion-strategy"] == "orphan"
+}

--- a/internal/controllers/synthesis/slicecleanup.go
+++ b/internal/controllers/synthesis/slicecleanup.go
@@ -191,7 +191,7 @@ func resourcesRemain(comp *apiv1.Composition, slice *apiv1.ResourceSlice) bool {
 	if len(slice.Status.Resources) == 0 && len(slice.Spec.Resources) > 0 {
 		return true // status is lagging behind
 	}
-	shouldOrphan := comp != nil && comp.Annotations != nil && comp.Annotations["eno.azure.io/deletion-strategy"] == "orphan"
+	shouldOrphan := comp != nil && comp.ShouldOrphanResources()
 	for _, state := range slice.Status.Resources {
 		if !state.Deleted && !shouldOrphan {
 			return true


### PR DESCRIPTION
Currently the reconciliation controller deletes resources when their defining resource slice is deleting. This kind of makes sense conceptually but not pragmatically since it complicates the logic used to clean up resource slices.

This change sets us up to simplify the logic of the slice cleanup controller without actually modifying any behavior (for now).