### PR TITLE
Remove unused logic from executor

### DIFF
--- a/internal/controllers/synthesis/pod.go
+++ b/internal/controllers/synthesis/pod.go
@@ -2,7 +2,6 @@ package synthesis
 
 import (
 	"slices"
-	"strconv"
 
 	"github.com/imdario/mergo"
 	corev1 "k8s.io/api/core/v1"
@@ -50,10 +49,6 @@ func newPod(cfg *Config, comp *apiv1.Composition, syn *apiv1.Synthesizer) *corev
 		{
 			Name:  "SYNTHESIS_UUID",
 			Value: comp.Status.InFlightSynthesis.UUID,
-		},
-		{
-			Name:  "SYNTHESIS_ATTEMPT",
-			Value: strconv.Itoa(comp.Status.InFlightSynthesis.Attempts + 1), // we write the next attempt _after_ pod creation
 		},
 	}
 

--- a/internal/execution/executor.go
+++ b/internal/execution/executor.go
@@ -235,14 +235,8 @@ func skipSynthesis(comp *apiv1.Composition, env *Env) (string, bool) {
 	if synthesis == nil {
 		return "MissingSynthesis", true
 	}
-	if synthesis.Synthesized != nil {
-		return "AlreadySynthesized", true
-	}
 	if synthesis.UUID != env.SynthesisUUID {
 		return "UUIDMismatch", true
-	}
-	if synthesis.Attempts > 0 && synthesis.Attempts > env.SynthesisAttempt {
-		return "StaleAttempt", true
 	}
 	return "", false
 }

--- a/internal/execution/handler.go
+++ b/internal/execution/handler.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"os"
 	"os/exec"
-	"strconv"
 
 	apiv1 "github.com/Azure/eno/api/v1"
 	krmv1 "github.com/Azure/eno/pkg/krm/functions/api/v1"
@@ -16,16 +15,13 @@ type Env struct {
 	CompositionName      string
 	CompositionNamespace string
 	SynthesisUUID        string
-	SynthesisAttempt     int
 }
 
 func LoadEnv() *Env {
-	attempt, _ := strconv.Atoi(os.Getenv("SYNTHESIS_ATTEMPT"))
 	return &Env{
 		CompositionName:      os.Getenv("COMPOSITION_NAME"),
 		CompositionNamespace: os.Getenv("COMPOSITION_NAMESPACE"),
 		SynthesisUUID:        os.Getenv("SYNTHESIS_UUID"),
-		SynthesisAttempt:     attempt,
 	}
 }
 

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -358,9 +358,6 @@ func WithFakeExecutor(t *testing.T, mgr *Manager, sh execution.SynthesizerHandle
 				env.CompositionNamespace = e.Value
 			case "SYNTHESIS_UUID":
 				env.SynthesisUUID = e.Value
-			case "SYNTHESIS_ATTEMPT":
-				val, _ := strconv.Atoi(e.Value)
-				env.SynthesisAttempt = val
 			}
 		}
 


### PR DESCRIPTION
Now that we have the in-flight synthesis, the Attempts and Synthesized logic in the executor is no longer reachable.