### PR TITLE
Support implicit bindings

### DIFF
--- a/api/v1/composition_test.go
+++ b/api/v1/composition_test.go
@@ -292,6 +292,21 @@ func TestCompositionInputsExist(t *testing.T) {
 	}
 }
 
+func TestCompositionInputsExistImplicitBinding(t *testing.T) {
+	comp := &Composition{}
+	synth := &Synthesizer{}
+	synth.Spec.Refs = []Ref{{Key: "key", Resource: ResourceRef{Name: "foo"}}}
+
+	t.Run("negative", func(t *testing.T) {
+		assert.False(t, comp.InputsExist(synth))
+	})
+
+	t.Run("positive", func(t *testing.T) {
+		comp.Status.InputRevisions = []InputRevisions{{Key: "key"}}
+		assert.True(t, comp.InputsExist(synth))
+	})
+}
+
 func TestInputsInLockstep(t *testing.T) {
 	revision1 := 1
 	revision2 := 2

--- a/api/v1/config/crd/eno.azure.io_synthesizers.yaml
+++ b/api/v1/config/crd/eno.azure.io_synthesizers.yaml
@@ -1096,6 +1096,13 @@ spec:
                           type: string
                         kind:
                           type: string
+                        name:
+                          description: |-
+                            If set, name and namespace form an "implicit binding", i.e. a ref that is bound to
+                            a specific resource without a corresponding binding on the composition resource.
+                          type: string
+                        namespace:
+                          type: string
                         version:
                           type: string
                       required:

--- a/api/v1/config/crd/eno.azure.io_synthesizers.yaml
+++ b/api/v1/config/crd/eno.azure.io_synthesizers.yaml
@@ -1100,6 +1100,7 @@ spec:
                           description: |-
                             If set, name and namespace form an "implicit binding", i.e. a ref that is bound to
                             a specific resource without a corresponding binding on the composition resource.
+                            The implied binding takes precedence over a corresponding binding from the composition.
                           type: string
                         namespace:
                           type: string

--- a/api/v1/inputs.go
+++ b/api/v1/inputs.go
@@ -69,4 +69,9 @@ type ResourceRef struct {
 	Group   string `json:"group,omitempty"`
 	Version string `json:"version,omitempty"`
 	Kind    string `json:"kind"`
+
+	// If set, name and namespace form an "implicit binding", i.e. a ref that is bound to
+	// a specific resource without a corresponding binding on the composition resource.
+	Name      string `json:"name,omitempty"`
+	Namespace string `json:"namespace,omitempty"`
 }

--- a/api/v1/inputs.go
+++ b/api/v1/inputs.go
@@ -72,6 +72,7 @@ type ResourceRef struct {
 
 	// If set, name and namespace form an "implicit binding", i.e. a ref that is bound to
 	// a specific resource without a corresponding binding on the composition resource.
+	// The implied binding takes precedence over a corresponding binding from the composition.
 	Name      string `json:"name,omitempty"`
 	Namespace string `json:"namespace,omitempty"`
 }

--- a/docs/api.md
+++ b/docs/api.md
@@ -218,6 +218,8 @@ _Appears in:_
 | `group` _string_ |  |  |  |
 | `version` _string_ |  |  |  |
 | `kind` _string_ |  |  |  |
+| `name` _string_ | If set, name and namespace form an "implicit binding", i.e. a ref that is bound to<br />a specific resource without a corresponding binding on the composition resource. |  |  |
+| `namespace` _string_ |  |  |  |
 
 
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -218,7 +218,7 @@ _Appears in:_
 | `group` _string_ |  |  |  |
 | `version` _string_ |  |  |  |
 | `kind` _string_ |  |  |  |
-| `name` _string_ | If set, name and namespace form an "implicit binding", i.e. a ref that is bound to<br />a specific resource without a corresponding binding on the composition resource. |  |  |
+| `name` _string_ | If set, name and namespace form an "implicit binding", i.e. a ref that is bound to<br />a specific resource without a corresponding binding on the composition resource.<br />The implied binding takes precedence over a corresponding binding from the composition. |  |  |
 | `namespace` _string_ |  |  |  |
 
 

--- a/docs/inputs.md
+++ b/docs/inputs.md
@@ -69,3 +69,24 @@ Synthesizers can opt-in to also honor the cooldown period for specific inputs by
 This is useful for inputs that are shared between many compositions, similar to synthesizers.
 
 > Note: if a synthesis honoring the cooldown fails, Eno will move onto the next period after one retry.
+
+
+## Implicit Bindings
+
+It's possible to avoid bindings in cases where a synthesizer's ref will only be bound to a single resource globally across all compositions.
+
+```yaml
+apiVersion: eno.azure.io/v1
+kind: Synthesizer
+spec:
+  refs:
+    - key: foo
+      resource:
+        group: ""
+        version: v1
+        kind: "ConfigMap"
+        name: my-configmap
+        namespace: default
+```
+
+Note that any other bindings to this ref will be ignored.

--- a/internal/controllers/watch/kind.go
+++ b/internal/controllers/watch/kind.go
@@ -128,9 +128,8 @@ func (k *KindWatchController) buildRequests(synth *apiv1.Synthesizer, comps ...a
 	keys := map[string]struct{}{}
 	reqs := []reconcile.Request{}
 	for _, ref := range synth.Spec.Refs {
-		keys[ref.Key] = struct{}{}
-
 		if ref.Resource.Name == "" {
+			keys[ref.Key] = struct{}{}
 			continue // ref does not have an "implicit" binding
 		}
 
@@ -149,11 +148,9 @@ func (k *KindWatchController) buildRequests(synth *apiv1.Synthesizer, comps ...a
 
 			nsn := types.NamespacedName{Namespace: binding.Resource.Namespace, Name: binding.Resource.Name}
 			req := reconcile.Request{NamespacedName: nsn}
-			idx := slices.Index(reqs, req)
-			if idx > 0 {
-				reqs[idx] = req // override the ref's name/namespace if set
+			if !slices.Contains(reqs, req) {
+				reqs = append(reqs, req)
 			}
-			reqs = append(reqs, req)
 		}
 	}
 

--- a/internal/controllers/watch/kind.go
+++ b/internal/controllers/watch/kind.go
@@ -6,6 +6,7 @@ import (
 	"math/rand"
 	"path"
 	"reflect"
+	"slices"
 	"time"
 
 	apiv1 "github.com/Azure/eno/api/v1"
@@ -125,11 +126,21 @@ func (k *KindWatchController) newResourceWatchController(parent *WatchController
 // buildRequests returns a reconcile request for every binding to this resource kind.
 func (k *KindWatchController) buildRequests(synth *apiv1.Synthesizer, comps ...apiv1.Composition) []reconcile.Request {
 	keys := map[string]struct{}{}
+	reqs := []reconcile.Request{}
 	for _, ref := range synth.Spec.Refs {
 		keys[ref.Key] = struct{}{}
+
+		if ref.Resource.Name == "" {
+			continue // ref does not have an "implicit" binding
+		}
+
+		nsn := types.NamespacedName{Namespace: ref.Resource.Namespace, Name: ref.Resource.Name}
+		req := reconcile.Request{NamespacedName: nsn}
+		if !slices.Contains(reqs, req) {
+			reqs = append(reqs, req)
+		}
 	}
 
-	reqs := []reconcile.Request{}
 	for _, comp := range comps {
 		for _, binding := range comp.Spec.Bindings {
 			if _, found := keys[binding.Key]; !found {
@@ -137,18 +148,15 @@ func (k *KindWatchController) buildRequests(synth *apiv1.Synthesizer, comps ...a
 			}
 
 			nsn := types.NamespacedName{Namespace: binding.Resource.Namespace, Name: binding.Resource.Name}
-			var exists bool
-			for _, req := range reqs {
-				if req.NamespacedName == nsn {
-					exists = true
-					break
-				}
+			req := reconcile.Request{NamespacedName: nsn}
+			idx := slices.Index(reqs, req)
+			if idx > 0 {
+				reqs[idx] = req // override the ref's name/namespace if set
 			}
-			if !exists {
-				reqs = append(reqs, reconcile.Request{NamespacedName: nsn})
-			}
+			reqs = append(reqs, req)
 		}
 	}
+
 	return reqs
 }
 
@@ -180,6 +188,24 @@ func (k *KindWatchController) Reconcile(ctx context.Context, req ctrl.Request) (
 	rand.Shuffle(len(list.Items), func(i, j int) { list.Items[i], list.Items[j] = list.Items[j], list.Items[i] })
 
 	for _, synth := range list.Items {
+		for _, ref := range synth.Spec.Refs {
+			if ref.Resource.Name != meta.GetName() || ref.Resource.Namespace != meta.GetNamespace() || ref.Resource.Group != k.gvk.Group || ref.Resource.Kind != k.gvk.Kind || ref.Resource.Version != k.gvk.Version {
+				continue
+			}
+
+			list := &apiv1.CompositionList{}
+			err = k.client.List(ctx, list, client.MatchingFields{
+				manager.IdxCompositionsBySynthesizer: synth.Name,
+			})
+			if err != nil {
+				return ctrl.Result{}, fmt.Errorf("listing compositions: %w", err)
+			}
+			modified, err := k.updateCompositions(ctx, logger, &synth, meta, list)
+			if modified || err != nil {
+				return ctrl.Result{}, err
+			}
+		}
+
 		list := &apiv1.CompositionList{}
 		err = k.client.List(ctx, list, client.MatchingFields{
 			manager.IdxCompositionsByBinding: path.Join(synth.Name, meta.Namespace, meta.Name),
@@ -187,30 +213,38 @@ func (k *KindWatchController) Reconcile(ctx context.Context, req ctrl.Request) (
 		if err != nil {
 			return ctrl.Result{}, fmt.Errorf("listing compositions: %w", err)
 		}
-
-		for _, comp := range list.Items {
-			key := findRefKey(&comp, &synth, meta)
-			if key == "" {
-				logger.V(1).Info("no matching input key found for resource")
-				continue
-			}
-
-			revs := resource.NewInputRevisions(meta, key)
-			if !setInputRevisions(&comp, revs) {
-				continue
-			}
-
-			// TODO: Reduce risk of conflict errors here
-			err = k.client.Status().Update(ctx, &comp)
-			if err != nil {
-				return ctrl.Result{}, fmt.Errorf("updating input revisions: %w", err)
-			}
-			logger.V(0).Info("noticed input resource change", "compositionName", comp.Name, "compositionNamespace", comp.Namespace, "ref", key)
-			return ctrl.Result{}, nil // wait for requeue
+		modified, err := k.updateCompositions(ctx, logger, &synth, meta, list)
+		if modified || err != nil {
+			return ctrl.Result{}, err
 		}
 	}
 
 	return ctrl.Result{}, nil
+}
+
+func (k *KindWatchController) updateCompositions(ctx context.Context, logger logr.Logger, synth *apiv1.Synthesizer, meta *metav1.PartialObjectMetadata, list *apiv1.CompositionList) (bool, error) {
+	for _, comp := range list.Items {
+		key := findRefKey(&comp, synth, meta)
+		if key == "" {
+			logger.V(1).Info("no matching input key found for resource")
+			continue
+		}
+
+		revs := resource.NewInputRevisions(meta, key)
+		if !setInputRevisions(&comp, revs) {
+			continue
+		}
+
+		// TODO: Reduce risk of conflict errors here
+		err := k.client.Status().Update(ctx, &comp)
+		if err != nil {
+			return false, fmt.Errorf("updating input revisions: %w", err)
+		}
+		logger.V(0).Info("noticed input resource change", "compositionName", comp.Name, "compositionNamespace", comp.Namespace, "ref", key)
+		return true, nil // wait for requeue
+	}
+
+	return false, nil
 }
 
 func findRefKey(comp *apiv1.Composition, synth *apiv1.Synthesizer, meta *metav1.PartialObjectMetadata) string {
@@ -224,7 +258,10 @@ func findRefKey(comp *apiv1.Composition, synth *apiv1.Synthesizer, meta *metav1.
 
 	for _, ref := range synth.Spec.Refs {
 		gvk := meta.GetObjectKind().GroupVersionKind()
-		if bindingKey == ref.Key && ref.Resource.Group == gvk.Group && ref.Resource.Version == gvk.Version && ref.Resource.Kind == gvk.Kind {
+		matchesGVK := ref.Resource.Group == gvk.Group && ref.Resource.Version == gvk.Version && ref.Resource.Kind == gvk.Kind
+		matchesKey := bindingKey == ref.Key
+		matchesNSN := ref.Resource.Name == meta.GetName() && ref.Resource.Namespace == meta.GetNamespace()
+		if matchesGVK && (matchesKey || matchesNSN) {
 			return ref.Key
 		}
 	}


### PR DESCRIPTION
When a ref will only ever be bound to a single resource across all compositions, we can avoid the need to specify a binding by letting synthesizers declare the name/namespace.