### PR TITLE
Handle case where synthesizer sees newer inputs than watch controller

### DIFF
--- a/api/v1/composition.go
+++ b/api/v1/composition.go
@@ -1,6 +1,8 @@
 package v1
 
 import (
+	"strconv"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -121,17 +123,25 @@ type InputRevisions struct {
 	SynthesizerGeneration *int64 `json:"synthesizerGeneration,omitempty"`
 }
 
-func (i *InputRevisions) Equal(b InputRevisions) bool {
+func (i *InputRevisions) Less(b InputRevisions) bool {
 	if i.Key != b.Key {
-		return false
+		return false // shouldn't be possible
 	}
 	if (i.Revision == nil) != (b.Revision == nil) {
-		return false
+		return true
 	}
 	if i.Revision != nil {
-		return *i.Revision == *b.Revision
+		return *i.Revision < *b.Revision
 	}
-	return i.ResourceVersion == b.ResourceVersion
+	if i.ResourceVersion == b.ResourceVersion {
+		return false
+	}
+	iInt, iErr := strconv.Atoi(i.ResourceVersion)
+	bInt, bErr := strconv.Atoi(b.ResourceVersion)
+	if iErr != nil || bErr != nil {
+		return true // effectively fall back to equality comparison if they aren't ints (shouldn't be possible)
+	}
+	return iInt < bInt
 }
 
 func (s *Synthesis) Failed() bool {

--- a/api/v1/composition_test.go
+++ b/api/v1/composition_test.go
@@ -8,7 +8,7 @@ import (
 	"k8s.io/utils/ptr"
 )
 
-func TestInputRevisionsEqual(t *testing.T) {
+func TestInputRevisionsLess(t *testing.T) {
 	revision1 := 1
 	revision2 := 2
 	tests := []struct {
@@ -18,94 +18,150 @@ func TestInputRevisionsEqual(t *testing.T) {
 		Expectation bool
 	}{
 		{
-			Name: "Equal with nil revisions and same ResourceVersion",
+			Name: "nil revisions and same ResourceVersion",
 			A: InputRevisions{
 				Key:             "key1",
 				Revision:        nil,
-				ResourceVersion: "v1",
+				ResourceVersion: "1",
 			},
 			B: InputRevisions{
 				Key:             "key1",
 				Revision:        nil,
-				ResourceVersion: "v1",
+				ResourceVersion: "1",
+			},
+			Expectation: false,
+		},
+		{
+			Name: "nil revisions and < ResourceVersion",
+			A: InputRevisions{
+				Key:             "key1",
+				Revision:        nil,
+				ResourceVersion: "1",
+			},
+			B: InputRevisions{
+				Key:             "key1",
+				Revision:        nil,
+				ResourceVersion: "2",
 			},
 			Expectation: true,
 		},
 		{
-			Name: "Equal with non-nil revisions",
+			Name: "nil revisions and invalid non-matching ResourceVersions",
+			A: InputRevisions{
+				Key:             "key1",
+				Revision:        nil,
+				ResourceVersion: "foo",
+			},
+			B: InputRevisions{
+				Key:             "key1",
+				Revision:        nil,
+				ResourceVersion: "bar",
+			},
+			Expectation: true,
+		},
+		{
+			Name: "nil revisions and invalid matching ResourceVersions",
+			A: InputRevisions{
+				Key:             "key1",
+				Revision:        nil,
+				ResourceVersion: "foo",
+			},
+			B: InputRevisions{
+				Key:             "key1",
+				Revision:        nil,
+				ResourceVersion: "foo",
+			},
+			Expectation: false,
+		},
+		{
+			Name: "nil revisions and > ResourceVersion",
+			A: InputRevisions{
+				Key:             "key1",
+				Revision:        nil,
+				ResourceVersion: "2",
+			},
+			B: InputRevisions{
+				Key:             "key1",
+				Revision:        nil,
+				ResourceVersion: "1",
+			},
+			Expectation: false,
+		},
+		{
+			Name: "non-nil revisions equal",
 			A: InputRevisions{
 				Key:             "key2",
 				Revision:        &revision1,
-				ResourceVersion: "v2",
+				ResourceVersion: "2",
 			},
 			B: InputRevisions{
 				Key:             "key2",
 				Revision:        &revision1,
-				ResourceVersion: "v2",
+				ResourceVersion: "2",
+			},
+			Expectation: false,
+		},
+		{
+			Name: "non-nil revisions >",
+			A: InputRevisions{
+				Key:             "key2",
+				Revision:        &revision2,
+				ResourceVersion: "2",
+			},
+			B: InputRevisions{
+				Key:             "key2",
+				Revision:        &revision1,
+				ResourceVersion: "2",
+			},
+			Expectation: false,
+		},
+		{
+			Name: "non-nil revisions <",
+			A: InputRevisions{
+				Key:             "key2",
+				Revision:        &revision1,
+				ResourceVersion: "2",
+			},
+			B: InputRevisions{
+				Key:             "key2",
+				Revision:        &revision2,
+				ResourceVersion: "2",
 			},
 			Expectation: true,
 		},
 		{
-			Name: "Not equal with different keys",
+			Name: "different keys",
 			A: InputRevisions{
 				Key:             "key3",
 				Revision:        &revision1,
-				ResourceVersion: "v3",
+				ResourceVersion: "3",
 			},
 			B: InputRevisions{
 				Key:             "key4",
 				Revision:        &revision1,
-				ResourceVersion: "v3",
+				ResourceVersion: "3",
 			},
 			Expectation: false,
 		},
 		{
-			Name: "Not equal with different non-nil revisions",
-			A: InputRevisions{
-				Key:             "key5",
-				Revision:        &revision1,
-				ResourceVersion: "v5",
-			},
-			B: InputRevisions{
-				Key:             "key5",
-				Revision:        &revision2,
-				ResourceVersion: "v5",
-			},
-			Expectation: false,
-		},
-		{
-			Name: "Not equal with one nil and one non-nil revision",
+			Name: "one nil and one non-nil revision",
 			A: InputRevisions{
 				Key:             "key6",
 				Revision:        nil,
-				ResourceVersion: "v6",
+				ResourceVersion: "6",
 			},
 			B: InputRevisions{
 				Key:             "key6",
 				Revision:        &revision1,
-				ResourceVersion: "v6",
+				ResourceVersion: "6",
 			},
-			Expectation: false,
-		},
-		{
-			Name: "Not equal with same keys but different ResourceVersions",
-			A: InputRevisions{
-				Key:             "key7",
-				Revision:        nil,
-				ResourceVersion: "v7",
-			},
-			B: InputRevisions{
-				Key:             "key7",
-				Revision:        nil,
-				ResourceVersion: "v8",
-			},
-			Expectation: false,
+			Expectation: true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.Name, func(t *testing.T) {
-			result := tt.A.Equal(tt.B)
+			result := tt.A.Less(tt.B)
 			assert.Equal(t, tt.Expectation, result)
 		})
 	}

--- a/internal/controllers/scheduling/op.go
+++ b/internal/controllers/scheduling/op.go
@@ -230,7 +230,7 @@ func inputChangeCount(synth *apiv1.Synthesizer, a, b []apiv1.InputRevisions) (no
 			continue
 		}
 
-		if !ar.Equal(br) {
+		if br.Less(ar) {
 			if ref.Defer {
 				deferred++
 			} else {


### PR DESCRIPTION
It's possible for the watch controller or its informers to lag behind the view of the input resources seen by synthesizer pods. In this case the version equality check in the scheduling controller will be false and cause a resynthesis loop until the watch controller catches up.