### PR TITLE
fix: torelate io.EOF for input reader

### DIFF
--- a/pkg/function/inputs.go
+++ b/pkg/function/inputs.go
@@ -2,6 +2,7 @@ package function
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -23,7 +24,7 @@ func NewDefaultInputReader() (*InputReader, error) {
 func NewInputReader(r io.Reader) (*InputReader, error) {
 	rl := krmv1.ResourceList{}
 	err := json.NewDecoder(r).Decode(&rl)
-	if err != nil {
+	if err != nil && !errors.Is(err, io.EOF) {
 		return nil, fmt.Errorf("decoding stdin as krm resource list: %w", err)
 	}
 	return &InputReader{

--- a/pkg/function/inputs_test.go
+++ b/pkg/function/inputs_test.go
@@ -25,3 +25,12 @@ func TestInputReader(t *testing.T) {
 	err = ReadInput(r, "bar", cm)
 	require.EqualError(t, err, "input \"bar\" was not found")
 }
+
+func TestNewInputReader(t *testing.T) {
+	t.Run("treat empty input (EOF) as empty resource list", func(t *testing.T) {
+		input := bytes.NewBufferString("")
+		r, err := NewInputReader(input)
+		require.NoError(t, err)
+		assert.Equal(t, 0, len(r.resources.Items))
+	})
+}


### PR DESCRIPTION
During local debugging, I am using empty input to trigger the synther binary. In this case, allowing EOF input might be helpful instead of erroring out as failed to parse as krm resources list