### PR TITLE
Remove unused ReconcileInterval property

### DIFF
--- a/api/v1/config/crd/eno.azure.io_synthesizers.yaml
+++ b/api/v1/config/crd/eno.azure.io_synthesizers.yaml
@@ -1066,11 +1066,6 @@ spec:
                   Pods are recreated after they've existed for at least the pod timeout interval.
                   This helps close the loop in failure modes where a pod may be considered ready but not actually able to run.
                 type: string
-              reconcileInterval:
-                description: |-
-                  Synthesized resources can optionally be reconciled at a given interval.
-                  Per-resource jitter will be applied to avoid spikes in request rate.
-                type: string
               refs:
                 description: |-
                   Refs define the Synthesizer's input schema without binding it to specific

--- a/api/v1/synthesizer.go
+++ b/api/v1/synthesizer.go
@@ -50,10 +50,6 @@ type SynthesizerSpec struct {
 	// +kubebuilder:default="2m"
 	PodTimeout *metav1.Duration `json:"podTimeout,omitempty"`
 
-	// Synthesized resources can optionally be reconciled at a given interval.
-	// Per-resource jitter will be applied to avoid spikes in request rate.
-	ReconcileInterval *metav1.Duration `json:"reconcileInterval,omitempty"`
-
 	// Refs define the Synthesizer's input schema without binding it to specific
 	// resources.
 	Refs []Ref `json:"refs,omitempty"`

--- a/api/v1/zz_generated.deepcopy.go
+++ b/api/v1/zz_generated.deepcopy.go
@@ -772,11 +772,6 @@ func (in *SynthesizerSpec) DeepCopyInto(out *SynthesizerSpec) {
 		*out = new(metav1.Duration)
 		**out = **in
 	}
-	if in.ReconcileInterval != nil {
-		in, out := &in.ReconcileInterval, &out.ReconcileInterval
-		*out = new(metav1.Duration)
-		**out = **in
-	}
 	if in.Refs != nil {
 		in, out := &in.Refs, &out.Refs
 		*out = make([]Ref, len(*in))

--- a/docs/api.md
+++ b/docs/api.md
@@ -406,7 +406,6 @@ _Appears in:_
 | `command` _string array_ | Copied opaquely into the container's command property. | [synthesize] |  |
 | `execTimeout` _[Duration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#duration-v1-meta)_ | Timeout for each execution of the synthesizer command. | 10s |  |
 | `podTimeout` _[Duration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#duration-v1-meta)_ | Pods are recreated after they've existed for at least the pod timeout interval.<br />This helps close the loop in failure modes where a pod may be considered ready but not actually able to run. | 2m |  |
-| `reconcileInterval` _[Duration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#duration-v1-meta)_ | Synthesized resources can optionally be reconciled at a given interval.<br />Per-resource jitter will be applied to avoid spikes in request rate. |  |  |
 | `refs` _[Ref](#ref) array_ | Refs define the Synthesizer's input schema without binding it to specific<br />resources. |  |  |
 | `podOverrides` _[PodOverrides](#podoverrides)_ | PodOverrides sets values in the pods used to execute this synthesizer. |  |  |
 


### PR DESCRIPTION
This was never actually wired up and doing so would be tricky since the reconstitution code doesn't currently have a coherent view of both compositions and synthesizers.