### PR TITLE
Handle missing slices for previous synthesis

### DIFF
--- a/internal/controllers/reconciliation/reconstitution.go
+++ b/internal/controllers/reconciliation/reconstitution.go
@@ -119,7 +119,7 @@ func (r *reconstitutionSource) populateCache(ctx context.Context, comp *apiv1.Co
 		slice.Namespace = comp.Namespace
 		err := r.client.Get(ctx, client.ObjectKeyFromObject(&slice), &slice)
 		if err != nil {
-			return false, fmt.Errorf("unable to get resource slice: %w", err)
+			return false, client.IgnoreNotFound(fmt.Errorf("unable to get resource slice (cached): %w", err))
 		}
 		slices[i] = slice
 	}
@@ -137,7 +137,7 @@ func (r *reconstitutionSource) populateCache(ctx context.Context, comp *apiv1.Co
 		slice.Namespace = comp.Namespace
 		err := r.nonCachedReader.Get(ctx, client.ObjectKeyFromObject(&slice), &slice)
 		if err != nil {
-			return false, fmt.Errorf("unable to get resource slice: %w", err)
+			return false, client.IgnoreNotFound(fmt.Errorf("unable to get resource slice (no cache): %w", err))
 		}
 		slices[i] = slice
 	}


### PR DESCRIPTION
Currently, reconciliation will eventually converge after deleting the resource slices out from under a composition - but only if the composition does not have a previous synthesis. (i.e. it was only synthesized once)

The fix is simple: bail out of the cache controller when a slice is missing. This is safe even if compositions/slices hit the informers out of order since the controller watches both types, so we'll always get another workqueue item eventually.