### PR TITLE
feat: expose chart loader options to caller

### DIFF
--- a/pkg/helmshim/helm.go
+++ b/pkg/helmshim/helm.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/Azure/eno/pkg/function"
 	"helm.sh/helm/v3/pkg/action"
-	"helm.sh/helm/v3/pkg/chart/loader"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/util/yaml"
 )
@@ -43,9 +42,9 @@ func RenderChart(opts ...RenderOption) error {
 	a.IncludeCRDs = true
 
 	o := &options{
-		Action:     a,
-		ValuesFunc: inputsToValues,
-		ChartPath:  "./chart",
+		Action:      a,
+		ValuesFunc:  inputsToValues,
+		ChartLoader: defaultChartLoader,
 	}
 	for _, opt := range opts {
 		opt.apply(o)
@@ -65,7 +64,7 @@ func RenderChart(opts ...RenderOption) error {
 		o.Writer = function.NewDefaultOutputWriter()
 	}
 
-	c, err := loader.Load(o.ChartPath)
+	c, err := o.ChartLoader()
 	if err != nil {
 		return errors.Join(ErrChartNotFound, err)
 	}

--- a/pkg/helmshim/options.go
+++ b/pkg/helmshim/options.go
@@ -15,7 +15,7 @@ type ValuesFunc func(*function.InputReader) (map[string]any, error)
 type ChartLoader func() (*chart.Chart, error)
 
 func defaultChartLoader() (*chart.Chart, error) {
-	return loader.Load("./charts")
+	return loader.Load("./chart")
 }
 
 type options struct {

--- a/pkg/helmshim/options.go
+++ b/pkg/helmshim/options.go
@@ -5,16 +5,25 @@ import (
 
 	"github.com/Azure/eno/pkg/function"
 	"helm.sh/helm/v3/pkg/action"
+	"helm.sh/helm/v3/pkg/chart"
+	"helm.sh/helm/v3/pkg/chart/loader"
 )
 
 type ValuesFunc func(*function.InputReader) (map[string]any, error)
 
+// ChartLoader is the function for loading a helm chart.
+type ChartLoader func() (*chart.Chart, error)
+
+func defaultChartLoader() (*chart.Chart, error) {
+	return loader.Load("./charts")
+}
+
 type options struct {
-	Action     *action.Install
-	ValuesFunc ValuesFunc
-	ChartPath  string
-	Reader     *function.InputReader
-	Writer     *function.OutputWriter
+	Action      *action.Install
+	ValuesFunc  ValuesFunc
+	ChartLoader ChartLoader
+	Reader      *function.InputReader
+	Writer      *function.OutputWriter
 }
 
 type RenderOption func(*options)
@@ -46,7 +55,18 @@ func WithChartPath(path string) RenderOption {
 		if o == nil {
 			return
 		}
-		o.ChartPath = path
+		o.ChartLoader = func() (*chart.Chart, error) {
+			return loader.Load(path)
+		}
+	})
+}
+
+func WithChartLoader(cl ChartLoader) RenderOption {
+	return RenderOption(func(o *options) {
+		if o == nil {
+			return
+		}
+		o.ChartLoader = cl
 	})
 }
 


### PR DESCRIPTION
In our use case, we want to embed the helm chart into the binary via embedding.FS . In this case, we want to provide the loaded chart (based on helm's https://github.com/helm/helm/blob/fa9efb07d9d8debbb4306d72af76a383895aa8c4/pkg/chart/loader/load.go#L72 ) This pull request refactored the ChartPath option to ChartLoader for this support.