### PR TITLE
Handle case where resource version doesn't change after update

### DIFF
--- a/internal/controllers/reconciliation/controller.go
+++ b/internal/controllers/reconciliation/controller.go
@@ -244,12 +244,12 @@ func (c *Controller) reconcileResource(ctx context.Context, comp *apiv1.Composit
 			return false, fmt.Errorf("encoding json patch: %w", err)
 		}
 
+		reconciliationActions.WithLabelValues("patch").Inc()
 		err = c.upstreamClient.Patch(ctx, current, client.RawPatch(types.JSONPatchType, patch))
 		if err != nil {
 			return false, fmt.Errorf("applying patch: %w", err)
 		}
 
-		reconciliationActions.WithLabelValues("patch").Inc()
 		logger.V(0).Info("patched resource", "resourceVersion", current.GetResourceVersion())
 		return true, nil
 	}
@@ -268,12 +268,17 @@ func (c *Controller) reconcileResource(ctx context.Context, comp *apiv1.Composit
 		logger.V(1).Info("INSECURE logging patch", "update", string(js))
 	}
 
+	reconciliationActions.WithLabelValues("patch").Inc()
 	err = c.upstreamClient.Update(ctx, updated)
 	if err != nil {
 		return false, fmt.Errorf("applying update: %w", err)
 	}
 
-	reconciliationActions.WithLabelValues("patch").Inc()
+	if updated.GetResourceVersion() == current.GetResourceVersion() {
+		logger.V(0).Info("updated resource but it did not change", "resourceVersion", updated.GetResourceVersion(), "typedMerge", typed)
+		return false, nil
+	}
+
 	logger.V(0).Info("updated resource", "resourceVersion", updated.GetResourceVersion(), "previousResourceVersion", current.GetResourceVersion(), "typedMerge", typed)
 	return true, nil
 }

--- a/internal/controllers/reconciliation/edgecase_test.go
+++ b/internal/controllers/reconciliation/edgecase_test.go
@@ -263,6 +263,65 @@ func TestPatchStrategyReplace(t *testing.T) {
 	})
 }
 
+func TestDeploymentFieldRefs(t *testing.T) {
+	scheme := runtime.NewScheme()
+	corev1.SchemeBuilder.AddToScheme(scheme)
+	testv1.SchemeBuilder.AddToScheme(scheme)
+
+	ctx := testutil.NewContext(t)
+	mgr := testutil.NewManager(t)
+	upstream := mgr.GetClient()
+
+	registerControllers(t, mgr)
+	testutil.WithFakeExecutor(t, mgr, func(ctx context.Context, s *apiv1.Synthesizer, input *krmv1.ResourceList) (*krmv1.ResourceList, error) {
+		output := &krmv1.ResourceList{}
+		output.Items = []*unstructured.Unstructured{{
+			Object: map[string]any{
+				"apiVersion": "apps/v1",
+				"kind":       "Deployment", // only PDBs set patch strategy == replace
+				"metadata": map[string]any{
+					"name":      "test-obj",
+					"namespace": "default",
+				},
+				"spec": map[string]any{
+					"selector": map[string]any{
+						"matchLabels": map[string]any{"app": "foobar"},
+					},
+					"template": map[string]any{
+						"metadata": map[string]any{
+							"labels": map[string]string{"app": "foobar"},
+						},
+						"spec": map[string]any{
+							"containers": []map[string]any{{
+								"name":  "nginx",
+								"image": "nginx:latest",
+								"env": []map[string]any{{
+									"name": "FOO",
+									"valueFrom": map[string]any{
+										"fieldRef": map[string]string{"fieldPath": "metadata.namespace"},
+									},
+								}},
+							}},
+						},
+					},
+				},
+			},
+		}}
+		return output, nil
+	})
+
+	// Test subject
+	setupTestSubject(t, mgr)
+	mgr.Start(t)
+	_, comp := writeGenericComposition(t, upstream)
+
+	// It should be able to become ready
+	testutil.Eventually(t, func() bool {
+		err := upstream.Get(ctx, client.ObjectKeyFromObject(comp), comp)
+		return err == nil && comp.Status.CurrentSynthesis != nil && comp.Status.CurrentSynthesis.Ready != nil && comp.Status.CurrentSynthesis.ObservedCompositionGeneration == comp.Generation
+	})
+}
+
 // TestRemoveProperty proves that properties can be removed as part of the three-way merge.
 func TestRemoveProperty(t *testing.T) {
 	scheme := runtime.NewScheme()

--- a/internal/resource/resource_test.go
+++ b/internal/resource/resource_test.go
@@ -342,7 +342,12 @@ func testMergeBasics(t *testing.T, schemaName string) {
 	merged, typed, err = newState.Merge(ctx, oldState, expected, sg)
 	require.NoError(t, err)
 	assert.Equal(t, schemaName != "", typed)
-	assert.Nil(t, merged)
+
+	if schemaName == "" {
+		assert.NotNil(t, merged)
+	} else {
+		assert.Nil(t, merged)
+	}
 }
 
 func TestResourceOrdering(t *testing.T) {


### PR DESCRIPTION
The builtin APIs are full of edge cases where SMD and even the client-go scheme are not capable of comparing two versions of an API object. A few examples are documented in integration tests: resource quantities, fieldRefs, etc.

Eno currently uses a combination of SMD's equality logic and the scheme. But it turns out that the client-go scheme doesn't support defaulting - that requires importing a scheme for kubernetes/kubernetes, which is... not ideal.

So this PR proposes a different approach: keep updating until the resource version doesn't change. This essentially outsources the equality logic to apiserver: it compares the current/updated objects to determine if the write (and thus new resource version) is necessary.

Ideally synthesizers would set the relevant fields to avoid hitting this code. But IMO it's a better protection against tightloops than fully trusting Eno's comparison logic.