### PR TITLE
Allow election retry period to be set

### DIFF
--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -99,6 +99,7 @@ func newMgr(logger logr.Logger, opts *Options, isController, isReconciler bool) 
 		LeaderElectionID:              opts.LeaderElectionID,
 		LeaseDuration:                 &opts.ElectionLeaseDuration,
 		RenewDeadline:                 &opts.ElectionLeaseRenewDeadline,
+		RetryPeriod:                   &opts.ElectionLeaseRetryPeriod,
 		LeaderElectionReleaseOnCancel: true,
 		Controller:                    config.Controller{SkipNameValidation: ptr.To(true)},
 	}

--- a/internal/manager/options.go
+++ b/internal/manager/options.go
@@ -15,6 +15,7 @@ type Options struct {
 	leaderelection.Options
 	ElectionLeaseDuration      time.Duration
 	ElectionLeaseRenewDeadline time.Duration
+	ElectionLeaseRetryPeriod   time.Duration
 
 	Rest                    *rest.Config
 	HealthProbeAddr         string
@@ -36,8 +37,9 @@ func (o *Options) Bind(set *flag.FlagSet) {
 	set.StringVar(&o.LeaderElectionNamespace, "leader-election-namespace", os.Getenv("POD_NAMESPACE"), "Determines the namespace in which the leader election resource will be created")
 	set.StringVar(&o.LeaderElectionResourceLock, "leader-election-resource-lock", "", "Determines which resource lock to use for leader election")
 	set.StringVar(&o.LeaderElectionID, "leader-election-id", "", "Determines the name of the resource that leader election will use for holding the leader lock")
-	set.DurationVar(&o.ElectionLeaseDuration, "leader-election-lease-duration", time.Second*90, "")
-	set.DurationVar(&o.ElectionLeaseRenewDeadline, "leader-election-lease-renew-deadline", time.Second*60, "")
+	set.DurationVar(&o.ElectionLeaseDuration, "leader-election-lease-duration", 35*time.Second, "How long before non-leaders will forcibly take leadership")
+	set.DurationVar(&o.ElectionLeaseRenewDeadline, "leader-election-lease-renew-deadline", 30*time.Second, "Max duration of all retries when leader is updating the election lease")
+	set.DurationVar(&o.ElectionLeaseRetryPeriod, "leader-election-lease-retry", 4*time.Second, "Interval at which the leader will update the election lease")
 }
 
 func newCacheOptions(ns string, selector labels.Selector) cache.ByObject {


### PR DESCRIPTION
The current election defaults are a bit lazy - waiting 90 seconds after the leader dies is not great. This PR adopts the values used by the various Flux controllers which have been proven to work well in most cases.

The retry period is exposed as a flag now, which is useful for reducing request volume from eno-reconciler processes in cases where many may be running concurrently.