### PR TITLE
Unblock reconciliation during synthesis

### DIFF
--- a/api/v1/composition.go
+++ b/api/v1/composition.go
@@ -52,7 +52,7 @@ type CompositionSpec struct {
 
 type CompositionStatus struct {
 	Simplified         *SimplifiedStatus `json:"simplified,omitempty"`
-	PendingSynthesis   *Synthesis        `json:"pendingSynthesis,omitempty"`
+	InFlightSynthesis  *Synthesis        `json:"inFlightSynthesis,omitempty"`
 	CurrentSynthesis   *Synthesis        `json:"currentSynthesis,omitempty"`
 	PreviousSynthesis  *Synthesis        `json:"previousSynthesis,omitempty"`
 	InputRevisions     []InputRevisions  `json:"inputRevisions,omitempty"`
@@ -225,7 +225,7 @@ func (c *Composition) ShouldIgnoreSideEffects() bool {
 }
 
 func (c *Composition) Synthesizing() bool {
-	return c.Status.PendingSynthesis != nil
+	return c.Status.InFlightSynthesis != nil
 }
 
 func (c *Composition) EnableIgnoreSideEffects() {
@@ -258,8 +258,8 @@ func (c *Composition) ShouldOrphanResources() bool {
 }
 
 func (s *CompositionStatus) getLatestSynthesisUUID() string {
-	if s.PendingSynthesis != nil {
-		return s.PendingSynthesis.UUID
+	if s.InFlightSynthesis != nil {
+		return s.InFlightSynthesis.UUID
 	}
 	if s.CurrentSynthesis != nil {
 		return s.CurrentSynthesis.UUID

--- a/api/v1/composition.go
+++ b/api/v1/composition.go
@@ -214,14 +214,6 @@ func (c *Composition) InputsOutOfLockstep(synth *Synthesizer) bool {
 }
 
 func (s *CompositionStatus) GetCurrentSynthesisUUID() string {
-	if s.CurrentSynthesis == nil {
-		return ""
-	}
-	return s.CurrentSynthesis.UUID
-}
-
-// TODO: Remove other?
-func (s *CompositionStatus) GetLatestSynthesisUUID() string {
 	if s.PendingSynthesis != nil {
 		return s.PendingSynthesis.UUID
 	}
@@ -255,13 +247,13 @@ func (c *Composition) ForceResynthesis() {
 	if anno == nil {
 		anno = map[string]string{}
 	}
-	anno[forceResynthesisAnnotation] = c.Status.GetLatestSynthesisUUID()
+	anno[forceResynthesisAnnotation] = c.Status.GetCurrentSynthesisUUID()
 	c.SetAnnotations(anno)
 }
 
 func (c *Composition) ShouldForceResynthesis() bool {
 	val, ok := c.GetAnnotations()[forceResynthesisAnnotation]
-	return ok && val == c.Status.GetLatestSynthesisUUID()
+	return ok && val == c.Status.GetCurrentSynthesisUUID()
 }
 
 func (c *Composition) ShouldOrphanResources() bool {

--- a/api/v1/composition.go
+++ b/api/v1/composition.go
@@ -214,6 +214,14 @@ func (c *Composition) InputsOutOfLockstep(synth *Synthesizer) bool {
 }
 
 func (s *CompositionStatus) GetCurrentSynthesisUUID() string {
+	if s.CurrentSynthesis == nil {
+		return ""
+	}
+	return s.CurrentSynthesis.UUID
+}
+
+// TODO: Remove other?
+func (s *CompositionStatus) GetLatestSynthesisUUID() string {
 	if s.PendingSynthesis != nil {
 		return s.PendingSynthesis.UUID
 	}
@@ -247,13 +255,13 @@ func (c *Composition) ForceResynthesis() {
 	if anno == nil {
 		anno = map[string]string{}
 	}
-	anno[forceResynthesisAnnotation] = c.Status.GetCurrentSynthesisUUID()
+	anno[forceResynthesisAnnotation] = c.Status.GetLatestSynthesisUUID()
 	c.SetAnnotations(anno)
 }
 
 func (c *Composition) ShouldForceResynthesis() bool {
 	val, ok := c.GetAnnotations()[forceResynthesisAnnotation]
-	return ok && val == c.Status.GetCurrentSynthesisUUID()
+	return ok && val == c.Status.GetLatestSynthesisUUID()
 }
 
 func (c *Composition) ShouldOrphanResources() bool {

--- a/api/v1/composition.go
+++ b/api/v1/composition.go
@@ -220,17 +220,6 @@ func (s *CompositionStatus) GetCurrentSynthesisUUID() string {
 	return s.CurrentSynthesis.UUID
 }
 
-// TODO: Remove other?
-func (s *CompositionStatus) GetLatestSynthesisUUID() string {
-	if s.PendingSynthesis != nil {
-		return s.PendingSynthesis.UUID
-	}
-	if s.CurrentSynthesis != nil {
-		return s.CurrentSynthesis.UUID
-	}
-	return ""
-}
-
 func (c *Composition) ShouldIgnoreSideEffects() bool {
 	return c.Annotations["eno.azure.io/ignore-side-effects"] == "true"
 }
@@ -255,15 +244,25 @@ func (c *Composition) ForceResynthesis() {
 	if anno == nil {
 		anno = map[string]string{}
 	}
-	anno[forceResynthesisAnnotation] = c.Status.GetLatestSynthesisUUID()
+	anno[forceResynthesisAnnotation] = c.Status.getLatestSynthesisUUID()
 	c.SetAnnotations(anno)
 }
 
 func (c *Composition) ShouldForceResynthesis() bool {
 	val, ok := c.GetAnnotations()[forceResynthesisAnnotation]
-	return ok && val == c.Status.GetLatestSynthesisUUID()
+	return ok && val == c.Status.getLatestSynthesisUUID()
 }
 
 func (c *Composition) ShouldOrphanResources() bool {
 	return c.Annotations["eno.azure.io/deletion-strategy"] == "orphan"
+}
+
+func (s *CompositionStatus) getLatestSynthesisUUID() string {
+	if s.PendingSynthesis != nil {
+		return s.PendingSynthesis.UUID
+	}
+	if s.CurrentSynthesis != nil {
+		return s.CurrentSynthesis.UUID
+	}
+	return ""
 }

--- a/api/v1/composition.go
+++ b/api/v1/composition.go
@@ -52,6 +52,7 @@ type CompositionSpec struct {
 
 type CompositionStatus struct {
 	Simplified         *SimplifiedStatus `json:"simplified,omitempty"`
+	PendingSynthesis   *Synthesis        `json:"pendingSynthesis,omitempty"`
 	CurrentSynthesis   *Synthesis        `json:"currentSynthesis,omitempty"`
 	PreviousSynthesis  *Synthesis        `json:"previousSynthesis,omitempty"`
 	InputRevisions     []InputRevisions  `json:"inputRevisions,omitempty"`
@@ -219,12 +220,23 @@ func (s *CompositionStatus) GetCurrentSynthesisUUID() string {
 	return s.CurrentSynthesis.UUID
 }
 
+// TODO: Remove other?
+func (s *CompositionStatus) GetLatestSynthesisUUID() string {
+	if s.PendingSynthesis != nil {
+		return s.PendingSynthesis.UUID
+	}
+	if s.CurrentSynthesis != nil {
+		return s.CurrentSynthesis.UUID
+	}
+	return ""
+}
+
 func (c *Composition) ShouldIgnoreSideEffects() bool {
 	return c.Annotations["eno.azure.io/ignore-side-effects"] == "true"
 }
 
 func (c *Composition) Synthesizing() bool {
-	return c.Status.CurrentSynthesis != nil && c.Status.CurrentSynthesis.Synthesized == nil
+	return c.Status.PendingSynthesis != nil
 }
 
 func (c *Composition) EnableIgnoreSideEffects() {
@@ -243,13 +255,13 @@ func (c *Composition) ForceResynthesis() {
 	if anno == nil {
 		anno = map[string]string{}
 	}
-	anno[forceResynthesisAnnotation] = c.Status.GetCurrentSynthesisUUID()
+	anno[forceResynthesisAnnotation] = c.Status.GetLatestSynthesisUUID()
 	c.SetAnnotations(anno)
 }
 
 func (c *Composition) ShouldForceResynthesis() bool {
 	val, ok := c.GetAnnotations()[forceResynthesisAnnotation]
-	return ok && val == c.Status.GetCurrentSynthesisUUID()
+	return ok && val == c.Status.GetLatestSynthesisUUID()
 }
 
 func (c *Composition) ShouldOrphanResources() bool {

--- a/api/v1/config/crd/eno.azure.io_compositions.yaml
+++ b/api/v1/config/crd/eno.azure.io_compositions.yaml
@@ -214,24 +214,7 @@ spec:
                       Used internally for strict ordering semantics.
                     type: string
                 type: object
-              inputRevisions:
-                items:
-                  properties:
-                    key:
-                      type: string
-                    resourceVersion:
-                      type: string
-                    revision:
-                      type: integer
-                    synthesizerGeneration:
-                      format: int64
-                      type: integer
-                  type: object
-                type: array
-              pendingResynthesis:
-                format: date-time
-                type: string
-              pendingSynthesis:
+              inFlightSynthesis:
                 description: |-
                   A synthesis is the result of synthesizing a composition.
                   In other words: it's a collection of resources returned from a synthesizer.
@@ -329,6 +312,23 @@ spec:
                       Used internally for strict ordering semantics.
                     type: string
                 type: object
+              inputRevisions:
+                items:
+                  properties:
+                    key:
+                      type: string
+                    resourceVersion:
+                      type: string
+                    revision:
+                      type: integer
+                    synthesizerGeneration:
+                      format: int64
+                      type: integer
+                  type: object
+                type: array
+              pendingResynthesis:
+                format: date-time
+                type: string
               previousSynthesis:
                 description: |-
                   A synthesis is the result of synthesizing a composition.

--- a/api/v1/config/crd/eno.azure.io_compositions.yaml
+++ b/api/v1/config/crd/eno.azure.io_compositions.yaml
@@ -231,6 +231,104 @@ spec:
               pendingResynthesis:
                 format: date-time
                 type: string
+              pendingSynthesis:
+                description: |-
+                  A synthesis is the result of synthesizing a composition.
+                  In other words: it's a collection of resources returned from a synthesizer.
+                properties:
+                  attempts:
+                    description: Counter used internally to calculate back off when
+                      retrying failed syntheses.
+                    type: integer
+                  deferred:
+                    description: |-
+                      Deferred is true when this synthesis was caused by a change to either the synthesizer
+                      or an input with a ref that sets `Defer == true`.
+                    type: boolean
+                  initialized:
+                    description: Initialized is set when the synthesis process is
+                      initiated.
+                    format: date-time
+                    type: string
+                  inputRevisions:
+                    description: InputRevisions contains the versions of the input
+                      resources that were used for this synthesis.
+                    items:
+                      properties:
+                        key:
+                          type: string
+                        resourceVersion:
+                          type: string
+                        revision:
+                          type: integer
+                        synthesizerGeneration:
+                          format: int64
+                          type: integer
+                      type: object
+                    type: array
+                  observedCompositionGeneration:
+                    description: |-
+                      The value of the composition's metadata.generation at the time the synthesis began.
+                      This is a min i.e. a newer composition may have been used.
+                    format: int64
+                    type: integer
+                  observedSynthesizerGeneration:
+                    description: |-
+                      The value of the synthesizer's metadata.generation at the time the synthesis began.
+                      This is a min i.e. a newer composition may have been used.
+                    format: int64
+                    type: integer
+                  podCreation:
+                    description: Time at which the most recent synthesizer pod was
+                      created.
+                    format: date-time
+                    type: string
+                  ready:
+                    description: Time at which the synthesis's reconciled resources
+                      became ready.
+                    format: date-time
+                    type: string
+                  reconciled:
+                    description: Time at which the synthesis's resources were reconciled
+                      into real Kubernetes resources.
+                    format: date-time
+                    type: string
+                  resourceSlices:
+                    description: |-
+                      References to every resource slice that contains the resources comprising this synthesis.
+                      Immutable.
+                    items:
+                      properties:
+                        name:
+                          type: string
+                      type: object
+                    type: array
+                  results:
+                    description: Results are passed through opaquely from the synthesizer's
+                      KRM function.
+                    items:
+                      properties:
+                        message:
+                          type: string
+                        severity:
+                          type: string
+                        tags:
+                          additionalProperties:
+                            type: string
+                          type: object
+                      type: object
+                    type: array
+                  synthesized:
+                    description: Time at which the synthesis completed i.e. resourceSlices
+                      was written
+                    format: date-time
+                    type: string
+                  uuid:
+                    description: |-
+                      A random UUID scoped to this particular synthesis operation.
+                      Used internally for strict ordering semantics.
+                    type: string
+                type: object
               previousSynthesis:
                 description: |-
                   A synthesis is the result of synthesizing a composition.

--- a/api/v1/config/crd/eno.azure.io_synthesizers.yaml
+++ b/api/v1/config/crd/eno.azure.io_synthesizers.yaml
@@ -350,7 +350,7 @@ spec:
                                         pod labels will be ignored. The default value is empty.
                                         The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                         Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                        This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                        This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                       items:
                                         type: string
                                       type: array
@@ -365,7 +365,7 @@ spec:
                                         pod labels will be ignored. The default value is empty.
                                         The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                         Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                        This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                        This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                       items:
                                         type: string
                                       type: array
@@ -532,7 +532,7 @@ spec:
                                     pod labels will be ignored. The default value is empty.
                                     The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                     Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                    This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                    This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                   items:
                                     type: string
                                   type: array
@@ -547,7 +547,7 @@ spec:
                                     pod labels will be ignored. The default value is empty.
                                     The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                     Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                    This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                    This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                   items:
                                     type: string
                                   type: array
@@ -712,7 +712,7 @@ spec:
                                         pod labels will be ignored. The default value is empty.
                                         The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                         Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                        This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                        This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                       items:
                                         type: string
                                       type: array
@@ -727,7 +727,7 @@ spec:
                                         pod labels will be ignored. The default value is empty.
                                         The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                         Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                        This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                        This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                       items:
                                         type: string
                                       type: array
@@ -894,7 +894,7 @@ spec:
                                     pod labels will be ignored. The default value is empty.
                                     The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                     Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                    This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                    This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                   items:
                                     type: string
                                   type: array
@@ -909,7 +909,7 @@ spec:
                                     pod labels will be ignored. The default value is empty.
                                     The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                     Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                    This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                    This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                   items:
                                     type: string
                                   type: array
@@ -1020,6 +1020,12 @@ spec:
                                 Name must match the name of one entry in pod.spec.resourceClaims of
                                 the Pod where this field is used. It makes that resource available
                                 inside a container.
+                              type: string
+                            request:
+                              description: |-
+                                Request is the name chosen for a request in the referenced claim.
+                                If empty, everything from the claim is made available, otherwise
+                                only the result of this request.
                               type: string
                           required:
                           - name

--- a/api/v1/zz_generated.deepcopy.go
+++ b/api/v1/zz_generated.deepcopy.go
@@ -119,6 +119,11 @@ func (in *CompositionStatus) DeepCopyInto(out *CompositionStatus) {
 		*out = new(SimplifiedStatus)
 		**out = **in
 	}
+	if in.PendingSynthesis != nil {
+		in, out := &in.PendingSynthesis, &out.PendingSynthesis
+		*out = new(Synthesis)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.CurrentSynthesis != nil {
 		in, out := &in.CurrentSynthesis, &out.CurrentSynthesis
 		*out = new(Synthesis)

--- a/api/v1/zz_generated.deepcopy.go
+++ b/api/v1/zz_generated.deepcopy.go
@@ -119,8 +119,8 @@ func (in *CompositionStatus) DeepCopyInto(out *CompositionStatus) {
 		*out = new(SimplifiedStatus)
 		**out = **in
 	}
-	if in.PendingSynthesis != nil {
-		in, out := &in.PendingSynthesis, &out.PendingSynthesis
+	if in.InFlightSynthesis != nil {
+		in, out := &in.InFlightSynthesis, &out.InFlightSynthesis
 		*out = new(Synthesis)
 		(*in).DeepCopyInto(*out)
 	}

--- a/docs/api.md
+++ b/docs/api.md
@@ -92,6 +92,7 @@ _Appears in:_
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
 | `simplified` _[SimplifiedStatus](#simplifiedstatus)_ |  |  |  |
+| `pendingSynthesis` _[Synthesis](#synthesis)_ |  |  |  |
 | `currentSynthesis` _[Synthesis](#synthesis)_ |  |  |  |
 | `previousSynthesis` _[Synthesis](#synthesis)_ |  |  |  |
 | `inputRevisions` _[InputRevisions](#inputrevisions) array_ |  |  |  |

--- a/docs/api.md
+++ b/docs/api.md
@@ -92,7 +92,7 @@ _Appears in:_
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
 | `simplified` _[SimplifiedStatus](#simplifiedstatus)_ |  |  |  |
-| `pendingSynthesis` _[Synthesis](#synthesis)_ |  |  |  |
+| `inFlightSynthesis` _[Synthesis](#synthesis)_ |  |  |  |
 | `currentSynthesis` _[Synthesis](#synthesis)_ |  |  |  |
 | `previousSynthesis` _[Synthesis](#synthesis)_ |  |  |  |
 | `inputRevisions` _[InputRevisions](#inputrevisions) array_ |  |  |  |

--- a/internal/controllers/aggregation/composition.go
+++ b/internal/controllers/aggregation/composition.go
@@ -68,7 +68,7 @@ func (c *compositionController) aggregate(synth *apiv1.Synthesizer, comp *apiv1.
 	if !comp.InputsExist(synth) {
 		copy.Status = "MissingInputs"
 	}
-	if comp.Status.CurrentSynthesis == nil {
+	if comp.Status.CurrentSynthesis == nil && comp.Status.InFlightSynthesis == nil {
 		return copy
 	}
 
@@ -94,13 +94,16 @@ func (c *compositionController) aggregate(synth *apiv1.Synthesizer, comp *apiv1.
 	if !comp.InputsExist(synth) {
 		copy.Status = "MissingInputs"
 	}
-	if comp.Status.CurrentSynthesis.Synthesized != nil {
+	if comp.Status.InFlightSynthesis != nil {
+		return copy
+	}
+	if syn := comp.Status.CurrentSynthesis; syn.Synthesized != nil {
 		copy.Status = "Reconciling"
 	}
-	if comp.Status.CurrentSynthesis.Reconciled != nil {
+	if syn := comp.Status.CurrentSynthesis; syn.Reconciled != nil {
 		copy.Status = "NotReady"
 	}
-	if comp.Status.CurrentSynthesis.Ready != nil {
+	if syn := comp.Status.CurrentSynthesis; syn.Ready != nil {
 		copy.Status = "Ready"
 	}
 	if comp.InputsOutOfLockstep(synth) {

--- a/internal/controllers/aggregation/composition_test.go
+++ b/internal/controllers/aggregation/composition_test.go
@@ -33,6 +33,15 @@ func TestCompositionSimplification(t *testing.T) {
 			},
 		},
 		{
+			Input: apiv1.CompositionStatus{
+				CurrentSynthesis:  &apiv1.Synthesis{UUID: "uuid", Synthesized: ptr.To(metav1.Now())},
+				InFlightSynthesis: &apiv1.Synthesis{UUID: "another-uuid"},
+			},
+			Expected: apiv1.SimplifiedStatus{
+				Status: "Synthesizing",
+			},
+		},
+		{
 			Input: apiv1.CompositionStatus{CurrentSynthesis: &apiv1.Synthesis{UUID: "uuid", Synthesized: ptr.To(metav1.Now())}},
 			Expected: apiv1.SimplifiedStatus{
 				Status: "Reconciling",

--- a/internal/controllers/reconciliation/crud_test.go
+++ b/internal/controllers/reconciliation/crud_test.go
@@ -702,60 +702,6 @@ func TestDisableUpdates(t *testing.T) {
 	assert.Equal(t, "baz", obj.Data["foo"])
 }
 
-// TestOrphanedCompositionDeletion proves that compositions can be deleted when their synthesizer is missing.
-// TODO
-func TestOrphanedCompositionDeletion(t *testing.T) {
-	scheme := runtime.NewScheme()
-	corev1.SchemeBuilder.AddToScheme(scheme)
-	testv1.SchemeBuilder.AddToScheme(scheme)
-
-	ctx := testutil.NewContext(t)
-	mgr := testutil.NewManager(t)
-	upstream := mgr.GetClient()
-
-	registerControllers(t, mgr)
-	testutil.WithFakeExecutor(t, mgr, func(ctx context.Context, s *apiv1.Synthesizer, input *krmv1.ResourceList) (*krmv1.ResourceList, error) {
-		output := &krmv1.ResourceList{}
-		output.Items = []*unstructured.Unstructured{{
-			Object: map[string]any{
-				"apiVersion": "v1",
-				"kind":       "ConfigMap",
-				"metadata": map[string]any{
-					"name":      "test-obj",
-					"namespace": "default",
-				},
-				"data": map[string]string{"foo": "bar"},
-			},
-		}}
-		return output, nil
-	})
-
-	// Test subject
-	setupTestSubject(t, mgr)
-	mgr.Start(t)
-	syn, comp := writeGenericComposition(t, upstream)
-
-	// Wait for composition to become ready
-	testutil.Eventually(t, func() bool {
-		err := upstream.Get(ctx, client.ObjectKeyFromObject(comp), comp)
-		return err == nil && comp.Status.CurrentSynthesis != nil && comp.Status.CurrentSynthesis.Ready != nil && comp.Status.CurrentSynthesis.ObservedCompositionGeneration == comp.Generation
-	})
-
-	// Delete the synthesizer
-	require.NoError(t, upstream.Delete(ctx, syn))
-	t.Logf("deleted synth")
-
-	time.Sleep(time.Millisecond * 100) // make sure the synth deletion has hit the informer cache
-
-	require.NoError(t, upstream.Delete(ctx, comp))
-	t.Logf("deleted composition")
-
-	// Everything should eventually be cleaned up
-	testutil.Eventually(t, func() bool {
-		return errors.IsNotFound(upstream.Get(ctx, client.ObjectKeyFromObject(comp), comp))
-	})
-}
-
 func TestOrphanedResources(t *testing.T) {
 	scheme := runtime.NewScheme()
 	corev1.SchemeBuilder.AddToScheme(scheme)

--- a/internal/controllers/reconciliation/crud_test.go
+++ b/internal/controllers/reconciliation/crud_test.go
@@ -488,6 +488,7 @@ func TestReconcileCacheRace(t *testing.T) {
 
 // TestCompositionDeletionOrdering proves that compositions are not deleted until all resulting resources have been deleted.
 // This covers significant surface area between reconciliation and synthesis.
+// TODO
 func TestCompositionDeletionOrdering(t *testing.T) {
 	scheme := runtime.NewScheme()
 	corev1.SchemeBuilder.AddToScheme(scheme)
@@ -547,6 +548,7 @@ func TestCompositionDeletionOrdering(t *testing.T) {
 }
 
 // TestMidSynthesisDeletion proves that compositions can be deleted while they are being synthesized.
+// TODO Fix
 func TestMidSynthesisDeletion(t *testing.T) {
 	scheme := runtime.NewScheme()
 	corev1.SchemeBuilder.AddToScheme(scheme)
@@ -703,6 +705,7 @@ func TestDisableUpdates(t *testing.T) {
 }
 
 // TestOrphanedCompositionDeletion proves that compositions can be deleted when their synthesizer is missing.
+// TODO
 func TestOrphanedCompositionDeletion(t *testing.T) {
 	scheme := runtime.NewScheme()
 	corev1.SchemeBuilder.AddToScheme(scheme)

--- a/internal/controllers/reconciliation/crud_test.go
+++ b/internal/controllers/reconciliation/crud_test.go
@@ -488,7 +488,6 @@ func TestReconcileCacheRace(t *testing.T) {
 
 // TestCompositionDeletionOrdering proves that compositions are not deleted until all resulting resources have been deleted.
 // This covers significant surface area between reconciliation and synthesis.
-// TODO
 func TestCompositionDeletionOrdering(t *testing.T) {
 	scheme := runtime.NewScheme()
 	corev1.SchemeBuilder.AddToScheme(scheme)
@@ -548,7 +547,6 @@ func TestCompositionDeletionOrdering(t *testing.T) {
 }
 
 // TestMidSynthesisDeletion proves that compositions can be deleted while they are being synthesized.
-// TODO Fix
 func TestMidSynthesisDeletion(t *testing.T) {
 	scheme := runtime.NewScheme()
 	corev1.SchemeBuilder.AddToScheme(scheme)
@@ -630,7 +628,7 @@ func TestMidSynthesisDeletion(t *testing.T) {
 	// Wait for the state to be swapped
 	testutil.Eventually(t, func() bool {
 		err = upstream.Get(ctx, client.ObjectKeyFromObject(comp), comp)
-		return err == nil && comp.Status.CurrentSynthesis != nil && comp.Status.CurrentSynthesis.Synthesized == nil
+		return err == nil && comp.Status.PendingSynthesis != nil
 	})
 
 	// Delete the composition

--- a/internal/controllers/reconciliation/crud_test.go
+++ b/internal/controllers/reconciliation/crud_test.go
@@ -628,7 +628,7 @@ func TestMidSynthesisDeletion(t *testing.T) {
 	// Wait for the state to be swapped
 	testutil.Eventually(t, func() bool {
 		err = upstream.Get(ctx, client.ObjectKeyFromObject(comp), comp)
-		return err == nil && comp.Status.PendingSynthesis != nil
+		return err == nil && comp.Status.InFlightSynthesis != nil
 	})
 
 	// Delete the composition

--- a/internal/controllers/reconciliation/error_test.go
+++ b/internal/controllers/reconciliation/error_test.go
@@ -187,7 +187,7 @@ func TestSliceCleanupOutdated(t *testing.T) {
 	// Wait for a few attempts
 	testutil.Eventually(t, func() bool {
 		err := upstream.Get(ctx, client.ObjectKeyFromObject(comp), comp)
-		return err == nil && comp.Status.PendingSynthesis != nil && comp.Status.PendingSynthesis.Attempts >= 3
+		return err == nil && comp.Status.InFlightSynthesis != nil && comp.Status.InFlightSynthesis.Attempts >= 3
 	})
 
 	// There should not be more than one set of resource slices

--- a/internal/controllers/reconciliation/error_test.go
+++ b/internal/controllers/reconciliation/error_test.go
@@ -187,7 +187,7 @@ func TestSliceCleanupOutdated(t *testing.T) {
 	// Wait for a few attempts
 	testutil.Eventually(t, func() bool {
 		err := upstream.Get(ctx, client.ObjectKeyFromObject(comp), comp)
-		return err == nil && comp.Status.CurrentSynthesis != nil && comp.Status.CurrentSynthesis.Attempts >= 3
+		return err == nil && comp.Status.PendingSynthesis != nil && comp.Status.PendingSynthesis.Attempts >= 3
 	})
 
 	// There should not be more than one set of resource slices

--- a/internal/controllers/scheduling/controller.go
+++ b/internal/controllers/scheduling/controller.go
@@ -145,7 +145,7 @@ func (c *controller) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 
 	if err := c.dispatchOp(ctx, op); err != nil {
 		if errors.IsInvalid(err) {
-			return ctrl.Result{}, fmt.Errorf("conflict while dispatching synthesis (reason=%s)", op.Reason)
+			return ctrl.Result{}, fmt.Errorf("conflict while dispatching synthesis")
 		}
 		return ctrl.Result{}, fmt.Errorf("dispatching synthesis operation: %w", err)
 	}

--- a/internal/controllers/scheduling/controller.go
+++ b/internal/controllers/scheduling/controller.go
@@ -161,7 +161,7 @@ func (c *controller) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 func (c *controller) getNextCooldownSlot(comps *apiv1.CompositionList) time.Time {
 	var next time.Time
 	for _, comp := range comps.Items {
-		for _, syn := range []*apiv1.Synthesis{comp.Status.PendingSynthesis, comp.Status.CurrentSynthesis, comp.Status.PreviousSynthesis} {
+		for _, syn := range []*apiv1.Synthesis{comp.Status.InFlightSynthesis, comp.Status.CurrentSynthesis, comp.Status.PreviousSynthesis} {
 			if syn != nil && syn.Deferred && syn.Initialized != nil && syn.Initialized.Time.After(next) {
 				next = syn.Initialized.Time
 			}

--- a/internal/controllers/scheduling/controller_test.go
+++ b/internal/controllers/scheduling/controller_test.go
@@ -44,17 +44,17 @@ func TestBasics(t *testing.T) {
 
 	testutil.Eventually(t, func() bool {
 		err := cli.Get(ctx, client.ObjectKeyFromObject(comp), comp)
-		return err == nil && comp.Status.PendingSynthesis != nil && comp.Status.PendingSynthesis.UUID != ""
+		return err == nil && comp.Status.InFlightSynthesis != nil && comp.Status.InFlightSynthesis.UUID != ""
 	})
-	initialUUID := comp.Status.PendingSynthesis.UUID
+	initialUUID := comp.Status.InFlightSynthesis.UUID
 
 	// Mark this synthesis as complete
 	err := retry.RetryOnConflict(testutil.Backoff, func() error {
 		cli.Get(ctx, client.ObjectKeyFromObject(comp), comp)
-		comp.Status.PendingSynthesis.Synthesized = ptr.To(metav1.Now())
+		comp.Status.InFlightSynthesis.Synthesized = ptr.To(metav1.Now())
 		comp.Status.PreviousSynthesis = comp.Status.CurrentSynthesis
-		comp.Status.CurrentSynthesis = comp.Status.PendingSynthesis
-		comp.Status.PendingSynthesis = nil
+		comp.Status.CurrentSynthesis = comp.Status.InFlightSynthesis
+		comp.Status.InFlightSynthesis = nil
 		return cli.Status().Update(ctx, comp)
 	})
 	require.NoError(t, err)
@@ -70,15 +70,15 @@ func TestBasics(t *testing.T) {
 	testutil.Eventually(t, func() bool {
 		err := cli.Get(ctx, client.ObjectKeyFromObject(comp), comp)
 		return err == nil &&
-			comp.Status.PendingSynthesis != nil &&
-			comp.Status.PendingSynthesis.UUID != initialUUID
+			comp.Status.InFlightSynthesis != nil &&
+			comp.Status.InFlightSynthesis.UUID != initialUUID
 	})
 
 	// Remove the current synthesis, things should eventually converge
-	updatedUUID := comp.Status.PendingSynthesis.UUID
+	updatedUUID := comp.Status.InFlightSynthesis.UUID
 	err = retry.RetryOnConflict(testutil.Backoff, func() error {
 		cli.Get(ctx, client.ObjectKeyFromObject(comp), comp)
-		comp.Status.PendingSynthesis = nil
+		comp.Status.InFlightSynthesis = nil
 		return cli.Status().Update(ctx, comp)
 	})
 	require.NoError(t, err)
@@ -86,9 +86,9 @@ func TestBasics(t *testing.T) {
 	testutil.Eventually(t, func() bool {
 		err := cli.Get(ctx, client.ObjectKeyFromObject(comp), comp)
 		return err == nil &&
-			comp.Status.PendingSynthesis != nil &&
-			comp.Status.PendingSynthesis.UUID != initialUUID &&
-			comp.Status.PendingSynthesis.UUID != updatedUUID
+			comp.Status.InFlightSynthesis != nil &&
+			comp.Status.InFlightSynthesis.UUID != initialUUID &&
+			comp.Status.InFlightSynthesis.UUID != updatedUUID
 	})
 }
 
@@ -115,19 +115,19 @@ func TestSynthRolloutBasics(t *testing.T) {
 	// Initial synthesis
 	testutil.Eventually(t, func() bool {
 		err := cli.Get(ctx, client.ObjectKeyFromObject(comp), comp)
-		return err == nil && comp.Status.PendingSynthesis != nil && comp.Status.PendingSynthesis.UUID != ""
+		return err == nil && comp.Status.InFlightSynthesis != nil && comp.Status.InFlightSynthesis.UUID != ""
 	})
-	lastUUID := comp.Status.PendingSynthesis.UUID
+	lastUUID := comp.Status.InFlightSynthesis.UUID
 
 	// Mark this synthesis as complete for the current synth version
 	start := time.Now()
 	err := retry.RetryOnConflict(testutil.Backoff, func() error {
 		cli.Get(ctx, client.ObjectKeyFromObject(comp), comp)
-		comp.Status.PendingSynthesis.Synthesized = ptr.To(metav1.Now())
-		comp.Status.PendingSynthesis.ObservedSynthesizerGeneration = synth.Generation
+		comp.Status.InFlightSynthesis.Synthesized = ptr.To(metav1.Now())
+		comp.Status.InFlightSynthesis.ObservedSynthesizerGeneration = synth.Generation
 		comp.Status.PreviousSynthesis = comp.Status.CurrentSynthesis
-		comp.Status.CurrentSynthesis = comp.Status.PendingSynthesis
-		comp.Status.PendingSynthesis = nil
+		comp.Status.CurrentSynthesis = comp.Status.InFlightSynthesis
+		comp.Status.InFlightSynthesis = nil
 		return cli.Status().Update(ctx, comp)
 	})
 	require.NoError(t, err)
@@ -143,19 +143,19 @@ func TestSynthRolloutBasics(t *testing.T) {
 	// It should resynthesize immediately
 	testutil.Eventually(t, func() bool {
 		err := cli.Get(ctx, client.ObjectKeyFromObject(comp), comp)
-		return err == nil && comp.Status.PendingSynthesis != nil && comp.Status.PendingSynthesis.UUID != lastUUID
+		return err == nil && comp.Status.InFlightSynthesis != nil && comp.Status.InFlightSynthesis.UUID != lastUUID
 	})
 	assert.Less(t, time.Since(start), time.Millisecond*500, "initial deferral period")
-	lastUUID = comp.Status.PendingSynthesis.UUID
+	lastUUID = comp.Status.InFlightSynthesis.UUID
 
 	// Mark this synthesis as complete for the current synth version
 	err = retry.RetryOnConflict(testutil.Backoff, func() error {
 		cli.Get(ctx, client.ObjectKeyFromObject(comp), comp)
-		comp.Status.PendingSynthesis.Synthesized = ptr.To(metav1.Now())
-		comp.Status.PendingSynthesis.ObservedSynthesizerGeneration = synth.Generation
+		comp.Status.InFlightSynthesis.Synthesized = ptr.To(metav1.Now())
+		comp.Status.InFlightSynthesis.ObservedSynthesizerGeneration = synth.Generation
 		comp.Status.PreviousSynthesis = comp.Status.CurrentSynthesis
-		comp.Status.CurrentSynthesis = comp.Status.PendingSynthesis
-		comp.Status.PendingSynthesis = nil
+		comp.Status.CurrentSynthesis = comp.Status.InFlightSynthesis
+		comp.Status.InFlightSynthesis = nil
 		return cli.Status().Update(ctx, comp)
 	})
 	require.NoError(t, err)
@@ -171,7 +171,7 @@ func TestSynthRolloutBasics(t *testing.T) {
 	// It should eventually resynthesize but this time with a cooldown
 	testutil.Eventually(t, func() bool {
 		err := cli.Get(ctx, client.ObjectKeyFromObject(comp), comp)
-		return err == nil && comp.Status.PendingSynthesis != nil && comp.Status.PendingSynthesis.UUID != lastUUID
+		return err == nil && comp.Status.InFlightSynthesis != nil && comp.Status.InFlightSynthesis.UUID != lastUUID
 	})
 	assert.Greater(t, time.Since(start), time.Millisecond*500, "chilled deferral period")
 
@@ -219,19 +219,19 @@ func TestDeferredInput(t *testing.T) {
 	// Initial synthesis
 	testutil.Eventually(t, func() bool {
 		err := cli.Get(ctx, client.ObjectKeyFromObject(comp), comp)
-		return err == nil && comp.Status.PendingSynthesis != nil && comp.Status.PendingSynthesis.UUID != ""
+		return err == nil && comp.Status.InFlightSynthesis != nil && comp.Status.InFlightSynthesis.UUID != ""
 	})
-	lastUUID := comp.Status.PendingSynthesis.UUID
+	lastUUID := comp.Status.InFlightSynthesis.UUID
 
 	// Mark this synthesis as complete but for the wrong input revision
 	start := time.Now()
 	err := retry.RetryOnConflict(testutil.Backoff, func() error {
 		cli.Get(ctx, client.ObjectKeyFromObject(comp), comp)
-		comp.Status.PendingSynthesis.Synthesized = ptr.To(metav1.Now())
-		comp.Status.PendingSynthesis.InputRevisions = []apiv1.InputRevisions{{Key: "foo", ResourceVersion: "NOT bar"}}
+		comp.Status.InFlightSynthesis.Synthesized = ptr.To(metav1.Now())
+		comp.Status.InFlightSynthesis.InputRevisions = []apiv1.InputRevisions{{Key: "foo", ResourceVersion: "NOT bar"}}
 		comp.Status.PreviousSynthesis = comp.Status.CurrentSynthesis
-		comp.Status.CurrentSynthesis = comp.Status.PendingSynthesis
-		comp.Status.PendingSynthesis = nil
+		comp.Status.CurrentSynthesis = comp.Status.InFlightSynthesis
+		comp.Status.InFlightSynthesis = nil
 		return cli.Status().Update(ctx, comp)
 	})
 	require.NoError(t, err)
@@ -239,26 +239,26 @@ func TestDeferredInput(t *testing.T) {
 	// It should eventually resynthesize
 	testutil.Eventually(t, func() bool {
 		err := cli.Get(ctx, client.ObjectKeyFromObject(comp), comp)
-		return err == nil && comp.Status.PendingSynthesis != nil && comp.Status.PendingSynthesis.UUID != lastUUID
+		return err == nil && comp.Status.InFlightSynthesis != nil && comp.Status.InFlightSynthesis.UUID != lastUUID
 	})
 	assert.Less(t, time.Since(start), time.Millisecond*500, "initial deferral period")
-	lastUUID = comp.Status.PendingSynthesis.UUID
+	lastUUID = comp.Status.InFlightSynthesis.UUID
 
 	// One more time
 	err = retry.RetryOnConflict(testutil.Backoff, func() error {
 		cli.Get(ctx, client.ObjectKeyFromObject(comp), comp)
-		comp.Status.PendingSynthesis.Synthesized = ptr.To(metav1.Now())
-		comp.Status.PendingSynthesis.InputRevisions = []apiv1.InputRevisions{{Key: "foo", ResourceVersion: "NOT bar"}}
+		comp.Status.InFlightSynthesis.Synthesized = ptr.To(metav1.Now())
+		comp.Status.InFlightSynthesis.InputRevisions = []apiv1.InputRevisions{{Key: "foo", ResourceVersion: "NOT bar"}}
 		comp.Status.PreviousSynthesis = comp.Status.CurrentSynthesis
-		comp.Status.CurrentSynthesis = comp.Status.PendingSynthesis
-		comp.Status.PendingSynthesis = nil
+		comp.Status.CurrentSynthesis = comp.Status.InFlightSynthesis
+		comp.Status.InFlightSynthesis = nil
 		return cli.Status().Update(ctx, comp)
 	})
 	require.NoError(t, err)
 
 	testutil.Eventually(t, func() bool {
 		err := cli.Get(ctx, client.ObjectKeyFromObject(comp), comp)
-		return err == nil && comp.Status.PendingSynthesis != nil && comp.Status.PendingSynthesis.UUID != lastUUID
+		return err == nil && comp.Status.InFlightSynthesis != nil && comp.Status.InFlightSynthesis.UUID != lastUUID
 	})
 	assert.Greater(t, time.Since(start), time.Millisecond*500, "chilled deferral period")
 }
@@ -286,9 +286,9 @@ func TestForcedResynth(t *testing.T) {
 	// Initial synthesis
 	testutil.Eventually(t, func() bool {
 		err := cli.Get(ctx, client.ObjectKeyFromObject(comp), comp)
-		return err == nil && comp.Status.PendingSynthesis != nil && comp.Status.PendingSynthesis.UUID != ""
+		return err == nil && comp.Status.InFlightSynthesis != nil && comp.Status.InFlightSynthesis.UUID != ""
 	})
-	initialUUID := comp.Status.PendingSynthesis.UUID
+	initialUUID := comp.Status.InFlightSynthesis.UUID
 
 	// Set the forced resynthesis annotation
 	err := retry.RetryOnConflict(testutil.Backoff, func() error {
@@ -301,7 +301,7 @@ func TestForcedResynth(t *testing.T) {
 	// It should eventually resynthesize
 	testutil.Eventually(t, func() bool {
 		err := cli.Get(ctx, client.ObjectKeyFromObject(comp), comp)
-		return err == nil && comp.Status.PendingSynthesis.UUID != initialUUID
+		return err == nil && comp.Status.InFlightSynthesis.UUID != initialUUID
 	})
 }
 
@@ -351,12 +351,12 @@ func testChaos(t *testing.T, mgr *testutil.Manager) {
 
 			time.Sleep(time.Duration(rand.IntN(100)) * time.Millisecond)
 
-			comp.Status.PendingSynthesis.Synthesized = ptr.To(metav1.Now())
-			comp.Status.PendingSynthesis.ObservedSynthesizerGeneration = synth.Generation
+			comp.Status.InFlightSynthesis.Synthesized = ptr.To(metav1.Now())
+			comp.Status.InFlightSynthesis.ObservedSynthesizerGeneration = synth.Generation
 
 			comp.Status.PreviousSynthesis = comp.Status.CurrentSynthesis
-			comp.Status.CurrentSynthesis = comp.Status.PendingSynthesis
-			comp.Status.PendingSynthesis = nil
+			comp.Status.CurrentSynthesis = comp.Status.InFlightSynthesis
+			comp.Status.InFlightSynthesis = nil
 			return reconcile.Result{}, cli.Status().Update(ctx, comp)
 		}))
 
@@ -384,7 +384,7 @@ func testChaos(t *testing.T, mgr *testutil.Manager) {
 		for _, comp := range list.Items {
 			if comp.Synthesizing() {
 				synthesizing++
-				assert.False(t, comp.Status.PendingSynthesis.Deferred)
+				assert.False(t, comp.Status.InFlightSynthesis.Deferred)
 			}
 		}
 
@@ -459,7 +459,7 @@ func TestSerializationGracePeriod(t *testing.T) {
 	assert.False(t, res.Requeue)
 
 	// Modify its synthesis uuid such that it no longer matches the controller's last known op
-	require.NoError(t, cli.Status().Patch(ctx, comp, client.RawPatch(types.JSONPatchType, []byte(`[{ "op": "replace", "path": "/status/pendingSynthesis/uuid", "value": "bar" }]`))))
+	require.NoError(t, cli.Status().Patch(ctx, comp, client.RawPatch(types.JSONPatchType, []byte(`[{ "op": "replace", "path": "/status/inFlightSynthesis/uuid", "value": "bar" }]`))))
 
 	// The controller hasn't seen its latest update, so it won't dispatch another synthesis
 	res, err = c.Reconcile(ctx, ctrl.Request{})

--- a/internal/controllers/scheduling/metrics.go
+++ b/internal/controllers/scheduling/metrics.go
@@ -8,6 +8,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
 )
 
+// TODO: Stuck synthesizing metric
+
 var (
 	freeSynthesisSlots = prometheus.NewGauge(
 		prometheus.GaugeOpts{

--- a/internal/controllers/scheduling/metrics.go
+++ b/internal/controllers/scheduling/metrics.go
@@ -8,8 +8,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
 )
 
-// TODO: Stuck synthesizing metric
-
 var (
 	freeSynthesisSlots = prometheus.NewGauge(
 		prometheus.GaugeOpts{

--- a/internal/controllers/scheduling/op.go
+++ b/internal/controllers/scheduling/op.go
@@ -49,7 +49,7 @@ func classifyOp(synth *apiv1.Synthesizer, comp *apiv1.Composition) (opReason, bo
 	case comp.DeletionTimestamp != nil || !comp.InputsExist(synth) || comp.InputsOutOfLockstep(synth) || !controllerutil.ContainsFinalizer(comp, "eno.azure.io/cleanup"):
 		return 0, false
 
-	case comp.Status.CurrentSynthesis == nil && comp.Status.PendingSynthesis == nil:
+	case (comp.Status.CurrentSynthesis == nil || comp.Status.CurrentSynthesis.Synthesized == nil) && comp.Status.PendingSynthesis == nil:
 		return initialSynthesisOp, true
 
 	case comp.ShouldForceResynthesis():

--- a/internal/controllers/scheduling/op.go
+++ b/internal/controllers/scheduling/op.go
@@ -15,8 +15,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
-// TODO: Also swap if the current synthesis somehow didn't converge, to cover the migration case
-
 type op struct {
 	Synthesizer *apiv1.Synthesizer
 	Composition *apiv1.Composition

--- a/internal/controllers/scheduling/op_test.go
+++ b/internal/controllers/scheduling/op_test.go
@@ -126,7 +126,7 @@ func TestFuzzNewOp(t *testing.T) {
 			comp.Status.CurrentSynthesis = nil
 		}
 		if synthesizing {
-			comp.Status.PendingSynthesis = comp.Status.CurrentSynthesis
+			comp.Status.InFlightSynthesis = comp.Status.CurrentSynthesis
 			comp.Status.CurrentSynthesis = nil
 		}
 		if compDeleting {
@@ -422,7 +422,7 @@ func TestOpNewerInputInSynthesis(t *testing.T) {
 			},
 		},
 		Status: apiv1.CompositionStatus{
-			PendingSynthesis: &apiv1.Synthesis{
+			InFlightSynthesis: &apiv1.Synthesis{
 				ObservedCompositionGeneration: 1,
 				ObservedSynthesizerGeneration: 11,
 				Synthesized:                   ptr.To(metav1.Now()),

--- a/internal/controllers/scheduling/op_test.go
+++ b/internal/controllers/scheduling/op_test.go
@@ -122,17 +122,18 @@ func TestFuzzNewOp(t *testing.T) {
 		if forceResynth {
 			comp.ForceResynthesis()
 		}
+		if nilSynthesis {
+			comp.Status.CurrentSynthesis = nil
+		}
 		if synthesizing {
-			comp.Status.CurrentSynthesis.Synthesized = nil
+			comp.Status.PendingSynthesis = comp.Status.CurrentSynthesis
+			comp.Status.CurrentSynthesis = nil
 		}
 		if compDeleting {
 			comp.DeletionTimestamp = ptr.To(metav1.Now())
 		}
 		if compModified {
-			comp.Status.CurrentSynthesis.ObservedCompositionGeneration = 123
-		}
-		if nilSynthesis {
-			comp.Status.CurrentSynthesis = nil
+			comp.Generation = 345
 		}
 
 		op := newOp(synth, comp)
@@ -421,7 +422,7 @@ func TestOpNewerInputInSynthesis(t *testing.T) {
 			},
 		},
 		Status: apiv1.CompositionStatus{
-			CurrentSynthesis: &apiv1.Synthesis{
+			PendingSynthesis: &apiv1.Synthesis{
 				ObservedCompositionGeneration: 1,
 				ObservedSynthesizerGeneration: 11,
 				Synthesized:                   ptr.To(metav1.Now()),

--- a/internal/controllers/selfhealing/slice.go
+++ b/internal/controllers/selfhealing/slice.go
@@ -131,7 +131,7 @@ func (s *sliceController) isSliceMissing(ctx context.Context, slice *apiv1.Resou
 // Composition should be resynthesized when the referenced resource slice is deleted
 func notEligibleForResynthesis(comp *apiv1.Composition) bool {
 	return comp.Status.CurrentSynthesis == nil ||
-		comp.Status.PendingSynthesis != nil ||
+		comp.Status.InFlightSynthesis != nil ||
 		comp.DeletionTimestamp != nil ||
 		comp.ShouldIgnoreSideEffects() ||
 		comp.ShouldForceResynthesis()

--- a/internal/controllers/selfhealing/slice.go
+++ b/internal/controllers/selfhealing/slice.go
@@ -131,7 +131,7 @@ func (s *sliceController) isSliceMissing(ctx context.Context, slice *apiv1.Resou
 // Composition should be resynthesized when the referenced resource slice is deleted
 func notEligibleForResynthesis(comp *apiv1.Composition) bool {
 	return comp.Status.CurrentSynthesis == nil ||
-		comp.Status.CurrentSynthesis.Synthesized == nil ||
+		comp.Status.PendingSynthesis != nil ||
 		comp.DeletionTimestamp != nil ||
 		comp.ShouldIgnoreSideEffects() ||
 		comp.ShouldForceResynthesis()

--- a/internal/controllers/selfhealing/slice_test.go
+++ b/internal/controllers/selfhealing/slice_test.go
@@ -480,14 +480,14 @@ func TestNotEligibleForResynthesis(t *testing.T) {
 		{
 			name: "CurrentSynthesis Synthesized is nil",
 			comp: &apiv1.Composition{
-				Status: apiv1.CompositionStatus{CurrentSynthesis: &apiv1.Synthesis{}},
+				Status: apiv1.CompositionStatus{PendingSynthesis: &apiv1.Synthesis{}},
 			},
 			expected: true,
 		},
 		{
 			name: "force-resynthesis is not nil",
 			comp: withForceResynthesis(&apiv1.Composition{
-				Status: apiv1.CompositionStatus{CurrentSynthesis: &apiv1.Synthesis{}},
+				Status: apiv1.CompositionStatus{PendingSynthesis: &apiv1.Synthesis{}},
 			}),
 			expected: true,
 		},

--- a/internal/controllers/selfhealing/slice_test.go
+++ b/internal/controllers/selfhealing/slice_test.go
@@ -480,14 +480,14 @@ func TestNotEligibleForResynthesis(t *testing.T) {
 		{
 			name: "CurrentSynthesis Synthesized is nil",
 			comp: &apiv1.Composition{
-				Status: apiv1.CompositionStatus{PendingSynthesis: &apiv1.Synthesis{}},
+				Status: apiv1.CompositionStatus{InFlightSynthesis: &apiv1.Synthesis{}},
 			},
 			expected: true,
 		},
 		{
 			name: "force-resynthesis is not nil",
 			comp: withForceResynthesis(&apiv1.Composition{
-				Status: apiv1.CompositionStatus{PendingSynthesis: &apiv1.Synthesis{}},
+				Status: apiv1.CompositionStatus{InFlightSynthesis: &apiv1.Synthesis{}},
 			}),
 			expected: true,
 		},

--- a/internal/controllers/synthesis/backoff_test.go
+++ b/internal/controllers/synthesis/backoff_test.go
@@ -39,7 +39,7 @@ func TestControllerBackoff(t *testing.T) {
 	t.Run("initial creation", func(t *testing.T) {
 		testutil.Eventually(t, func() bool {
 			require.NoError(t, client.IgnoreNotFound(cli.Get(ctx, client.ObjectKeyFromObject(comp), comp)))
-			return comp.Status.CurrentSynthesis != nil && comp.Status.CurrentSynthesis.Attempts >= 10
+			return comp.Status.PendingSynthesis != nil && comp.Status.PendingSynthesis.Attempts >= 10
 		})
 
 		// It shouldn't be possible to try this many times within 250ms

--- a/internal/controllers/synthesis/backoff_test.go
+++ b/internal/controllers/synthesis/backoff_test.go
@@ -39,7 +39,7 @@ func TestControllerBackoff(t *testing.T) {
 	t.Run("initial creation", func(t *testing.T) {
 		testutil.Eventually(t, func() bool {
 			require.NoError(t, client.IgnoreNotFound(cli.Get(ctx, client.ObjectKeyFromObject(comp), comp)))
-			return comp.Status.PendingSynthesis != nil && comp.Status.PendingSynthesis.Attempts >= 10
+			return comp.Status.InFlightSynthesis != nil && comp.Status.InFlightSynthesis.Attempts >= 10
 		})
 
 		// It shouldn't be possible to try this many times within 250ms

--- a/internal/controllers/synthesis/integration_test.go
+++ b/internal/controllers/synthesis/integration_test.go
@@ -88,7 +88,7 @@ func TestControllerHappyPath(t *testing.T) {
 		t.Error("state wasn't swapped to previous")
 	}
 
-	if comp.Status.PendingSynthesis != nil {
+	if comp.Status.InFlightSynthesis != nil {
 		t.Error("pending synthesis wasn't removed")
 	}
 
@@ -233,7 +233,7 @@ func TestControllerSwitchingSynthesizers(t *testing.T) {
 
 		testutil.Eventually(t, func() bool {
 			require.NoError(t, cli.Get(ctx, client.ObjectKeyFromObject(comp), comp))
-			return comp.Status.CurrentSynthesis!= nil && comp.Status.CurrentSynthesis.ObservedCompositionGeneration > initialGen
+			return comp.Status.CurrentSynthesis != nil && comp.Status.CurrentSynthesis.ObservedCompositionGeneration > initialGen
 		})
 		assert.NotEqual(t, comp.Status.CurrentSynthesis.ResourceSlices, initialSlices)
 	})

--- a/internal/controllers/synthesis/integration_test.go
+++ b/internal/controllers/synthesis/integration_test.go
@@ -88,6 +88,10 @@ func TestControllerHappyPath(t *testing.T) {
 		t.Error("state wasn't swapped to previous")
 	}
 
+	if comp.Status.PendingSynthesis != nil {
+		t.Error("pending synthesis wasn't removed")
+	}
+
 	// The synthesizer is eventually executed a second time
 	testutil.Eventually(t, func() bool {
 		return calls.Load() >= 2
@@ -229,7 +233,7 @@ func TestControllerSwitchingSynthesizers(t *testing.T) {
 
 		testutil.Eventually(t, func() bool {
 			require.NoError(t, cli.Get(ctx, client.ObjectKeyFromObject(comp), comp))
-			return comp.Status.CurrentSynthesis != nil && comp.Status.CurrentSynthesis.ObservedCompositionGeneration > initialGen
+			return comp.Status.CurrentSynthesis!= nil && comp.Status.CurrentSynthesis.ObservedCompositionGeneration > initialGen
 		})
 		assert.NotEqual(t, comp.Status.CurrentSynthesis.ResourceSlices, initialSlices)
 	})

--- a/internal/controllers/synthesis/lifecycle.go
+++ b/internal/controllers/synthesis/lifecycle.go
@@ -348,6 +348,10 @@ func shouldBackOffPodCreation(comp *apiv1.Composition) bool {
 	return current != nil && current.Attempts > 0 && current.PodCreation != nil
 }
 
+func shouldUpdateDeletedCompositionStatus(comp *apiv1.Composition) bool {
+	return comp.Status.CurrentSynthesis != nil && comp.Status.CurrentSynthesis.ObservedCompositionGeneration != comp.Generation
+}
+
 func isReconciling(comp *apiv1.Composition) bool {
 	return comp.Status.CurrentSynthesis != nil && comp.Status.CurrentSynthesis.Reconciled == nil
 }
@@ -363,8 +367,4 @@ func getPodScheduledTime(pod *corev1.Pod) *time.Time {
 		return &cond.LastTransitionTime.Time
 	}
 	return nil
-}
-
-func shouldUpdateDeletedCompositionStatus(comp *apiv1.Composition) bool {
-	return comp.Status.CurrentSynthesis != nil && comp.Status.CurrentSynthesis.ObservedCompositionGeneration != comp.Generation
 }

--- a/internal/controllers/synthesis/lifecycle.go
+++ b/internal/controllers/synthesis/lifecycle.go
@@ -70,7 +70,7 @@ func (c *podLifecycleController) Reconcile(ctx context.Context, req ctrl.Request
 	logger = logger.WithValues("compositionName", comp.Name,
 		"compositionNamespace", comp.Namespace,
 		"compositionGeneration", comp.Generation,
-		"synthesisID", comp.Status.GetLatestSynthesisUUID())
+		"synthesisID", comp.Status.GetCurrentSynthesisUUID())
 
 	// It isn't safe to delete compositions until their resource slices have been cleaned up,
 	// since reconciling resources necessarily requires the composition.

--- a/internal/controllers/synthesis/lifecycle.go
+++ b/internal/controllers/synthesis/lifecycle.go
@@ -70,7 +70,7 @@ func (c *podLifecycleController) Reconcile(ctx context.Context, req ctrl.Request
 	logger = logger.WithValues("compositionName", comp.Name,
 		"compositionNamespace", comp.Namespace,
 		"compositionGeneration", comp.Generation,
-		"synthesisID", comp.Status.GetCurrentSynthesisUUID())
+		"synthesisID", comp.Status.GetLatestSynthesisUUID())
 
 	// It isn't safe to delete compositions until their resource slices have been cleaned up,
 	// since reconciling resources necessarily requires the composition.

--- a/internal/controllers/synthesis/lifecycle.go
+++ b/internal/controllers/synthesis/lifecycle.go
@@ -7,10 +7,8 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
-	"github.com/google/uuid"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -69,7 +67,7 @@ func (c *podLifecycleController) Reconcile(ctx context.Context, req ctrl.Request
 	logger = logger.WithValues("compositionName", comp.Name,
 		"compositionNamespace", comp.Namespace,
 		"compositionGeneration", comp.Generation,
-		"synthesisID", comp.Status.GetCurrentSynthesisUUID())
+		"synthesisID", comp.Status.GetLatestSynthesisUUID())
 
 	// It isn't safe to delete compositions until their resource slices have been cleaned up,
 	// since reconciling resources necessarily requires the composition.
@@ -98,7 +96,7 @@ func (c *podLifecycleController) Reconcile(ctx context.Context, req ctrl.Request
 	// It's only safe to ignore as a missing synth if we have already started synthesis,
 	// otherwise creating the synth and composition around the same time could result in a deadlock
 	// if the composition is processed before the synth hits the informer cache.
-	if (errors.IsNotFound(err) || syn.DeletionTimestamp != nil) && comp.Status.CurrentSynthesis != nil {
+	if (errors.IsNotFound(err) || syn.DeletionTimestamp != nil) && comp.Status.PendingSynthesis != nil {
 		syn = nil
 		err = nil
 	}
@@ -136,15 +134,15 @@ func (c *podLifecycleController) Reconcile(ctx context.Context, req ctrl.Request
 	}
 
 	// Bail if it isn't time to synthesize yet, or synthesis is already complete
-	if comp.Status.CurrentSynthesis == nil || comp.Status.CurrentSynthesis.UUID == "" || comp.Status.CurrentSynthesis.Synthesized != nil || comp.DeletionTimestamp != nil {
+	if comp.Status.PendingSynthesis == nil || comp.Status.PendingSynthesis.UUID == "" || comp.Status.PendingSynthesis.Synthesized != nil || comp.DeletionTimestamp != nil {
 		return ctrl.Result{}, nil
 	}
 
 	// Back off to avoid constantly re-synthesizing impossible compositions (unlikely but possible)
 	if shouldBackOffPodCreation(comp) {
 		const base = time.Millisecond * 250
-		wait := base * time.Duration(comp.Status.CurrentSynthesis.Attempts)
-		nextAttempt := comp.Status.CurrentSynthesis.PodCreation.Time.Add(wait)
+		wait := base * time.Duration(comp.Status.PendingSynthesis.Attempts)
+		nextAttempt := comp.Status.PendingSynthesis.PodCreation.Time.Add(wait)
 		if time.Since(nextAttempt) < 0 { // positive when past the nextAttempt
 			logger.V(1).Info("backing off pod creation", "latency", wait.Abs().Milliseconds())
 			return ctrl.Result{RequeueAfter: wait}, nil
@@ -155,7 +153,7 @@ func (c *podLifecycleController) Reconcile(ctx context.Context, req ctrl.Request
 	// This protects against cases where synthesis has recently started and something causes
 	// another tick of this loop before the pod write hits the informer.
 	err = c.noCacheReader.List(ctx, pods, client.InNamespace(c.config.PodNamespace), client.MatchingLabels{
-		"eno.azure.io/synthesis-uuid": comp.Status.CurrentSynthesis.UUID,
+		"eno.azure.io/synthesis-uuid": comp.Status.PendingSynthesis.UUID,
 	})
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("checking for existing pod: %w", err)
@@ -178,10 +176,10 @@ func (c *podLifecycleController) Reconcile(ctx context.Context, req ctrl.Request
 
 	// This metadata is optional - it's safe for the process to crash before reaching this point
 	patch := []map[string]any{
-		{"op": "test", "path": "/status/currentSynthesis/uuid", "value": comp.Status.CurrentSynthesis.UUID},
-		{"op": "test", "path": "/status/currentSynthesis/synthesized", "value": nil},
-		{"op": "replace", "path": "/status/currentSynthesis/attempts", "value": comp.Status.CurrentSynthesis.Attempts + 1},
-		{"op": "replace", "path": "/status/currentSynthesis/podCreation", "value": pod.CreationTimestamp},
+		{"op": "test", "path": "/status/pendingSynthesis/uuid", "value": comp.Status.PendingSynthesis.UUID},
+		{"op": "test", "path": "/status/pendingSynthesis/synthesized", "value": nil},
+		{"op": "replace", "path": "/status/pendingSynthesis/attempts", "value": comp.Status.PendingSynthesis.Attempts + 1},
+		{"op": "replace", "path": "/status/pendingSynthesis/podCreation", "value": pod.CreationTimestamp},
 	}
 	patchJS, err := json.Marshal(&patch)
 	if err != nil {
@@ -197,45 +195,6 @@ func (c *podLifecycleController) Reconcile(ctx context.Context, req ctrl.Request
 
 func (c *podLifecycleController) reconcileDeletedComposition(ctx context.Context, comp *apiv1.Composition) (ctrl.Result, error) {
 	logger := logr.FromContextOrDiscard(ctx)
-
-	// If the composition was being synthesized at the time of deletion we need to swap the previous
-	// state back to current. Otherwise we'll get stuck waiting for a synthesis that can't happen.
-	if shouldRevertStateSwap(comp) {
-		comp.Status.CurrentSynthesis = comp.Status.PreviousSynthesis
-		comp.Status.PreviousSynthesis = nil
-		err := c.client.Status().Update(ctx, comp)
-		if err != nil {
-			return ctrl.Result{}, fmt.Errorf("reverting swapped status for deletion: %w", err)
-		}
-		logger.V(0).Info("reverted swapped status for deletion")
-		return ctrl.Result{}, nil
-	}
-
-	// Deletion increments the composition's generation, but the reconstitution cache is only invalidated
-	// when the synthesized generation (from the status) changes, which will never happen because synthesis
-	// is righly disabled for deleted compositions. We break out of this deadlock condition by updating
-	// the status without actually synthesizing.
-	if shouldUpdateDeletedCompositionStatus(comp) {
-		comp.Status.CurrentSynthesis.ObservedCompositionGeneration = comp.Generation
-		comp.Status.CurrentSynthesis.Ready = nil
-		comp.Status.CurrentSynthesis.UUID = uuid.NewString()
-		now := metav1.Now()
-		if (comp.Status.PreviousSynthesis == nil || comp.Status.PreviousSynthesis.Synthesized == nil) &&
-			comp.Status.CurrentSynthesis.Synthesized == nil {
-			// In this case, the composition is not reconciling due to the synthesizer is missing and the composition finalizer should be removed.
-			// If not, the composition will stuck in waiting for reconciliation to be completed and the it can't be deleted.
-			comp.Status.CurrentSynthesis.Reconciled = &now
-		} else {
-			comp.Status.CurrentSynthesis.Reconciled = nil
-		}
-		comp.Status.CurrentSynthesis.Synthesized = &now
-		err := c.client.Status().Update(ctx, comp)
-		if err != nil {
-			return ctrl.Result{}, fmt.Errorf("updating current composition generation: %w", err)
-		}
-		logger.V(0).Info("updated composition status to reflect deletion")
-		return ctrl.Result{}, nil
-	}
 
 	// Remove the finalizer when all pods and slices have been deleted
 	if isReconciling(comp) {
@@ -303,10 +262,10 @@ func shouldDeletePod(logger logr.Logger, comp *apiv1.Composition, syn *apiv1.Syn
 		}
 
 		// Synthesis is done
-		if comp.Status.CurrentSynthesis != nil && comp.Status.CurrentSynthesis.PodCreation != nil {
-			logger = logger.WithValues("latency", time.Since(comp.Status.CurrentSynthesis.PodCreation.Time).Abs().Milliseconds())
+		if comp.Status.PendingSynthesis != nil && comp.Status.PendingSynthesis.PodCreation != nil {
+			logger = logger.WithValues("latency", time.Since(comp.Status.PendingSynthesis.PodCreation.Time).Abs().Milliseconds())
 		}
-		if comp.Status.CurrentSynthesis != nil && comp.Status.CurrentSynthesis.Synthesized != nil {
+		if comp.Status.PendingSynthesis != nil && comp.Status.PendingSynthesis.Synthesized != nil {
 			logger = logger.WithValues("reason", "Success")
 			return logger, &pod, true
 		}
@@ -319,7 +278,7 @@ func shouldDeletePod(logger logr.Logger, comp *apiv1.Composition, syn *apiv1.Syn
 		// i.e. when another pod for this synthesis isn't already terminating
 		// AND we bail out when the synthesis has already been tried a few times (what's a few more seconds latency at that point)
 		seenByKubelet := len(pod.Status.ContainerStatuses) != 0
-		retryPressure := comp.Status.CurrentSynthesis != nil && comp.Status.CurrentSynthesis.Attempts > 3
+		retryPressure := comp.Status.PendingSynthesis != nil && comp.Status.PendingSynthesis.Attempts > 3
 		if scheduledTime := getPodScheduledTime(&pod); !onePodDeleting && !seenByKubelet && !retryPressure && scheduledTime != nil && time.Since(*scheduledTime) > creationTTL {
 			logger = logger.WithValues("reason", "ContainerCreationTimeout", "scheduledTime", scheduledTime.UnixMilli())
 			return logger, &pod, true
@@ -364,20 +323,12 @@ func (c *podLifecycleController) deletePod(ctx context.Context, comp types.Names
 }
 
 func shouldBackOffPodCreation(comp *apiv1.Composition) bool {
-	current := comp.Status.CurrentSynthesis
+	current := comp.Status.PendingSynthesis
 	return current != nil && current.Attempts > 0 && current.PodCreation != nil
 }
 
-func shouldRevertStateSwap(comp *apiv1.Composition) bool {
-	return comp.Status.PreviousSynthesis != nil && (comp.Status.CurrentSynthesis == nil || comp.Status.CurrentSynthesis.Synthesized == nil)
-}
-
-func shouldUpdateDeletedCompositionStatus(comp *apiv1.Composition) bool {
-	return comp.Status.CurrentSynthesis != nil && (comp.Status.CurrentSynthesis.ObservedCompositionGeneration != comp.Generation || comp.Status.CurrentSynthesis.Synthesized == nil)
-}
-
 func isReconciling(comp *apiv1.Composition) bool {
-	return comp.Status.CurrentSynthesis != nil && (comp.Status.CurrentSynthesis.Reconciled == nil || comp.Status.CurrentSynthesis.ObservedCompositionGeneration != comp.Generation)
+	return comp.Status.PendingSynthesis != nil && (comp.Status.PendingSynthesis.Reconciled == nil || comp.Status.PendingSynthesis.ObservedCompositionGeneration != comp.Generation)
 }
 
 func getPodScheduledTime(pod *corev1.Pod) *time.Time {

--- a/internal/controllers/synthesis/lifecycle_test.go
+++ b/internal/controllers/synthesis/lifecycle_test.go
@@ -1,7 +1,6 @@
 package synthesis
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -11,174 +10,12 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/client-go/util/retry"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	apiv1 "github.com/Azure/eno/api/v1"
-	"github.com/Azure/eno/internal/controllers/scheduling"
 	"github.com/Azure/eno/internal/testutil"
-	krmv1 "github.com/Azure/eno/pkg/krm/functions/api/v1"
 )
-
-// TestCompositionDeletion proves that a composition's status is eventually updated to reflect its deletion.
-// This is necessary to unblock finalizer removal, since we don't synthesize deleted compositions.
-func TestCompositionDeletion(t *testing.T) {
-	ctx := testutil.NewContext(t)
-	mgr := testutil.NewManager(t)
-	cli := mgr.GetClient()
-
-	testutil.WithFakeExecutor(t, mgr, func(ctx context.Context, s *apiv1.Synthesizer, input *krmv1.ResourceList) (*krmv1.ResourceList, error) {
-		output := &krmv1.ResourceList{}
-		output.Items = []*unstructured.Unstructured{{
-			Object: map[string]any{
-				"apiVersion": "v1",
-				"kind":       "ConfigMap",
-				"metadata": map[string]string{
-					"name":      "test",
-					"namespace": "default",
-				},
-			},
-		}}
-		return output, nil
-	})
-
-	require.NoError(t, NewPodLifecycleController(mgr.Manager, minimalTestConfig))
-	require.NoError(t, NewSliceCleanupController(mgr.Manager))
-	require.NoError(t, scheduling.NewController(mgr.Manager, 10, 2*time.Second, time.Second))
-	mgr.Start(t)
-
-	syn := &apiv1.Synthesizer{}
-	syn.Name = "test-syn-1"
-	syn.Spec.Image = "initial-image"
-	require.NoError(t, cli.Create(ctx, syn))
-
-	comp := &apiv1.Composition{}
-	comp.Name = "test-comp"
-	comp.Namespace = "default"
-	comp.Spec.Synthesizer.Name = syn.Name
-	require.NoError(t, cli.Create(ctx, comp))
-
-	// Create the composition's resource slice
-	testutil.Eventually(t, func() bool {
-		require.NoError(t, client.IgnoreNotFound(cli.Get(ctx, client.ObjectKeyFromObject(comp), comp)))
-		return comp.Status.CurrentSynthesis != nil && len(comp.Status.CurrentSynthesis.ResourceSlices) > 0
-	})
-	assert.NotNil(t, comp.Status.CurrentSynthesis.Initialized, "initialized timestamp is set")
-
-	// Wait for the resource slice to be created
-	testutil.Eventually(t, func() bool {
-		require.NoError(t, client.IgnoreNotFound(cli.Get(ctx, client.ObjectKeyFromObject(comp), comp)))
-		return comp.Status.CurrentSynthesis != nil && comp.Status.CurrentSynthesis.ResourceSlices != nil
-	})
-
-	// Delete the composition
-	require.NoError(t, cli.Delete(ctx, comp))
-	deleteGen := comp.Generation
-
-	// The generation should be updated
-	testutil.Eventually(t, func() bool {
-		require.NoError(t, client.IgnoreNotFound(cli.Get(ctx, client.ObjectKeyFromObject(comp), comp)))
-		return comp.Status.CurrentSynthesis != nil && comp.Status.CurrentSynthesis.ObservedCompositionGeneration >= deleteGen
-	})
-
-	// The composition should still exist after a bit
-	// Yeahyeahyeah a fake clock would be better but this is more obvious and not meaningfully slower
-	time.Sleep(time.Millisecond * 100)
-	require.NoError(t, cli.Get(ctx, client.ObjectKeyFromObject(comp), comp))
-
-	// Mark the composition as reconciled
-	err := retry.RetryOnConflict(testutil.Backoff, func() error {
-		cli.Get(ctx, client.ObjectKeyFromObject(comp), comp)
-		comp.Status.CurrentSynthesis.Reconciled = ptr.To(metav1.Now())
-		return cli.Status().Update(ctx, comp)
-	})
-	require.NoError(t, err)
-
-	// The composition should eventually be released
-	testutil.Eventually(t, func() bool {
-		return errors.IsNotFound(cli.Get(ctx, client.ObjectKeyFromObject(comp), comp))
-	})
-}
-
-// TestDeleteCompositionWhenSynthesizerMissing proves that a composition's finalizer will be removed if the synthesizer is missing.
-func TestDeleteCompositionWhenSynthesizerMissing(t *testing.T) {
-	ctx := testutil.NewContext(t)
-	mgr := testutil.NewManager(t)
-	cli := mgr.GetClient()
-
-	testutil.WithFakeExecutor(t, mgr, func(ctx context.Context, s *apiv1.Synthesizer, input *krmv1.ResourceList) (*krmv1.ResourceList, error) {
-		output := &krmv1.ResourceList{}
-		output.Items = []*unstructured.Unstructured{{
-			Object: map[string]any{
-				"apiVersion": "v1",
-				"kind":       "ConfigMap",
-				"metadata": map[string]string{
-					"name":      "test",
-					"namespace": "default",
-				},
-			},
-		}}
-		return output, nil
-	})
-
-	require.NoError(t, NewPodLifecycleController(mgr.Manager, minimalTestConfig))
-	require.NoError(t, NewSliceCleanupController(mgr.Manager))
-	require.NoError(t, scheduling.NewController(mgr.Manager, 10, 2*time.Second, time.Second))
-	mgr.Start(t)
-
-	syn := &apiv1.Synthesizer{}
-	syn.Name = "test-syn-1"
-	syn.Spec.Image = "initial-image"
-	require.NoError(t, cli.Create(ctx, syn))
-
-	comp := &apiv1.Composition{}
-	comp.Name = "test-comp"
-	comp.Namespace = "default"
-	comp.Spec.Synthesizer.Name = syn.Name
-	require.NoError(t, cli.Create(ctx, comp))
-
-	// Create the composition's resource slice
-	testutil.Eventually(t, func() bool {
-		require.NoError(t, client.IgnoreNotFound(cli.Get(ctx, client.ObjectKeyFromObject(comp), comp)))
-		return comp.Status.CurrentSynthesis != nil && len(comp.Status.CurrentSynthesis.ResourceSlices) > 0
-	})
-	assert.NotNil(t, comp.Status.CurrentSynthesis.Initialized, "initialized timestamp is set")
-
-	// Wait for the resource slice to be created
-	testutil.Eventually(t, func() bool {
-		require.NoError(t, client.IgnoreNotFound(cli.Get(ctx, client.ObjectKeyFromObject(comp), comp)))
-		return comp.Status.CurrentSynthesis != nil && comp.Status.CurrentSynthesis.ResourceSlices != nil
-	})
-
-	// Delete the composition
-	require.NoError(t, cli.Delete(ctx, comp))
-	deleteGen := comp.Generation
-
-	// The generation should be updated
-	testutil.Eventually(t, func() bool {
-		require.NoError(t, client.IgnoreNotFound(cli.Get(ctx, client.ObjectKeyFromObject(comp), comp)))
-		return comp.Status.CurrentSynthesis != nil && comp.Status.CurrentSynthesis.ObservedCompositionGeneration >= deleteGen
-	})
-
-	// The composition should still exist after a bit
-	time.Sleep(time.Millisecond * 100)
-	require.NoError(t, cli.Get(ctx, client.ObjectKeyFromObject(comp), comp))
-
-	// Mark the synthesized time as nil to simulate the synthesizer is missing
-	err := retry.RetryOnConflict(testutil.Backoff, func() error {
-		cli.Get(ctx, client.ObjectKeyFromObject(comp), comp)
-		comp.Status.CurrentSynthesis.Synthesized = nil
-		return cli.Status().Update(ctx, comp)
-	})
-	require.NoError(t, err)
-
-	// The composition should eventually be released even the composition is waiting for reconciliation to be completed
-	testutil.Eventually(t, func() bool {
-		return errors.IsNotFound(cli.Get(ctx, client.ObjectKeyFromObject(comp), comp))
-	})
-}
 
 func TestNonExistentComposition(t *testing.T) {
 	ctx := testutil.NewContext(t)
@@ -237,7 +74,7 @@ var shouldDeletePodTests = []struct {
 		Composition: &apiv1.Composition{
 			ObjectMeta: metav1.ObjectMeta{},
 			Status: apiv1.CompositionStatus{
-				CurrentSynthesis: &apiv1.Synthesis{
+				PendingSynthesis: &apiv1.Synthesis{
 					UUID: "test-uuid",
 				},
 			},
@@ -265,7 +102,7 @@ var shouldDeletePodTests = []struct {
 				Generation: 2,
 			},
 			Status: apiv1.CompositionStatus{
-				CurrentSynthesis: &apiv1.Synthesis{
+				PendingSynthesis: &apiv1.Synthesis{
 					Synthesized: ptr.To(metav1.Now()),
 				},
 			},
@@ -293,7 +130,7 @@ var shouldDeletePodTests = []struct {
 				Generation: 2,
 			},
 			Status: apiv1.CompositionStatus{
-				CurrentSynthesis: &apiv1.Synthesis{
+				PendingSynthesis: &apiv1.Synthesis{
 					Synthesized: ptr.To(metav1.Now()),
 				},
 			},
@@ -321,7 +158,7 @@ var shouldDeletePodTests = []struct {
 		}},
 		Composition: &apiv1.Composition{
 			Status: apiv1.CompositionStatus{
-				CurrentSynthesis: &apiv1.Synthesis{},
+				PendingSynthesis: &apiv1.Synthesis{},
 			},
 		},
 		Synth: &apiv1.Synthesizer{
@@ -351,7 +188,7 @@ var shouldDeletePodTests = []struct {
 		}},
 		Composition: &apiv1.Composition{
 			Status: apiv1.CompositionStatus{
-				CurrentSynthesis: &apiv1.Synthesis{},
+				PendingSynthesis: &apiv1.Synthesis{},
 			},
 		},
 		Synth: &apiv1.Synthesizer{
@@ -373,7 +210,7 @@ var shouldDeletePodTests = []struct {
 		}},
 		Composition: &apiv1.Composition{
 			Status: apiv1.CompositionStatus{
-				CurrentSynthesis: &apiv1.Synthesis{},
+				PendingSynthesis: &apiv1.Synthesis{},
 			},
 		},
 		Synth: &apiv1.Synthesizer{
@@ -395,7 +232,7 @@ var shouldDeletePodTests = []struct {
 		}},
 		Composition: &apiv1.Composition{
 			Status: apiv1.CompositionStatus{
-				CurrentSynthesis: &apiv1.Synthesis{},
+				PendingSynthesis: &apiv1.Synthesis{},
 			},
 		},
 		Synth: &apiv1.Synthesizer{
@@ -426,7 +263,7 @@ var shouldDeletePodTests = []struct {
 		}},
 		Composition: &apiv1.Composition{
 			Status: apiv1.CompositionStatus{
-				CurrentSynthesis: &apiv1.Synthesis{},
+				PendingSynthesis: &apiv1.Synthesis{},
 			},
 		},
 		Synth: &apiv1.Synthesizer{
@@ -452,7 +289,7 @@ var shouldDeletePodTests = []struct {
 		}},
 		Composition: &apiv1.Composition{
 			Status: apiv1.CompositionStatus{
-				CurrentSynthesis: &apiv1.Synthesis{Attempts: 4},
+				PendingSynthesis: &apiv1.Synthesis{Attempts: 4},
 			},
 		},
 		Synth: &apiv1.Synthesizer{
@@ -473,7 +310,7 @@ var shouldDeletePodTests = []struct {
 		}},
 		Composition: &apiv1.Composition{
 			Status: apiv1.CompositionStatus{
-				CurrentSynthesis: &apiv1.Synthesis{},
+				PendingSynthesis: &apiv1.Synthesis{},
 			},
 		},
 		Synth: &apiv1.Synthesizer{

--- a/internal/controllers/synthesis/lifecycle_test.go
+++ b/internal/controllers/synthesis/lifecycle_test.go
@@ -1,6 +1,7 @@
 package synthesis
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -10,12 +11,96 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/client-go/util/retry"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	apiv1 "github.com/Azure/eno/api/v1"
+	"github.com/Azure/eno/internal/controllers/scheduling"
 	"github.com/Azure/eno/internal/testutil"
+	krmv1 "github.com/Azure/eno/pkg/krm/functions/api/v1"
 )
+
+// TestCompositionDeletion proves that a composition's status is eventually updated to reflect its deletion.
+// This is necessary to unblock finalizer removal, since we don't synthesize deleted compositions.
+func TestCompositionDeletion(t *testing.T) {
+	ctx := testutil.NewContext(t)
+	mgr := testutil.NewManager(t)
+	cli := mgr.GetClient()
+
+	testutil.WithFakeExecutor(t, mgr, func(ctx context.Context, s *apiv1.Synthesizer, input *krmv1.ResourceList) (*krmv1.ResourceList, error) {
+		output := &krmv1.ResourceList{}
+		output.Items = []*unstructured.Unstructured{{
+			Object: map[string]any{
+				"apiVersion": "v1",
+				"kind":       "ConfigMap",
+				"metadata": map[string]string{
+					"name":      "test",
+					"namespace": "default",
+				},
+			},
+		}}
+		return output, nil
+	})
+
+	require.NoError(t, NewPodLifecycleController(mgr.Manager, minimalTestConfig))
+	require.NoError(t, NewSliceCleanupController(mgr.Manager))
+	require.NoError(t, scheduling.NewController(mgr.Manager, 10, 2*time.Second, time.Second))
+	mgr.Start(t)
+
+	syn := &apiv1.Synthesizer{}
+	syn.Name = "test-syn-1"
+	syn.Spec.Image = "initial-image"
+	require.NoError(t, cli.Create(ctx, syn))
+
+	comp := &apiv1.Composition{}
+	comp.Name = "test-comp"
+	comp.Namespace = "default"
+	comp.Spec.Synthesizer.Name = syn.Name
+	require.NoError(t, cli.Create(ctx, comp))
+
+	// Create the composition's resource slice
+	testutil.Eventually(t, func() bool {
+		require.NoError(t, client.IgnoreNotFound(cli.Get(ctx, client.ObjectKeyFromObject(comp), comp)))
+		return comp.Status.CurrentSynthesis != nil && len(comp.Status.CurrentSynthesis.ResourceSlices) > 0
+	})
+	assert.NotNil(t, comp.Status.CurrentSynthesis.Initialized, "initialized timestamp is set")
+
+	// Wait for the resource slice to be created
+	testutil.Eventually(t, func() bool {
+		require.NoError(t, client.IgnoreNotFound(cli.Get(ctx, client.ObjectKeyFromObject(comp), comp)))
+		return comp.Status.CurrentSynthesis != nil && comp.Status.CurrentSynthesis.ResourceSlices != nil
+	})
+
+	// Delete the composition
+	require.NoError(t, cli.Delete(ctx, comp))
+	deleteGen := comp.Generation
+
+	// The generation should be updated
+	testutil.Eventually(t, func() bool {
+		require.NoError(t, client.IgnoreNotFound(cli.Get(ctx, client.ObjectKeyFromObject(comp), comp)))
+		return comp.Status.CurrentSynthesis != nil && comp.Status.CurrentSynthesis.ObservedCompositionGeneration >= deleteGen
+	})
+
+	// The composition should still exist after a bit
+	// Yeahyeahyeah a fake clock would be better but this is more obvious and not meaningfully slower
+	time.Sleep(time.Millisecond * 100)
+	require.NoError(t, cli.Get(ctx, client.ObjectKeyFromObject(comp), comp))
+
+	// Mark the composition as reconciled
+	err := retry.RetryOnConflict(testutil.Backoff, func() error {
+		cli.Get(ctx, client.ObjectKeyFromObject(comp), comp)
+		comp.Status.CurrentSynthesis.Reconciled = ptr.To(metav1.Now())
+		return cli.Status().Update(ctx, comp)
+	})
+	require.NoError(t, err)
+
+	// The composition should eventually be released
+	testutil.Eventually(t, func() bool {
+		return errors.IsNotFound(cli.Get(ctx, client.ObjectKeyFromObject(comp), comp))
+	})
+}
 
 func TestNonExistentComposition(t *testing.T) {
 	ctx := testutil.NewContext(t)

--- a/internal/controllers/synthesis/lifecycle_test.go
+++ b/internal/controllers/synthesis/lifecycle_test.go
@@ -159,7 +159,7 @@ var shouldDeletePodTests = []struct {
 		Composition: &apiv1.Composition{
 			ObjectMeta: metav1.ObjectMeta{},
 			Status: apiv1.CompositionStatus{
-				PendingSynthesis: &apiv1.Synthesis{
+				InFlightSynthesis: &apiv1.Synthesis{
 					UUID: "test-uuid",
 				},
 			},
@@ -187,7 +187,7 @@ var shouldDeletePodTests = []struct {
 				Generation: 2,
 			},
 			Status: apiv1.CompositionStatus{
-				PendingSynthesis: &apiv1.Synthesis{
+				InFlightSynthesis: &apiv1.Synthesis{
 					Synthesized: ptr.To(metav1.Now()),
 				},
 			},
@@ -215,7 +215,7 @@ var shouldDeletePodTests = []struct {
 				Generation: 2,
 			},
 			Status: apiv1.CompositionStatus{
-				PendingSynthesis: &apiv1.Synthesis{
+				InFlightSynthesis: &apiv1.Synthesis{
 					Synthesized: ptr.To(metav1.Now()),
 				},
 			},
@@ -243,7 +243,7 @@ var shouldDeletePodTests = []struct {
 		}},
 		Composition: &apiv1.Composition{
 			Status: apiv1.CompositionStatus{
-				PendingSynthesis: &apiv1.Synthesis{},
+				InFlightSynthesis: &apiv1.Synthesis{},
 			},
 		},
 		Synth: &apiv1.Synthesizer{
@@ -273,7 +273,7 @@ var shouldDeletePodTests = []struct {
 		}},
 		Composition: &apiv1.Composition{
 			Status: apiv1.CompositionStatus{
-				PendingSynthesis: &apiv1.Synthesis{},
+				InFlightSynthesis: &apiv1.Synthesis{},
 			},
 		},
 		Synth: &apiv1.Synthesizer{
@@ -295,7 +295,7 @@ var shouldDeletePodTests = []struct {
 		}},
 		Composition: &apiv1.Composition{
 			Status: apiv1.CompositionStatus{
-				PendingSynthesis: &apiv1.Synthesis{},
+				InFlightSynthesis: &apiv1.Synthesis{},
 			},
 		},
 		Synth: &apiv1.Synthesizer{
@@ -317,7 +317,7 @@ var shouldDeletePodTests = []struct {
 		}},
 		Composition: &apiv1.Composition{
 			Status: apiv1.CompositionStatus{
-				PendingSynthesis: &apiv1.Synthesis{},
+				InFlightSynthesis: &apiv1.Synthesis{},
 			},
 		},
 		Synth: &apiv1.Synthesizer{
@@ -348,7 +348,7 @@ var shouldDeletePodTests = []struct {
 		}},
 		Composition: &apiv1.Composition{
 			Status: apiv1.CompositionStatus{
-				PendingSynthesis: &apiv1.Synthesis{},
+				InFlightSynthesis: &apiv1.Synthesis{},
 			},
 		},
 		Synth: &apiv1.Synthesizer{
@@ -374,7 +374,7 @@ var shouldDeletePodTests = []struct {
 		}},
 		Composition: &apiv1.Composition{
 			Status: apiv1.CompositionStatus{
-				PendingSynthesis: &apiv1.Synthesis{Attempts: 4},
+				InFlightSynthesis: &apiv1.Synthesis{Attempts: 4},
 			},
 		},
 		Synth: &apiv1.Synthesizer{
@@ -395,7 +395,7 @@ var shouldDeletePodTests = []struct {
 		}},
 		Composition: &apiv1.Composition{
 			Status: apiv1.CompositionStatus{
-				PendingSynthesis: &apiv1.Synthesis{},
+				InFlightSynthesis: &apiv1.Synthesis{},
 			},
 		},
 		Synth: &apiv1.Synthesizer{

--- a/internal/controllers/synthesis/pod.go
+++ b/internal/controllers/synthesis/pod.go
@@ -21,7 +21,7 @@ func newPod(cfg *Config, comp *apiv1.Composition, syn *apiv1.Synthesizer) *corev
 		manager.CompositionNameLabelKey:      comp.Name,
 		manager.CompositionNamespaceLabelKey: comp.Namespace,
 		manager.ManagerLabelKey:              manager.ManagerLabelValue,
-		"eno.azure.io/synthesis-uuid":        comp.Status.CurrentSynthesis.UUID,
+		"eno.azure.io/synthesis-uuid":        comp.Status.PendingSynthesis.UUID,
 	}
 	for k, v := range syn.Spec.PodOverrides.Labels {
 		pod.Labels[k] = v
@@ -43,11 +43,11 @@ func newPod(cfg *Config, comp *apiv1.Composition, syn *apiv1.Synthesizer) *corev
 		},
 		{
 			Name:  "SYNTHESIS_UUID",
-			Value: comp.Status.CurrentSynthesis.UUID,
+			Value: comp.Status.PendingSynthesis.UUID,
 		},
 		{
 			Name:  "SYNTHESIS_ATTEMPT",
-			Value: strconv.Itoa(comp.Status.CurrentSynthesis.Attempts + 1), // we write the next attempt _after_ pod creation
+			Value: strconv.Itoa(comp.Status.PendingSynthesis.Attempts + 1), // we write the next attempt _after_ pod creation
 		},
 	}
 
@@ -186,7 +186,7 @@ func newPod(cfg *Config, comp *apiv1.Composition, syn *apiv1.Synthesizer) *corev
 }
 
 func podIsCurrent(comp *apiv1.Composition, pod *corev1.Pod) bool {
-	return pod.Labels != nil && comp.Status.CurrentSynthesis != nil && comp.Status.CurrentSynthesis.UUID == pod.Labels["eno.azure.io/synthesis-uuid"]
+	return pod.Labels != nil && comp.Status.PendingSynthesis != nil && comp.Status.PendingSynthesis.UUID == pod.Labels["eno.azure.io/synthesis-uuid"]
 }
 
 // filterEnv returns env taking out any items that have the same name as

--- a/internal/controllers/synthesis/pod.go
+++ b/internal/controllers/synthesis/pod.go
@@ -21,7 +21,7 @@ func newPod(cfg *Config, comp *apiv1.Composition, syn *apiv1.Synthesizer) *corev
 		manager.CompositionNameLabelKey:      comp.Name,
 		manager.CompositionNamespaceLabelKey: comp.Namespace,
 		manager.ManagerLabelKey:              manager.ManagerLabelValue,
-		"eno.azure.io/synthesis-uuid":        comp.Status.PendingSynthesis.UUID,
+		"eno.azure.io/synthesis-uuid":        comp.Status.InFlightSynthesis.UUID,
 	}
 	for k, v := range syn.Spec.PodOverrides.Labels {
 		pod.Labels[k] = v
@@ -43,11 +43,11 @@ func newPod(cfg *Config, comp *apiv1.Composition, syn *apiv1.Synthesizer) *corev
 		},
 		{
 			Name:  "SYNTHESIS_UUID",
-			Value: comp.Status.PendingSynthesis.UUID,
+			Value: comp.Status.InFlightSynthesis.UUID,
 		},
 		{
 			Name:  "SYNTHESIS_ATTEMPT",
-			Value: strconv.Itoa(comp.Status.PendingSynthesis.Attempts + 1), // we write the next attempt _after_ pod creation
+			Value: strconv.Itoa(comp.Status.InFlightSynthesis.Attempts + 1), // we write the next attempt _after_ pod creation
 		},
 	}
 
@@ -186,7 +186,7 @@ func newPod(cfg *Config, comp *apiv1.Composition, syn *apiv1.Synthesizer) *corev
 }
 
 func podIsCurrent(comp *apiv1.Composition, pod *corev1.Pod) bool {
-	return pod.Labels != nil && comp.Status.PendingSynthesis != nil && comp.Status.PendingSynthesis.UUID == pod.Labels["eno.azure.io/synthesis-uuid"]
+	return pod.Labels != nil && comp.Status.InFlightSynthesis != nil && comp.Status.InFlightSynthesis.UUID == pod.Labels["eno.azure.io/synthesis-uuid"]
 }
 
 // filterEnv returns env taking out any items that have the same name as

--- a/internal/controllers/synthesis/pod_test.go
+++ b/internal/controllers/synthesis/pod_test.go
@@ -97,7 +97,7 @@ var newPodTests = []struct {
 			comp.Name = "test-composition"
 			comp.Namespace = "test-composition-ns"
 			comp.Generation = 123
-			comp.Status.PendingSynthesis = &apiv1.Synthesis{UUID: "test-uuid"}
+			comp.Status.InFlightSynthesis = &apiv1.Synthesis{UUID: "test-uuid"}
 			comp.Spec.SynthesisEnv = []apiv1.EnvVar{{Name: "some_env", Value: "some-val"}}
 			return comp
 		}(),
@@ -112,7 +112,7 @@ var newPodTests = []struct {
 			comp.Name = "test-composition"
 			comp.Namespace = "test-composition-ns"
 			comp.Generation = 123
-			comp.Status.PendingSynthesis = &apiv1.Synthesis{UUID: "test-uuid"}
+			comp.Status.InFlightSynthesis = &apiv1.Synthesis{UUID: "test-uuid"}
 			comp.Spec.SynthesisEnv = []apiv1.EnvVar{
 				{Name: "some_env", Value: "some-val"},
 				{Name: "COMPOSITION_NAME", Value: "some-comp"},
@@ -224,7 +224,7 @@ func TestNewPod(t *testing.T) {
 			comp.Name = "test-composition"
 			comp.Namespace = "test-composition-ns"
 			comp.Generation = 123
-			comp.Status.PendingSynthesis = &apiv1.Synthesis{UUID: "test-uuid"}
+			comp.Status.InFlightSynthesis = &apiv1.Synthesis{UUID: "test-uuid"}
 			tc.Comp = comp
 		}
 

--- a/internal/controllers/synthesis/pod_test.go
+++ b/internal/controllers/synthesis/pod_test.go
@@ -97,7 +97,7 @@ var newPodTests = []struct {
 			comp.Name = "test-composition"
 			comp.Namespace = "test-composition-ns"
 			comp.Generation = 123
-			comp.Status.CurrentSynthesis = &apiv1.Synthesis{UUID: "test-uuid"}
+			comp.Status.PendingSynthesis = &apiv1.Synthesis{UUID: "test-uuid"}
 			comp.Spec.SynthesisEnv = []apiv1.EnvVar{{Name: "some_env", Value: "some-val"}}
 			return comp
 		}(),
@@ -112,7 +112,7 @@ var newPodTests = []struct {
 			comp.Name = "test-composition"
 			comp.Namespace = "test-composition-ns"
 			comp.Generation = 123
-			comp.Status.CurrentSynthesis = &apiv1.Synthesis{UUID: "test-uuid"}
+			comp.Status.PendingSynthesis = &apiv1.Synthesis{UUID: "test-uuid"}
 			comp.Spec.SynthesisEnv = []apiv1.EnvVar{
 				{Name: "some_env", Value: "some-val"},
 				{Name: "COMPOSITION_NAME", Value: "some-comp"},
@@ -224,7 +224,7 @@ func TestNewPod(t *testing.T) {
 			comp.Name = "test-composition"
 			comp.Namespace = "test-composition-ns"
 			comp.Generation = 123
-			comp.Status.CurrentSynthesis = &apiv1.Synthesis{UUID: "test-uuid"}
+			comp.Status.PendingSynthesis = &apiv1.Synthesis{UUID: "test-uuid"}
 			tc.Comp = comp
 		}
 

--- a/internal/controllers/synthesis/slicecleanup.go
+++ b/internal/controllers/synthesis/slicecleanup.go
@@ -147,8 +147,13 @@ func (c *cleanupDecision) String() string {
 }
 
 func shouldDeleteSlice(comp *apiv1.Composition, slice *apiv1.ResourceSlice) bool {
-	// TODO: Current also
-	if comp.Status.PendingSynthesis == nil || slice.Spec.CompositionGeneration > comp.Status.PendingSynthesis.ObservedCompositionGeneration {
+	var synthesizedGeneration int64
+	if comp.Status.PendingSynthesis != nil {
+		synthesizedGeneration = comp.Status.PendingSynthesis.ObservedCompositionGeneration
+	} else if comp.Status.CurrentSynthesis != nil {
+		synthesizedGeneration = comp.Status.CurrentSynthesis.ObservedCompositionGeneration
+	}
+	if slice.Spec.CompositionGeneration > synthesizedGeneration {
 		return false // stale informer
 	}
 
@@ -168,7 +173,13 @@ func shouldDeleteSlice(comp *apiv1.Composition, slice *apiv1.ResourceSlice) bool
 }
 
 func shouldReleaseSliceFinalizer(comp *apiv1.Composition, slice *apiv1.ResourceSlice) bool {
-	if comp.Status.PendingSynthesis == nil || slice.Spec.CompositionGeneration > comp.Status.PendingSynthesis.ObservedCompositionGeneration {
+	var synthesizedGeneration int64
+	if comp.Status.PendingSynthesis != nil {
+		synthesizedGeneration = comp.Status.PendingSynthesis.ObservedCompositionGeneration
+	} else if comp.Status.CurrentSynthesis != nil {
+		synthesizedGeneration = comp.Status.CurrentSynthesis.ObservedCompositionGeneration
+	}
+	if slice.Spec.CompositionGeneration > synthesizedGeneration {
 		return false // stale informer
 	}
 	isOutdated := slice.Spec.Attempt != 0 && comp.Status.PendingSynthesis != nil && comp.Status.PendingSynthesis.Attempts > slice.Spec.Attempt

--- a/internal/controllers/synthesis/slicecleanup.go
+++ b/internal/controllers/synthesis/slicecleanup.go
@@ -158,7 +158,7 @@ func shouldDeleteSlice(comp *apiv1.Composition, slice *apiv1.ResourceSlice) bool
 	}
 
 	var (
-		hasBeenRetried     = slice.Spec.Attempt != 0 && comp.Status.PendingSynthesis.Attempts > slice.Spec.Attempt && slice.Spec.SynthesisUUID == comp.Status.PendingSynthesis.UUID
+		hasBeenRetried     = slice.Spec.Attempt != 0 && comp.Status.PendingSynthesis != nil && comp.Status.PendingSynthesis.Attempts > slice.Spec.Attempt && slice.Spec.SynthesisUUID == comp.Status.PendingSynthesis.UUID
 		isReferencedByComp = synthesisReferencesSlice(comp.Status.PendingSynthesis, slice) || synthesisReferencesSlice(comp.Status.CurrentSynthesis, slice) || synthesisReferencesSlice(comp.Status.PreviousSynthesis, slice)
 		isSynthesized      = comp.Status.CurrentSynthesis != nil
 		compIsDeleted      = comp.DeletionTimestamp != nil

--- a/internal/controllers/synthesis/slicecleanup_test.go
+++ b/internal/controllers/synthesis/slicecleanup_test.go
@@ -98,7 +98,7 @@ func TestShouldDeleteSlice(t *testing.T) {
 			name: "another attempt started for a different synthesis, old one still references the slice",
 			comp: &apiv1.Composition{
 				Status: apiv1.CompositionStatus{
-					CurrentSynthesis: &apiv1.Synthesis{
+					PendingSynthesis: &apiv1.Synthesis{
 						Attempts: 5,
 						UUID:     "the-next-one",
 					},
@@ -121,7 +121,7 @@ func TestShouldDeleteSlice(t *testing.T) {
 			name: "another attempt started for the same synthesis",
 			comp: &apiv1.Composition{
 				Status: apiv1.CompositionStatus{
-					CurrentSynthesis: &apiv1.Synthesis{
+					PendingSynthesis: &apiv1.Synthesis{
 						Attempts: 5,
 					},
 				},
@@ -137,7 +137,7 @@ func TestShouldDeleteSlice(t *testing.T) {
 			name: "slice is referenced by composition",
 			comp: &apiv1.Composition{
 				Status: apiv1.CompositionStatus{
-					CurrentSynthesis: &apiv1.Synthesis{},
+					PendingSynthesis: &apiv1.Synthesis{},
 				},
 			},
 			slice: &apiv1.ResourceSlice{
@@ -154,6 +154,7 @@ func TestShouldDeleteSlice(t *testing.T) {
 					DeletionTimestamp: &metav1.Time{Time: time.Now()},
 				},
 				Status: apiv1.CompositionStatus{
+					PendingSynthesis: nil,
 					CurrentSynthesis: &apiv1.Synthesis{
 						Synthesized: &metav1.Time{Time: time.Now()},
 					},

--- a/internal/controllers/synthesis/slicecleanup_test.go
+++ b/internal/controllers/synthesis/slicecleanup_test.go
@@ -381,6 +381,7 @@ func TestBuildCleanupDecision_StaleCache(t *testing.T) {
 	slice := &apiv1.ResourceSlice{}
 	slice.Name = "test-slice"
 	slice.Namespace = staleComp.Namespace
+	slice.Spec.CompositionGeneration = 2 // newer than the composition
 	slice.CreationTimestamp = metav1.NewTime(time.Now().Add(-time.Minute * 5))
 
 	comp := staleComp.DeepCopy()

--- a/internal/controllers/synthesis/slicecleanup_test.go
+++ b/internal/controllers/synthesis/slicecleanup_test.go
@@ -357,6 +357,66 @@ func TestShouldDeleteSlice(t *testing.T) {
 			},
 			expected: false,
 		},
+		{
+			name: "slice is from an older composition generation",
+			comp: &apiv1.Composition{
+				Status: apiv1.CompositionStatus{
+					CurrentSynthesis: &apiv1.Synthesis{
+						ObservedCompositionGeneration: 3,
+					},
+				},
+			},
+			slice: &apiv1.ResourceSlice{
+				Spec: apiv1.ResourceSliceSpec{
+					CompositionGeneration: 2,
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "slice is from an older composition generation, no current synthesis",
+			comp: &apiv1.Composition{
+				Status: apiv1.CompositionStatus{},
+			},
+			slice: &apiv1.ResourceSlice{
+				Spec: apiv1.ResourceSliceSpec{
+					CompositionGeneration: 2,
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "slice is from the current composition generation",
+			comp: &apiv1.Composition{
+				Status: apiv1.CompositionStatus{
+					CurrentSynthesis: &apiv1.Synthesis{
+						ObservedCompositionGeneration: 3,
+					},
+				},
+			},
+			slice: &apiv1.ResourceSlice{
+				Spec: apiv1.ResourceSliceSpec{
+					CompositionGeneration: 3,
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "slice is from a newer composition generation",
+			comp: &apiv1.Composition{
+				Status: apiv1.CompositionStatus{
+					CurrentSynthesis: &apiv1.Synthesis{
+						ObservedCompositionGeneration: 3,
+					},
+				},
+			},
+			slice: &apiv1.ResourceSlice{
+				Spec: apiv1.ResourceSliceSpec{
+					CompositionGeneration: 4,
+				},
+			},
+			expected: false,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/controllers/synthesis/slicecleanup_test.go
+++ b/internal/controllers/synthesis/slicecleanup_test.go
@@ -98,7 +98,7 @@ func TestShouldDeleteSlice(t *testing.T) {
 			name: "another attempt started for a different synthesis, old one still references the slice",
 			comp: &apiv1.Composition{
 				Status: apiv1.CompositionStatus{
-					PendingSynthesis: &apiv1.Synthesis{
+					InFlightSynthesis: &apiv1.Synthesis{
 						Attempts: 5,
 						UUID:     "the-next-one",
 					},
@@ -121,7 +121,7 @@ func TestShouldDeleteSlice(t *testing.T) {
 			name: "another attempt started for the same synthesis",
 			comp: &apiv1.Composition{
 				Status: apiv1.CompositionStatus{
-					PendingSynthesis: &apiv1.Synthesis{
+					InFlightSynthesis: &apiv1.Synthesis{
 						Attempts: 5,
 					},
 				},
@@ -137,7 +137,7 @@ func TestShouldDeleteSlice(t *testing.T) {
 			name: "slice is referenced by composition",
 			comp: &apiv1.Composition{
 				Status: apiv1.CompositionStatus{
-					PendingSynthesis: &apiv1.Synthesis{},
+					InFlightSynthesis: &apiv1.Synthesis{},
 				},
 			},
 			slice: &apiv1.ResourceSlice{
@@ -154,7 +154,7 @@ func TestShouldDeleteSlice(t *testing.T) {
 					DeletionTimestamp: &metav1.Time{Time: time.Now()},
 				},
 				Status: apiv1.CompositionStatus{
-					PendingSynthesis: nil,
+					InFlightSynthesis: nil,
 					CurrentSynthesis: &apiv1.Synthesis{
 						Synthesized: &metav1.Time{Time: time.Now()},
 					},

--- a/internal/execution/executor_test.go
+++ b/internal/execution/executor_test.go
@@ -3,18 +3,14 @@ package execution
 import (
 	"context"
 	"testing"
-	"time"
 
 	apiv1 "github.com/Azure/eno/api/v1"
 	krmv1 "github.com/Azure/eno/pkg/krm/functions/api/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/client-go/util/retry"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
@@ -41,7 +37,7 @@ func TestBasics(t *testing.T) {
 	err = cli.Create(ctx, comp)
 	require.NoError(t, err)
 
-	comp.Status.CurrentSynthesis = &apiv1.Synthesis{UUID: "test-uuid"}
+	comp.Status.PendingSynthesis = &apiv1.Synthesis{UUID: "test-uuid"}
 	err = cli.Status().Update(ctx, comp)
 	require.NoError(t, err)
 
@@ -69,7 +65,7 @@ func TestBasics(t *testing.T) {
 	env := &Env{
 		CompositionName:      comp.Name,
 		CompositionNamespace: comp.Namespace,
-		SynthesisUUID:        comp.Status.CurrentSynthesis.UUID,
+		SynthesisUUID:        comp.Status.PendingSynthesis.UUID,
 	}
 
 	// First pass
@@ -147,7 +143,7 @@ func TestWithInputs(t *testing.T) {
 	err = cli.Create(ctx, comp)
 	require.NoError(t, err)
 
-	comp.Status.CurrentSynthesis = &apiv1.Synthesis{UUID: "test-uuid"}
+	comp.Status.PendingSynthesis = &apiv1.Synthesis{UUID: "test-uuid"}
 	err = cli.Status().Update(ctx, comp)
 	require.NoError(t, err)
 
@@ -177,7 +173,7 @@ func TestWithInputs(t *testing.T) {
 	env := &Env{
 		CompositionName:      comp.Name,
 		CompositionNamespace: comp.Namespace,
-		SynthesisUUID:        comp.Status.CurrentSynthesis.UUID,
+		SynthesisUUID:        comp.Status.PendingSynthesis.UUID,
 	}
 
 	err = e.Synthesize(ctx, env)
@@ -229,7 +225,7 @@ func TestWithVersionedInput(t *testing.T) {
 	err = cli.Create(ctx, comp)
 	require.NoError(t, err)
 
-	comp.Status.CurrentSynthesis = &apiv1.Synthesis{UUID: "test-uuid"}
+	comp.Status.PendingSynthesis = &apiv1.Synthesis{UUID: "test-uuid"}
 	err = cli.Status().Update(ctx, comp)
 	require.NoError(t, err)
 
@@ -254,7 +250,7 @@ func TestWithVersionedInput(t *testing.T) {
 	env := &Env{
 		CompositionName:      comp.Name,
 		CompositionNamespace: comp.Namespace,
-		SynthesisUUID:        comp.Status.CurrentSynthesis.UUID,
+		SynthesisUUID:        comp.Status.PendingSynthesis.UUID,
 	}
 
 	err = e.Synthesize(ctx, env)
@@ -325,80 +321,4 @@ func TestUUIDMismatch(t *testing.T) {
 	err = cli.Get(ctx, client.ObjectKeyFromObject(comp), comp)
 	require.NoError(t, err)
 	assert.Nil(t, comp.Status.CurrentSynthesis.Synthesized)
-}
-
-func TestCompletionMismatchDuringSynthesis(t *testing.T) {
-	ctx := context.Background()
-	scheme := runtime.NewScheme()
-	require.NoError(t, apiv1.SchemeBuilder.AddToScheme(scheme))
-
-	cli := fake.NewClientBuilder().
-		WithScheme(scheme).
-		WithStatusSubresource(&apiv1.ResourceSlice{}, &apiv1.Composition{}).
-		Build()
-
-	syn := &apiv1.Synthesizer{}
-	syn.Name = "test-synth"
-	err := cli.Create(ctx, syn)
-	require.NoError(t, err)
-
-	comp := &apiv1.Composition{}
-	comp.Name = "test-comp"
-	comp.Namespace = "default"
-	comp.Spec.Synthesizer.Name = syn.Name
-	err = cli.Create(ctx, comp)
-	require.NoError(t, err)
-
-	comp.Status.CurrentSynthesis = &apiv1.Synthesis{UUID: "test-uuid"}
-	err = cli.Status().Update(ctx, comp)
-	require.NoError(t, err)
-
-	env := &Env{
-		CompositionName:      comp.Name,
-		CompositionNamespace: comp.Namespace,
-		SynthesisUUID:        comp.Status.CurrentSynthesis.UUID,
-	}
-	originalSynthTime := metav1.NewTime(time.Now().Round(time.Second).Local())
-	e := &Executor{
-		Reader: cli,
-		Writer: cli,
-		Handler: func(ctx context.Context, s *apiv1.Synthesizer, rl *krmv1.ResourceList) (*krmv1.ResourceList, error) {
-			// Act as if another synthesizer pod with the same synthesis uuid but different attempt has updated the status concurrently
-			err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
-				require.NoError(t, cli.Get(ctx, client.ObjectKeyFromObject(comp), comp))
-				comp.Status.CurrentSynthesis.Synthesized = ptr.To(originalSynthTime)
-				return cli.Status().Update(ctx, comp)
-			})
-			require.NoError(t, err)
-
-			// Wait for that write to hit the informer cache
-			assert.Eventually(t, func() bool {
-				cli.Get(ctx, client.ObjectKeyFromObject(comp), comp)
-				return comp.Status.CurrentSynthesis.Synthesized != nil
-			}, time.Second*2, time.Millisecond*10)
-
-			out := &unstructured.Unstructured{
-				Object: map[string]any{
-					"apiVersion": "v1",
-					"kind":       "ConfigMap",
-					"metadata": map[string]string{
-						"name":      "test",
-						"namespace": "default",
-					},
-					"data": map[string]string{"foo": "bar"},
-				},
-			}
-			return &krmv1.ResourceList{
-				Items:   []*unstructured.Unstructured{out},
-				Results: []*krmv1.Result{{Message: "foo", Severity: "error"}},
-			}, nil
-		},
-	}
-
-	err = e.Synthesize(ctx, env)
-	require.NoError(t, err)
-
-	err = cli.Get(ctx, client.ObjectKeyFromObject(comp), comp)
-	require.NoError(t, err)
-	assert.Equal(t, originalSynthTime, *comp.Status.CurrentSynthesis.Synthesized)
 }

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -275,7 +275,7 @@ func (m *Manager) GetCurrentResourceSlices(ctx context.Context) ([]*apiv1.Resour
 	if l := len(comps.Items); l != 1 {
 		return nil, fmt.Errorf("expected one composition, found %d", l)
 	}
-	if comps.Items[0].Status.CurrentSynthesis.Synthesized == nil {
+	if comps.Items[0].Synthesizing() {
 		return nil, fmt.Errorf("composition is still being synthesized")
 	}
 


### PR DESCRIPTION
Resolves #229.

Since Eno only currently retains two syntheses, it isn't possible to (correctly) reconcile resources while synthesis is in-progress. So configuration might drift in cases where synthesis is slow.

It isn't a huge problem currently since synthesis is fast, but keeping a third synthesis ends up significantly simplifying the synthesis controller, which I'm working on property-based tests and refactoring for currently.

This change adds an "in flight" synthesis that is swapped into the existing "current" slot when synthesis is complete. I tried not to touch unrelated code - the diff mostly just swaps synthesis references, with a few exceptions (I'll leave PR comments to clarify).

## Backcompat

- Compositions with `CurrentSynthesis.Synthesized != nil` are unaffected - this is still the terminal state
- Compositions with `CurrentSynthesis == nil` are unaffected since the new code will be used for synthesis
- Compositions with `CurrentSynthesis != nil && CurrentSynthesis.Synthesized == nil` (a.k.a. in-flight synthesis) will converge eventually because the scheduling controller considers `(CurrentSynthesis.Synthesized == nil) == (CurrentSynthesis == nil)` 