### PR TITLE
Log status transitions

### DIFF
--- a/api/v1/composition.go
+++ b/api/v1/composition.go
@@ -65,6 +65,16 @@ type SimplifiedStatus struct {
 	Error  string `json:"error,omitempty"`
 }
 
+func (s *SimplifiedStatus) String() string {
+	if s == nil {
+		return "Nil"
+	}
+	if s.Error == "" {
+		return s.Status
+	}
+	return fmt.Sprintf("%s (error: %s)", s.Status, s.Error)
+}
+
 // A synthesis is the result of synthesizing a composition.
 // In other words: it's a collection of resources returned from a synthesizer.
 type Synthesis struct {

--- a/internal/controllers/composition/controller.go
+++ b/internal/controllers/composition/controller.go
@@ -70,6 +70,7 @@ func (c *compositionController) Reconcile(ctx context.Context, req ctrl.Request)
 	if synth != nil {
 		logger = logger.WithValues("synthesizerName", synth.Name, "synthesizerGeneration", synth.Generation)
 	}
+	ctx = logr.NewContext(ctx, logger)
 
 	// Write the simplified status
 	modified, err := c.reconcileSimplifiedStatus(ctx, synth, comp)
@@ -136,10 +137,14 @@ func (c *compositionController) reconcileDeletedComposition(ctx context.Context,
 }
 
 func (c *compositionController) reconcileSimplifiedStatus(ctx context.Context, synth *apiv1.Synthesizer, comp *apiv1.Composition) (bool, error) {
+	logger := logr.FromContextOrDiscard(ctx)
+
 	next := buildSimplifiedStatus(synth, comp)
 	if equality.Semantic.DeepEqual(next, comp.Status.Simplified) {
 		return false, nil
 	}
+
+	logger.V(0).Info("composition status changed", "status", next, "previousStatus", comp.Status.Simplified)
 
 	copy := comp.DeepCopy()
 	copy.Status.Simplified = next


### PR DESCRIPTION
Useful for troubleshooting stuck compositions without resorting to `kubectl`