### PR TITLE
Re-enter the scheduling controller on synthesis timeout

### DIFF
--- a/api/v1/composition.go
+++ b/api/v1/composition.go
@@ -94,6 +94,10 @@ type Synthesis struct {
 	// Time at which the synthesis's reconciled resources became ready.
 	Ready *metav1.Time `json:"ready,omitempty"`
 
+	// Canceled signals that any running synthesis pods should be deleted,
+	// and new synthesis pods should never be created for this synthesis UUID.
+	Canceled *metav1.Time `json:"canceled,omitempty"`
+
 	// Counter used internally to calculate back off when retrying failed syntheses.
 	Attempts int `json:"attempts,omitempty"`
 
@@ -225,7 +229,7 @@ func (c *Composition) ShouldIgnoreSideEffects() bool {
 }
 
 func (c *Composition) Synthesizing() bool {
-	return c.Status.InFlightSynthesis != nil
+	return c.Status.InFlightSynthesis != nil && c.Status.InFlightSynthesis.Canceled == nil
 }
 
 func (c *Composition) EnableIgnoreSideEffects() {

--- a/api/v1/config/crd/eno.azure.io_compositions.yaml
+++ b/api/v1/config/crd/eno.azure.io_compositions.yaml
@@ -125,6 +125,12 @@ spec:
                     description: Counter used internally to calculate back off when
                       retrying failed syntheses.
                     type: integer
+                  canceled:
+                    description: |-
+                      Canceled signals that any running synthesis pods should be deleted,
+                      and new synthesis pods should never be created for this synthesis UUID.
+                    format: date-time
+                    type: string
                   deferred:
                     description: |-
                       Deferred is true when this synthesis was caused by a change to either the synthesizer
@@ -223,6 +229,12 @@ spec:
                     description: Counter used internally to calculate back off when
                       retrying failed syntheses.
                     type: integer
+                  canceled:
+                    description: |-
+                      Canceled signals that any running synthesis pods should be deleted,
+                      and new synthesis pods should never be created for this synthesis UUID.
+                    format: date-time
+                    type: string
                   deferred:
                     description: |-
                       Deferred is true when this synthesis was caused by a change to either the synthesizer
@@ -338,6 +350,12 @@ spec:
                     description: Counter used internally to calculate back off when
                       retrying failed syntheses.
                     type: integer
+                  canceled:
+                    description: |-
+                      Canceled signals that any running synthesis pods should be deleted,
+                      and new synthesis pods should never be created for this synthesis UUID.
+                    format: date-time
+                    type: string
                   deferred:
                     description: |-
                       Deferred is true when this synthesis was caused by a change to either the synthesizer

--- a/api/v1/zz_generated.deepcopy.go
+++ b/api/v1/zz_generated.deepcopy.go
@@ -643,6 +643,10 @@ func (in *Synthesis) DeepCopyInto(out *Synthesis) {
 		in, out := &in.Ready, &out.Ready
 		*out = (*in).DeepCopy()
 	}
+	if in.Canceled != nil {
+		in, out := &in.Canceled, &out.Canceled
+		*out = (*in).DeepCopy()
+	}
 	if in.ResourceSlices != nil {
 		in, out := &in.ResourceSlices, &out.ResourceSlices
 		*out = make([]*ResourceSliceRef, len(*in))

--- a/cmd/eno-controller/main.go
+++ b/cmd/eno-controller/main.go
@@ -19,6 +19,7 @@ import (
 
 	v1 "github.com/Azure/eno/api/v1"
 	"github.com/Azure/eno/internal/controllers/aggregation"
+	"github.com/Azure/eno/internal/controllers/composition"
 	"github.com/Azure/eno/internal/controllers/replication"
 	"github.com/Azure/eno/internal/controllers/resourceslice"
 	"github.com/Azure/eno/internal/controllers/scheduling"
@@ -145,6 +146,11 @@ func runController() error {
 	err = scheduling.NewController(mgr, concurrencyLimit, rolloutCooldown, watchdogThres)
 	if err != nil {
 		return fmt.Errorf("constructing synthesis scheduling controller: %w", err)
+	}
+
+	err = composition.NewController(mgr)
+	if err != nil {
+		return fmt.Errorf("constructing composition controller: %w", err)
 	}
 
 	return mgr.Start(ctx)

--- a/docs/api.md
+++ b/docs/api.md
@@ -342,6 +342,7 @@ _Appears in:_
 | `synthesized` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#time-v1-meta)_ | Time at which the synthesis completed i.e. resourceSlices was written |  |  |
 | `reconciled` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#time-v1-meta)_ | Time at which the synthesis's resources were reconciled into real Kubernetes resources. |  |  |
 | `ready` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#time-v1-meta)_ | Time at which the synthesis's reconciled resources became ready. |  |  |
+| `canceled` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#time-v1-meta)_ | Canceled signals that any running synthesis pods should be deleted,<br />and new synthesis pods should never be created for this synthesis UUID. |  |  |
 | `attempts` _integer_ | Counter used internally to calculate back off when retrying failed syntheses. |  |  |
 | `results` _[Result](#result) array_ | Results are passed through opaquely from the synthesizer's KRM function. |  |  |
 | `inputRevisions` _[InputRevisions](#inputrevisions) array_ | InputRevisions contains the versions of the input resources that were used for this synthesis. |  |  |

--- a/internal/controllers/aggregation/composition.go
+++ b/internal/controllers/aggregation/composition.go
@@ -72,6 +72,8 @@ func (c *compositionController) aggregate(synth *apiv1.Synthesizer, comp *apiv1.
 		return copy
 	}
 
+	// TODO: New status for synthesis retry backoff
+
 	copy.Status = "Synthesizing"
 	if !comp.InputsExist(synth) {
 		copy.Status = "MissingInputs"

--- a/internal/controllers/composition/controller.go
+++ b/internal/controllers/composition/controller.go
@@ -1,0 +1,123 @@
+package composition
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/google/uuid"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	apiv1 "github.com/Azure/eno/api/v1"
+	"github.com/Azure/eno/internal/manager"
+)
+
+type compositionController struct {
+	client client.Client
+}
+
+func NewController(mgr ctrl.Manager) error {
+	c := &compositionController{
+		client: mgr.GetClient(),
+	}
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&apiv1.Composition{}).
+		WithLogConstructor(manager.NewLogConstructor(mgr, "compositionController")).
+		Complete(c)
+}
+
+func (c *compositionController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	logger := logr.FromContextOrDiscard(ctx)
+	comp := &apiv1.Composition{}
+	err := c.client.Get(ctx, req.NamespacedName, comp)
+	if err != nil {
+		return ctrl.Result{}, client.IgnoreNotFound(fmt.Errorf("getting composition resource: %w", err))
+	}
+
+	logger = logger.WithValues("compositionName", comp.Name, "compositionNamespace", comp.Namespace, "compositionGeneration", comp.Generation, "synthesisID", comp.Status.GetCurrentSynthesisUUID())
+
+	if comp.DeletionTimestamp != nil {
+		return c.reconcileDeletedComposition(ctx, comp)
+	}
+
+	if controllerutil.AddFinalizer(comp, "eno.azure.io/cleanup") {
+		err = c.client.Update(ctx, comp)
+		if err != nil {
+			return ctrl.Result{}, fmt.Errorf("updating composition: %w", err)
+		}
+		logger.V(1).Info("added cleanup finalizer to composition")
+		return ctrl.Result{}, nil
+	}
+
+	synth := &apiv1.Synthesizer{}
+	synth.Name = comp.Spec.Synthesizer.Name
+	err = c.client.Get(ctx, client.ObjectKeyFromObject(synth), synth)
+	if err != nil {
+		return ctrl.Result{}, client.IgnoreNotFound(fmt.Errorf("getting synthesizer: %w", err))
+	}
+	if synth != nil {
+		logger = logger.WithValues("synthesizerName", synth.Name, "synthesizerGeneration", synth.Generation)
+	}
+
+	// Enforce the synthesis timeout period
+	if syn := comp.Status.InFlightSynthesis; syn != nil && syn.Initialized != nil && synth.Spec.PodTimeout != nil {
+		delta := time.Until(syn.Initialized.Time.Add(synth.Spec.PodTimeout.Duration))
+		if delta > 0 {
+			return ctrl.Result{RequeueAfter: delta}, nil
+		}
+		syn.Canceled = ptr.To(metav1.Now())
+		if err := c.client.Status().Update(ctx, comp); err != nil {
+			return ctrl.Result{}, fmt.Errorf("updating compostion to reflect synthesis timeout: %w", err)
+		}
+		logger.V(0).Info("synthesis timed out")
+		return ctrl.Result{}, nil
+	}
+
+	return ctrl.Result{}, nil
+}
+
+func (c *compositionController) reconcileDeletedComposition(ctx context.Context, comp *apiv1.Composition) (ctrl.Result, error) {
+	logger := logr.FromContextOrDiscard(ctx)
+	syn := comp.Status.CurrentSynthesis
+
+	if syn != nil {
+		// Deletion increments the composition's generation, but the reconstitution cache is only invalidated
+		// when the synthesized generation (from the status) changes, which will never happen because synthesis
+		// is righly disabled for deleted compositions. We break out of this deadlock condition by updating
+		// the status without actually synthesizing.
+		if syn.ObservedCompositionGeneration != comp.Generation {
+			comp.Status.CurrentSynthesis.ObservedCompositionGeneration = comp.Generation
+			comp.Status.CurrentSynthesis.UUID = uuid.NewString()
+			comp.Status.CurrentSynthesis.Synthesized = ptr.To(metav1.Now())
+			comp.Status.CurrentSynthesis.Reconciled = nil
+			comp.Status.CurrentSynthesis.Ready = nil
+			err := c.client.Status().Update(ctx, comp)
+			if err != nil {
+				return ctrl.Result{}, fmt.Errorf("updating current composition generation: %w", err)
+			}
+			logger.V(0).Info("updated composition status to reflect deletion", "synthesisID", comp.Status.CurrentSynthesis.UUID)
+			return ctrl.Result{}, nil
+		}
+
+		if syn.Reconciled == nil {
+			logger.V(1).Info("refusing to remove composition finalizer because it is still being reconciled")
+			return ctrl.Result{}, nil
+		}
+	}
+
+	if controllerutil.RemoveFinalizer(comp, "eno.azure.io/cleanup") {
+		err := c.client.Update(ctx, comp)
+		if err != nil {
+			return ctrl.Result{}, fmt.Errorf("removing finalizer: %w", err)
+		}
+
+		logger.V(0).Info("removed finalizer from composition")
+	}
+
+	return ctrl.Result{}, nil
+}

--- a/internal/controllers/composition/controller_test.go
+++ b/internal/controllers/composition/controller_test.go
@@ -1,0 +1,141 @@
+package composition
+
+import (
+	"testing"
+	"time"
+
+	apiv1 "github.com/Azure/eno/api/v1"
+	"github.com/Azure/eno/internal/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+func TestFinalizerBasics(t *testing.T) {
+	comp := &apiv1.Composition{}
+	comp.Name = "test-comp"
+	comp.Namespace = "default"
+	req := reconcile.Request{NamespacedName: client.ObjectKeyFromObject(comp)}
+
+	ctx := testutil.NewContext(t)
+	cli := testutil.NewClient(t, comp)
+	c := &compositionController{client: cli}
+
+	// Add finalizer
+	_, err := c.Reconcile(ctx, req)
+	require.NoError(t, err)
+
+	_, err = c.Reconcile(ctx, req)
+	require.NoError(t, err)
+
+	require.NoError(t, cli.Get(ctx, client.ObjectKeyFromObject(comp), comp))
+	assert.Len(t, comp.Finalizers, 1)
+
+	// Remove finalizer
+	require.NoError(t, cli.Delete(ctx, comp))
+
+	_, err = c.Reconcile(ctx, req)
+	require.NoError(t, err)
+
+	_, err = c.Reconcile(ctx, req)
+	require.NoError(t, err)
+
+	require.True(t, errors.IsNotFound(cli.Get(ctx, client.ObjectKeyFromObject(comp), comp)))
+}
+
+func TestFinalizerStillReconciling(t *testing.T) {
+	comp := &apiv1.Composition{}
+	comp.Name = "test-comp"
+	comp.Namespace = "default"
+	comp.Finalizers = []string{"eno.azure.io/cleanup"}
+	comp.Status.CurrentSynthesis = &apiv1.Synthesis{Reconciled: nil}
+	req := reconcile.Request{NamespacedName: client.ObjectKeyFromObject(comp)}
+
+	ctx := testutil.NewContext(t)
+	cli := testutil.NewClient(t, comp)
+	c := &compositionController{client: cli}
+
+	require.NoError(t, cli.Delete(ctx, comp))
+
+	_, err := c.Reconcile(ctx, req)
+	require.NoError(t, err)
+
+	require.NoError(t, cli.Get(ctx, client.ObjectKeyFromObject(comp), comp))
+	assert.Len(t, comp.Finalizers, 1)
+}
+
+func TestFinalizerSynthesisOutdated(t *testing.T) {
+	comp := &apiv1.Composition{}
+	comp.Name = "test-comp"
+	comp.Namespace = "default"
+	comp.Finalizers = []string{"eno.azure.io/cleanup"}
+	comp.Status.CurrentSynthesis = &apiv1.Synthesis{ObservedCompositionGeneration: -1}
+	req := reconcile.Request{NamespacedName: client.ObjectKeyFromObject(comp)}
+
+	ctx := testutil.NewContext(t)
+	cli := testutil.NewClient(t, comp)
+	c := &compositionController{client: cli}
+
+	require.NoError(t, cli.Delete(ctx, comp))
+
+	_, err := c.Reconcile(ctx, req)
+	require.NoError(t, err)
+
+	require.NoError(t, cli.Get(ctx, client.ObjectKeyFromObject(comp), comp))
+	assert.Len(t, comp.Finalizers, 1)
+	assert.NotEmpty(t, comp.Status.CurrentSynthesis.UUID)
+}
+
+func TestTimeoutDeferral(t *testing.T) {
+	synth := &apiv1.Synthesizer{}
+	synth.Name = "test"
+	synth.Spec.PodTimeout = &metav1.Duration{Duration: time.Hour}
+
+	comp := &apiv1.Composition{}
+	comp.Name = "test-comp"
+	comp.Namespace = "default"
+	comp.Finalizers = []string{"eno.azure.io/cleanup"}
+	comp.Spec.Synthesizer.Name = synth.Name
+	comp.Status.InFlightSynthesis = &apiv1.Synthesis{Initialized: ptr.To(metav1.NewTime(time.Now().Add(-time.Minute)))}
+	req := reconcile.Request{NamespacedName: client.ObjectKeyFromObject(comp)}
+
+	ctx := testutil.NewContext(t)
+	cli := testutil.NewClient(t, comp, synth)
+	c := &compositionController{client: cli}
+
+	res, err := c.Reconcile(ctx, req)
+	require.NoError(t, err)
+	assert.NotZero(t, res.RequeueAfter)
+
+	require.NoError(t, cli.Get(ctx, client.ObjectKeyFromObject(comp), comp))
+	assert.Nil(t, comp.Status.InFlightSynthesis.Canceled)
+}
+
+func TestTimeoutCancelation(t *testing.T) {
+	synth := &apiv1.Synthesizer{}
+	synth.Name = "test"
+	synth.Spec.PodTimeout = &metav1.Duration{Duration: time.Minute}
+
+	comp := &apiv1.Composition{}
+	comp.Name = "test-comp"
+	comp.Namespace = "default"
+	comp.Finalizers = []string{"eno.azure.io/cleanup"}
+	comp.Spec.Synthesizer.Name = synth.Name
+	comp.Status.InFlightSynthesis = &apiv1.Synthesis{Initialized: ptr.To(metav1.NewTime(time.Now().Add(-time.Hour)))}
+	req := reconcile.Request{NamespacedName: client.ObjectKeyFromObject(comp)}
+
+	ctx := testutil.NewContext(t)
+	cli := testutil.NewClient(t, comp, synth)
+	c := &compositionController{client: cli}
+
+	res, err := c.Reconcile(ctx, req)
+	require.NoError(t, err)
+	assert.Zero(t, res.RequeueAfter)
+
+	require.NoError(t, cli.Get(ctx, client.ObjectKeyFromObject(comp), comp))
+	assert.NotNil(t, comp.Status.InFlightSynthesis.Canceled)
+}

--- a/internal/controllers/reconciliation/helpers_test.go
+++ b/internal/controllers/reconciliation/helpers_test.go
@@ -7,6 +7,7 @@ import (
 
 	apiv1 "github.com/Azure/eno/api/v1"
 	"github.com/Azure/eno/internal/controllers/aggregation"
+	"github.com/Azure/eno/internal/controllers/composition"
 	"github.com/Azure/eno/internal/controllers/liveness"
 	"github.com/Azure/eno/internal/controllers/replication"
 	"github.com/Azure/eno/internal/controllers/resourceslice"
@@ -34,6 +35,7 @@ func registerControllers(t *testing.T, mgr *testutil.Manager) {
 	require.NoError(t, watch.NewController(mgr.Manager))
 	require.NoError(t, resourceslice.NewController(mgr.Manager))
 	require.NoError(t, resourceslice.NewCleanupController(mgr.Manager))
+	require.NoError(t, composition.NewController(mgr.Manager))
 }
 
 func writeGenericComposition(t *testing.T, client client.Client) (*apiv1.Synthesizer, *apiv1.Composition) {

--- a/internal/controllers/scheduling/controller.go
+++ b/internal/controllers/scheduling/controller.go
@@ -119,7 +119,7 @@ func (c *controller) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 			continue
 		}
 
-		next := newOp(&synth, &comp)
+		next := newOp(&synth, &comp, nextSlot)
 		if next != nil && (op == nil || next.Less(op)) {
 			op = next
 		}
@@ -129,8 +129,10 @@ func (c *controller) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	if op == nil || inFlight >= c.concurrencyLimit {
 		return ctrl.Result{}, nil
 	}
-	if wait := time.Until(nextSlot); op.Reason.Deferred() && wait > 0 {
-		return ctrl.Result{RequeueAfter: wait}, nil
+	if !op.NotBefore.IsZero() {
+		if wait := time.Until(op.NotBefore); wait > 0 {
+			return ctrl.Result{RequeueAfter: wait}, nil
+		}
 	}
 	logger = logger.WithValues("compositionName", op.Composition.Name, "compositionNamespace", op.Composition.Namespace, "reason", op.Reason, "synthEpoch", synthEpoch)
 

--- a/internal/controllers/scheduling/controller.go
+++ b/internal/controllers/scheduling/controller.go
@@ -129,7 +129,7 @@ func (c *controller) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	if op == nil || inFlight >= c.concurrencyLimit {
 		return ctrl.Result{}, nil
 	}
-	if !op.NotBefore.IsZero() {
+	if !op.NotBefore.IsZero() { // the next op isn't ready to be dispathced yet
 		if wait := time.Until(op.NotBefore); wait > 0 {
 			return ctrl.Result{RequeueAfter: wait}, nil
 		}

--- a/internal/controllers/synthesis/integration_test.go
+++ b/internal/controllers/synthesis/integration_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -54,6 +53,7 @@ func TestControllerHappyPath(t *testing.T) {
 	comp := &apiv1.Composition{}
 	comp.Name = "test-comp"
 	comp.Namespace = "default"
+	comp.Finalizers = []string{"eno.azure.io/cleanup"}
 	comp.Spec.Synthesizer.Name = syn.Name
 	require.NoError(t, cli.Create(ctx, comp))
 
@@ -133,6 +133,7 @@ func TestControllerFastCompositionUpdates(t *testing.T) {
 	comp := &apiv1.Composition{}
 	comp.Name = "test-comp"
 	comp.Namespace = "default"
+	comp.Finalizers = []string{"eno.azure.io/cleanup"}
 	comp.Spec.Synthesizer.Name = syn.Name
 	require.NoError(t, cli.Create(ctx, comp))
 
@@ -211,6 +212,7 @@ func TestControllerSwitchingSynthesizers(t *testing.T) {
 	comp := &apiv1.Composition{}
 	comp.Name = "test-comp"
 	comp.Namespace = "default"
+	comp.Finalizers = []string{"eno.azure.io/cleanup"}
 	comp.Spec.Synthesizer.Name = syn1.Name
 	require.NoError(t, cli.Create(ctx, comp))
 
@@ -240,40 +242,5 @@ func TestControllerSwitchingSynthesizers(t *testing.T) {
 			return comp.Status.CurrentSynthesis != nil && comp.Status.CurrentSynthesis.ObservedCompositionGeneration > initialGen
 		})
 		assert.NotEqual(t, comp.Status.CurrentSynthesis.ResourceSlices, initialSlices)
-	})
-}
-
-func TestControllerBackoff(t *testing.T) {
-	ctx := testutil.NewContext(t)
-	mgr := testutil.NewManager(t)
-	cli := mgr.GetClient()
-
-	require.NoError(t, NewPodLifecycleController(mgr.Manager, minimalTestConfig))
-	require.NoError(t, scheduling.NewController(mgr.Manager, 10, 2*time.Second, time.Second))
-	require.NoError(t, NewPodGC(mgr.Manager, 0))
-	mgr.Start(t)
-
-	syn := &apiv1.Synthesizer{}
-	syn.Name = "test-syn-1"
-	syn.Spec.Image = "initial-image"
-	syn.Spec.PodTimeout = &metav1.Duration{Duration: time.Millisecond * 2}
-	syn.Spec.ExecTimeout = &metav1.Duration{Duration: time.Millisecond}
-	require.NoError(t, cli.Create(ctx, syn))
-
-	start := time.Now()
-	comp := &apiv1.Composition{}
-	comp.Name = "test-comp"
-	comp.Namespace = "default"
-	comp.Spec.Synthesizer.Name = syn.Name
-	require.NoError(t, cli.Create(ctx, comp))
-
-	t.Run("initial creation", func(t *testing.T) {
-		testutil.Eventually(t, func() bool {
-			require.NoError(t, client.IgnoreNotFound(cli.Get(ctx, client.ObjectKeyFromObject(comp), comp)))
-			return comp.Status.InFlightSynthesis != nil && comp.Status.InFlightSynthesis.Attempts >= 10
-		})
-
-		// It shouldn't be possible to try this many times within 250ms
-		assert.Greater(t, int(time.Since(start).Milliseconds()), 250)
 	})
 }

--- a/internal/controllers/synthesis/lifecycle.go
+++ b/internal/controllers/synthesis/lifecycle.go
@@ -2,17 +2,12 @@ package synthesis
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
-	"time"
 
 	"github.com/go-logr/logr"
-	"github.com/google/uuid"
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/workqueue"
-	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -83,28 +78,14 @@ func (c *podLifecycleController) Reconcile(ctx context.Context, req ctrl.Request
 	if err != nil {
 		return ctrl.Result{}, client.IgnoreNotFound(fmt.Errorf("getting composition resource: %w", err))
 	}
-
-	logger = logger.WithValues("compositionName", comp.Name, "compositionNamespace", comp.Namespace, "compositionGeneration", comp.Generation)
-
-	if comp.DeletionTimestamp != nil {
-		return c.reconcileDeletedComposition(ctx, comp)
-	}
-
-	// It isn't safe to delete compositions until their resource slices have been cleaned up,
-	// since reconciling resources necessarily requires the composition.
-	if controllerutil.AddFinalizer(comp, "eno.azure.io/cleanup") {
-		err = c.client.Update(ctx, comp)
-		if err != nil {
-			return ctrl.Result{}, fmt.Errorf("updating composition: %w", err)
-		}
-		logger.V(1).Info("added cleanup finalizer to composition")
+	if comp.DeletionTimestamp != nil ||
+		!controllerutil.ContainsFinalizer(comp, "eno.azure.io/cleanup") ||
+		comp.Status.InFlightSynthesis == nil ||
+		comp.Status.InFlightSynthesis.Canceled != nil {
 		return ctrl.Result{}, nil
 	}
 
-	if comp.Status.InFlightSynthesis == nil || comp.Status.InFlightSynthesis.Synthesized != nil {
-		return ctrl.Result{}, nil
-	}
-	logger = logger.WithValues("synthesisID", comp.Status.InFlightSynthesis.UUID)
+	logger = logger.WithValues("compositionName", comp.Name, "compositionNamespace", comp.Namespace, "compositionGeneration", comp.Generation, "synthesisID", comp.Status.InFlightSynthesis.UUID)
 
 	syn := &apiv1.Synthesizer{}
 	syn.Name = comp.Spec.Synthesizer.Name
@@ -114,17 +95,6 @@ func (c *podLifecycleController) Reconcile(ctx context.Context, req ctrl.Request
 	}
 	if syn != nil {
 		logger = logger.WithValues("synthesizerName", syn.Name, "synthesizerGeneration", syn.Generation)
-	}
-
-	// Back off to avoid constantly re-synthesizing impossible compositions (unlikely but possible)
-	if shouldBackOffPodCreation(comp) {
-		const base = time.Millisecond * 250
-		wait := base * time.Duration(comp.Status.InFlightSynthesis.Attempts)
-		nextAttempt := comp.Status.InFlightSynthesis.PodCreation.Time.Add(wait)
-		if time.Since(nextAttempt) < 0 { // positive when past the nextAttempt
-			logger.V(1).Info("backing off pod creation", "latency", wait.Abs().Milliseconds())
-			return ctrl.Result{RequeueAfter: wait}, nil
-		}
 	}
 
 	// Confirm that a pod doesn't already exist for this synthesis without trusting informers.
@@ -153,72 +123,5 @@ func (c *podLifecycleController) Reconcile(ctx context.Context, req ctrl.Request
 	logger.V(0).Info("created synthesizer pod", "podName", pod.Name)
 	sytheses.Inc()
 
-	// This metadata is optional - it's safe for the process to crash before reaching this point
-	patch := []map[string]any{
-		{"op": "test", "path": "/status/inFlightSynthesis/uuid", "value": comp.Status.InFlightSynthesis.UUID},
-		{"op": "test", "path": "/status/inFlightSynthesis/synthesized", "value": nil},
-		{"op": "replace", "path": "/status/inFlightSynthesis/attempts", "value": comp.Status.InFlightSynthesis.Attempts + 1},
-		{"op": "replace", "path": "/status/inFlightSynthesis/podCreation", "value": pod.CreationTimestamp},
-	}
-	patchJS, err := json.Marshal(&patch)
-	if err != nil {
-		return ctrl.Result{}, fmt.Errorf("encoding patch: %w", err)
-	}
-
-	if err := c.client.Status().Patch(ctx, comp, client.RawPatch(types.JSONPatchType, patchJS)); err != nil {
-		return ctrl.Result{}, fmt.Errorf("updating composition status after synthesizer pod creation: %w", err)
-	}
-
 	return ctrl.Result{}, nil
-}
-
-func (c *podLifecycleController) reconcileDeletedComposition(ctx context.Context, comp *apiv1.Composition) (ctrl.Result, error) {
-	logger := logr.FromContextOrDiscard(ctx)
-
-	// Deletion increments the composition's generation, but the reconstitution cache is only invalidated
-	// when the synthesized generation (from the status) changes, which will never happen because synthesis
-	// is righly disabled for deleted compositions. We break out of this deadlock condition by updating
-	// the status without actually synthesizing.
-	if shouldUpdateDeletedCompositionStatus(comp) {
-		comp.Status.CurrentSynthesis.ObservedCompositionGeneration = comp.Generation
-		comp.Status.CurrentSynthesis.UUID = uuid.NewString()
-		comp.Status.CurrentSynthesis.Synthesized = ptr.To(metav1.Now())
-		comp.Status.CurrentSynthesis.Reconciled = nil
-		comp.Status.CurrentSynthesis.Ready = nil
-		err := c.client.Status().Update(ctx, comp)
-		if err != nil {
-			return ctrl.Result{}, fmt.Errorf("updating current composition generation: %w", err)
-		}
-		logger.V(0).Info("updated composition status to reflect deletion", "synthesisID", comp.Status.CurrentSynthesis.UUID)
-		return ctrl.Result{}, nil
-	}
-
-	// Remove the finalizer when all pods and slices have been deleted
-	if isReconciling(comp) {
-		logger.V(1).Info("refusing to remove composition finalizer because it is still being reconciled")
-		return ctrl.Result{}, nil
-	}
-	if controllerutil.RemoveFinalizer(comp, "eno.azure.io/cleanup") {
-		err := c.client.Update(ctx, comp)
-		if err != nil {
-			return ctrl.Result{}, fmt.Errorf("removing finalizer: %w", err)
-		}
-
-		logger.V(0).Info("removed finalizer from composition")
-	}
-
-	return ctrl.Result{}, nil
-}
-
-func shouldBackOffPodCreation(comp *apiv1.Composition) bool {
-	current := comp.Status.InFlightSynthesis
-	return current != nil && current.Attempts > 0 && current.PodCreation != nil
-}
-
-func shouldUpdateDeletedCompositionStatus(comp *apiv1.Composition) bool {
-	return comp.Status.CurrentSynthesis != nil && comp.Status.CurrentSynthesis.ObservedCompositionGeneration != comp.Generation
-}
-
-func isReconciling(comp *apiv1.Composition) bool {
-	return comp.Status.CurrentSynthesis != nil && comp.Status.CurrentSynthesis.Reconciled == nil
 }

--- a/internal/controllers/synthesis/lifecycle_test.go
+++ b/internal/controllers/synthesis/lifecycle_test.go
@@ -16,6 +16,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	apiv1 "github.com/Azure/eno/api/v1"
+	"github.com/Azure/eno/internal/controllers/composition"
 	"github.com/Azure/eno/internal/controllers/resourceslice"
 	"github.com/Azure/eno/internal/controllers/scheduling"
 	"github.com/Azure/eno/internal/testutil"
@@ -47,6 +48,7 @@ func TestCompositionDeletion(t *testing.T) {
 	require.NoError(t, NewPodLifecycleController(mgr.Manager, minimalTestConfig))
 	require.NoError(t, resourceslice.NewCleanupController(mgr.Manager))
 	require.NoError(t, scheduling.NewController(mgr.Manager, 10, 2*time.Second, time.Second))
+	require.NoError(t, composition.NewController(mgr.Manager))
 	require.NoError(t, NewPodGC(mgr.Manager, 0))
 	mgr.Start(t)
 

--- a/internal/controllers/synthesis/pod.go
+++ b/internal/controllers/synthesis/pod.go
@@ -191,10 +191,6 @@ func newPod(cfg *Config, comp *apiv1.Composition, syn *apiv1.Synthesizer) *corev
 	return pod
 }
 
-func podIsCurrent(comp *apiv1.Composition, pod *corev1.Pod) bool {
-	return pod.Labels != nil && comp.Status.InFlightSynthesis != nil && comp.Status.InFlightSynthesis.UUID == pod.Labels[synthesisIDLabelKey]
-}
-
 // filterEnv returns env taking out any items that have the same name as
 // any item in filter.
 func filterEnv(filter []corev1.EnvVar, env []apiv1.EnvVar) []apiv1.EnvVar {


### PR DESCRIPTION
Currently synthesis pods are recreated using exponential backoff until they succeed or fail. But the retries are handled by the synthesis lifecycle controller, which isn't aware of the priorities/limits imposed by the scheduling controller.

So impossible syntheses will count against the concurrency limit forever - potentially blocking other more important operations.

This change replaces the pod-level retries with synthesis-scoped retries, which essentially re-enter the scheduling controller at a lower priority.