### PR TITLE
Improved resource interface

### DIFF
--- a/internal/controllers/reconciliation/controller.go
+++ b/internal/controllers/reconciliation/controller.go
@@ -203,11 +203,7 @@ func (c *Controller) reconcileResource(ctx context.Context, comp *apiv1.Composit
 	// Create the resource when it doesn't exist
 	if current == nil {
 		reconciliationActions.WithLabelValues("create").Inc()
-		obj, err := resource.Parse()
-		if err != nil {
-			return false, fmt.Errorf("invalid resource: %w", err)
-		}
-		err = c.upstreamClient.Create(ctx, obj)
+		err := c.upstreamClient.Create(ctx, resource.Unstructured())
 		if err != nil {
 			return false, fmt.Errorf("creating resource: %w", err)
 		}

--- a/internal/controllers/reconciliation/controller.go
+++ b/internal/controllers/reconciliation/controller.go
@@ -137,13 +137,8 @@ func (c *Controller) Reconcile(ctx context.Context, req resource.Request) (ctrl.
 	// - Readiness checks are skipped when this version of the resource's desired state has already become ready
 	// - Readiness checks are skipped when the resource hasn't changed since the last check
 	// - Readiness defaults to true if no checks are given
-	slice := &apiv1.ResourceSlice{}
-	err = c.client.Get(ctx, resource.ManifestRef.Slice, slice)
-	if err != nil {
-		return ctrl.Result{}, fmt.Errorf("getting resource slice: %w", err)
-	}
 	var ready *metav1.Time
-	status := resource.FindStatus(slice)
+	status := resource.State()
 	if status == nil || status.Ready == nil {
 		readiness, ok := resource.ReadinessChecks.EvalOptionally(ctx, current)
 		if ok {

--- a/internal/controllers/reconciliation/helpers_test.go
+++ b/internal/controllers/reconciliation/helpers_test.go
@@ -85,9 +85,10 @@ func mapToResource(t *testing.T, res map[string]any) (*unstructured.Unstructured
 	js, err := obj.MarshalJSON()
 	require.NoError(t, err)
 
-	rr := &resource.Resource{
-		Manifest: &apiv1.Manifest{Manifest: string(js)},
-		GVK:      obj.GroupVersionKind(),
-	}
+	slice := &apiv1.ResourceSlice{}
+	slice.Spec.Resources = []apiv1.Manifest{{Manifest: string(js)}}
+	rr, err := resource.NewResource(context.Background(), slice, 0)
+	require.NoError(t, err)
+
 	return obj, rr
 }

--- a/internal/resource/resource.go
+++ b/internal/resource/resource.go
@@ -241,10 +241,6 @@ func NewResource(ctx context.Context, slice *apiv1.ResourceSlice, index int) (*R
 	if err != nil {
 		return nil, fmt.Errorf("invalid json: %w", err)
 	}
-	if parsed.Object != nil {
-		delete(parsed.Object, "status")
-		parsed.SetCreationTimestamp(metav1.Time{})
-	}
 
 	res.value = value.NewValueInterface(parsed.Object)
 	gvk := parsed.GroupVersionKind()

--- a/internal/resource/resource.go
+++ b/internal/resource/resource.go
@@ -241,6 +241,10 @@ func NewResource(ctx context.Context, slice *apiv1.ResourceSlice, index int) (*R
 	if err != nil {
 		return nil, fmt.Errorf("invalid json: %w", err)
 	}
+	if parsed.Object != nil {
+		delete(parsed.Object, "status")
+		parsed.SetCreationTimestamp(metav1.Time{})
+	}
 
 	res.value = value.NewValueInterface(parsed.Object)
 	gvk := parsed.GroupVersionKind()

--- a/internal/resource/resource.go
+++ b/internal/resource/resource.go
@@ -7,7 +7,6 @@ import (
 	"sort"
 	"strconv"
 	"strings"
-	"sync"
 	"time"
 
 	apiv1 "github.com/Azure/eno/api/v1"
@@ -49,8 +48,6 @@ type ManifestRef struct {
 
 // Resource is the controller's internal representation of a single resource out of a ResourceSlice.
 type Resource struct {
-	lastReconciledMeta
-
 	Ref               Ref
 	Manifest          *apiv1.Manifest
 	ManifestRef       ManifestRef
@@ -338,26 +335,6 @@ type patchMeta struct {
 	APIVersion string          `json:"apiVersion"`
 	Kind       string          `json:"kind"`
 	Ops        jsonpatch.Patch `json:"ops"`
-}
-
-type lastReconciledMeta struct {
-	lock           sync.Mutex
-	lastReconciled *time.Time
-}
-
-func (l *lastReconciledMeta) ObserveReconciliation() time.Duration {
-	now := time.Now()
-
-	l.lock.Lock()
-	defer l.lock.Unlock()
-
-	var latency time.Duration
-	if l.lastReconciled != nil {
-		latency = now.Sub(*l.lastReconciled)
-	}
-
-	l.lastReconciled = &now
-	return time.Duration(latency.Abs().Milliseconds())
 }
 
 func NewInputRevisions(obj client.Object, refKey string) *apiv1.InputRevisions {

--- a/internal/resource/resource.go
+++ b/internal/resource/resource.go
@@ -241,6 +241,10 @@ func NewResource(ctx context.Context, slice *apiv1.ResourceSlice, index int) (*R
 	if err != nil {
 		return nil, fmt.Errorf("invalid json: %w", err)
 	}
+
+	// Prune out the status/creation time.
+	// This is a pragmatic choice to make Eno behave in expected ways for synthesizers written using client-go structs,
+	// which set metadata.creationTime=null and status={}.
 	if parsed.Object != nil {
 		delete(parsed.Object, "status")
 		parsed.SetCreationTimestamp(metav1.Time{})

--- a/internal/resource/resource_test.go
+++ b/internal/resource/resource_test.go
@@ -352,11 +352,11 @@ func testMergeBasics(t *testing.T, schemaName string) {
 
 func TestResourceOrdering(t *testing.T) {
 	resources := []*Resource{
-		{Manifest: &apiv1.Manifest{Manifest: "a"}},
+		{ManifestHash: []byte("a")},
 		{},
-		{Manifest: &apiv1.Manifest{Manifest: "b"}},
+		{ManifestHash: []byte("b")},
 		{},
-		{Manifest: &apiv1.Manifest{Manifest: "c"}},
+		{ManifestHash: []byte("c")},
 	}
 	sort.Slice(resources, func(i, j int) bool {
 		return resources[i].Less(resources[j])
@@ -365,9 +365,9 @@ func TestResourceOrdering(t *testing.T) {
 	assert.Equal(t, []*Resource{
 		{},
 		{},
-		{Manifest: &apiv1.Manifest{Manifest: "a"}},
-		{Manifest: &apiv1.Manifest{Manifest: "b"}},
-		{Manifest: &apiv1.Manifest{Manifest: "c"}},
+		{ManifestHash: []byte("a")},
+		{ManifestHash: []byte("b")},
+		{ManifestHash: []byte("c")},
 	}, resources)
 }
 

--- a/internal/resource/tree.go
+++ b/internal/resource/tree.go
@@ -127,6 +127,8 @@ func (t *tree) UpdateState(comp *apiv1.Composition, ref ManifestRef, state *apiv
 	if (!idx.Seen && lastKnown == nil) || !lastKnown.Equal(state) || (!idx.CompositionDeleting && comp.DeletionTimestamp != nil) {
 		enqueue(idx.Resource.Ref)
 	}
+	idx.Seen = true
+	idx.CompositionDeleting = comp.DeletionTimestamp != nil
 
 	// Dependents should no longer be blocked by this resource
 	if state.Ready != nil && (lastKnown == nil || lastKnown.Ready == nil) {
@@ -135,9 +137,6 @@ func (t *tree) UpdateState(comp *apiv1.Composition, ref ManifestRef, state *apiv
 			enqueue(dep.Resource.Ref)
 		}
 	}
-
-	idx.CompositionDeleting = comp.DeletionTimestamp != nil // TODO: Should move to the top?
-	idx.Seen = true
 }
 
 // MarshalJSON allows the current tree to be serialized to JSON for testing/debugging purposes.

--- a/internal/resource/tree_test.go
+++ b/internal/resource/tree_test.go
@@ -302,12 +302,12 @@ func TestTreeDeletion(t *testing.T) {
 func TestTreeRefConflicts(t *testing.T) {
 	var b treeBuilder
 	b.Add(&Resource{
-		Ref:      newTestRef("test-resource"),
-		Manifest: &apiv1.Manifest{Manifest: "b"},
+		Ref:          newTestRef("test-resource"),
+		ManifestHash: []byte("b"),
 	})
 	b.Add(&Resource{
-		Ref:      newTestRef("test-resource"),
-		Manifest: &apiv1.Manifest{Manifest: "a"},
+		Ref:          newTestRef("test-resource"),
+		ManifestHash: []byte("a"),
 	})
 
 	tree := b.Build()
@@ -315,5 +315,5 @@ func TestTreeRefConflicts(t *testing.T) {
 	res, visible, found := tree.Get(newTestRef("test-resource"))
 	assert.True(t, found)
 	assert.True(t, visible)
-	assert.Equal(t, "b", res.Manifest.Manifest)
+	assert.Equal(t, "b", string(res.ManifestHash))
 }


### PR DESCRIPTION
- Don't bother caching the JSON manifest since we have the parsed SMD representation anyway
- Don't read the resource slice from the reconciliation controller - move the cached status up from the private indexed resource struct to the public Resource type
