### PR TITLE
Don't validate non-defaulted resources against schema

### DIFF
--- a/examples/go-synthesizer/main.go
+++ b/examples/go-synthesizer/main.go
@@ -37,6 +37,7 @@ func main() {
 			Containers: []corev1.Container{{
 				Name:  "nginx",
 				Image: "nginx:latest",
+				Ports: []corev1.ContainerPort{{ContainerPort: 80}},
 			}},
 		},
 	}

--- a/internal/resource/resource.go
+++ b/internal/resource/resource.go
@@ -180,14 +180,8 @@ func (r *Resource) Merge(ctx context.Context, old *Resource, current *unstructur
 
 	// Convert to SMD values
 	currentVal := value.NewValueInterface(current.Object)
-	typedNew, err := typed.AsTyped(r.value, schem, *typeref)
-	if err != nil {
-		return nil, false, fmt.Errorf("converting new version to typed: %w", err)
-	}
-	typedCurrent, err := typed.AsTyped(currentVal, schem, *typeref)
-	if err != nil {
-		return nil, false, fmt.Errorf("converting current state to typed: %w", err)
-	}
+	typedNew := typed.AsTypedUnvalidated(r.value, schem, *typeref)
+	typedCurrent := typed.AsTypedUnvalidated(currentVal, schem, *typeref)
 
 	// Merge properties that are set in the new state onto the current state
 	merged, err := typedCurrent.Merge(typedNew)


### PR DESCRIPTION
Some types have schemas that require fields commonly set by the defaulting functions, which don't run in Eno. Everything actually works as expected in this case except the SMD library's validation fails - we can just skip it.