### PR TITLE
Add higher level interface for writing synths in Go

### DIFF
--- a/examples/go-synthesizer/main.go
+++ b/examples/go-synthesizer/main.go
@@ -8,19 +8,15 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func main() {
-	w := function.NewDefaultOutputWriter()
-	r, err := function.NewDefaultInputReader()
-	if err != nil {
-		panic(err) // non-zero exits will be retried
-	}
+type Inputs struct {
+	Config *corev1.ConfigMap `eno_key:"example-input"`
+}
 
-	input := &corev1.ConfigMap{}
-	function.ReadInput(r, "example-input", input)
-
-	replicas, _ := strconv.Atoi(input.Data["replicas"])
+func synthesize(inputs Inputs) ([]client.Object, error) {
+	replicas, _ := strconv.Atoi(inputs.Config.Data["replicas"])
 
 	deploy := &appsv1.Deployment{}
 	deploy.APIVersion = "apps/v1"
@@ -41,7 +37,10 @@ func main() {
 			}},
 		},
 	}
-	w.Add(deploy)
 
-	w.Write()
+	return []client.Object{deploy}, nil
+}
+
+func main() {
+	function.Main(synthesize)
 }

--- a/pkg/function/main.go
+++ b/pkg/function/main.go
@@ -1,0 +1,72 @@
+package function
+
+import (
+	"fmt"
+	"reflect"
+
+	krmv1 "github.com/Azure/eno/pkg/krm/functions/api/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// Inputs is satisfied by any struct that defines the inputs required by a SynthFunc.
+// Use the `eno_key` struct tag to specify the corresponding ref key for each input.
+type Inputs interface{}
+
+// SynthFunc defines a synthesizer function that takes a set of inputs and returns a list of objects.
+type SynthFunc[T Inputs] func(inputs T) ([]client.Object, error)
+
+// Main is the entrypoint for Eno synthesizer processes written using the framework defined by this package.
+func Main[T Inputs](fn SynthFunc[T]) {
+	ow := NewDefaultOutputWriter()
+	ir, err := NewDefaultInputReader()
+	if err != nil {
+		panic(fmt.Sprintf("failed to create default input reader: %s", err))
+	}
+
+	err = main(fn, ir, ow)
+	if err != nil {
+		panic(fmt.Sprintf("error while calling synthesizer function: %s", err))
+	}
+}
+
+func main[T Inputs](fn SynthFunc[T], ir *InputReader, ow *OutputWriter) error {
+	var inputs T
+	v := reflect.ValueOf(&inputs).Elem()
+	t := v.Type()
+
+	// Read the inputs
+	for i := 0; i < t.NumField(); i++ {
+		field := t.Field(i)
+		tagValue := field.Tag.Get("eno_key")
+		if tagValue == "" {
+			continue
+		}
+		if v.Field(i).IsNil() {
+			v.Field(i).Set(reflect.New(field.Type.Elem()))
+		}
+		err := ReadInput[client.Object](ir, tagValue, v.Field(i).Interface().(client.Object))
+		if err != nil {
+			ow.AddResult(&krmv1.Result{
+				Message:  fmt.Sprintf("error while reading input with key %q: %s", tagValue, err),
+				Severity: krmv1.ResultSeverityError,
+			})
+			return ow.Write()
+		}
+	}
+
+	// Call the fn and handle errors through the KRM interface
+	outputs, err := fn(inputs)
+	if err != nil {
+		ow.AddResult(&krmv1.Result{
+			Message:  err.Error(),
+			Severity: krmv1.ResultSeverityError,
+		})
+		return ow.Write()
+	}
+
+	// Write the outputs
+	for _, out := range outputs {
+		ow.Add(out)
+	}
+	return ow.Write()
+}

--- a/pkg/function/main_test.go
+++ b/pkg/function/main_test.go
@@ -1,0 +1,105 @@
+package function
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func ExampleMain() {
+	fn := func(inputs struct{}) ([]client.Object, error) {
+		output := &corev1.Pod{}
+		output.Name = "test-pod"
+		return []client.Object{output}, nil
+	}
+
+	Main(fn)
+	// Output: {"apiVersion":"config.kubernetes.io/v1","kind":"ResourceList","items":[{"metadata":{"creationTimestamp":null,"name":"test-pod"},"spec":{"containers":null},"status":{}}]}
+}
+
+func ExampleInputs() {
+	type exampleInputs struct {
+		MySecret *corev1.Secret `eno_key:"test-secret"`
+	}
+
+	fn := func(inputs exampleInputs) ([]client.Object, error) {
+		output := &corev1.Pod{}
+		output.Name = string(inputs.MySecret.Data["key"])
+		return []client.Object{output}, nil
+	}
+
+	ir := newTestInputReader()
+	main(fn, ir, NewDefaultOutputWriter())
+	// Output: {"apiVersion":"config.kubernetes.io/v1","kind":"ResourceList","items":[{"metadata":{"creationTimestamp":null,"name":"foobar\n"},"spec":{"containers":null},"status":{}}]}
+}
+
+func TestMain(t *testing.T) {
+	outBuf := &bytes.Buffer{}
+	ow := NewOutputWriter(outBuf, nil)
+	ir := newTestInputReader()
+
+	fn := func(inputs testSimpleInputs) ([]client.Object, error) {
+		output := &corev1.Pod{}
+		output.Name = "test-pod"
+		output.Annotations = map[string]string{
+			"cm-value":     inputs.MyConfigmap.Data["key"],
+			"secret-value": string(inputs.MySecret.Data["key"]),
+		}
+		return []client.Object{output}, nil
+	}
+
+	require.NoError(t, main(fn, ir, ow))
+	assert.Equal(t, "{\"apiVersion\":\"config.kubernetes.io/v1\",\"kind\":\"ResourceList\",\"items\":[{\"metadata\":{\"annotations\":{\"cm-value\":\"foo\",\"secret-value\":\"foobar\\n\"},\"creationTimestamp\":null,\"name\":\"test-pod\"},\"spec\":{\"containers\":null},\"status\":{}}]}\n", outBuf.String())
+}
+
+func TestMainInputMissing(t *testing.T) {
+	outBuf := &bytes.Buffer{}
+	inBuf := bytes.NewBufferString(`{}`)
+
+	ow := NewOutputWriter(outBuf, nil)
+	ir, err := NewInputReader(inBuf)
+	require.NoError(t, err)
+
+	fn := func(inputs testSimpleInputs) ([]client.Object, error) {
+		output := &corev1.Pod{}
+		return []client.Object{output}, nil
+	}
+
+	require.NoError(t, main(fn, ir, ow))
+	assert.Equal(t, "{\"apiVersion\":\"config.kubernetes.io/v1\",\"kind\":\"ResourceList\",\"items\":[],\"results\":[{\"message\":\"error while reading input with key \\\"test-cm\\\": input \\\"test-cm\\\" was not found\",\"severity\":\"error\"}]}\n", outBuf.String())
+}
+
+func TestMainError(t *testing.T) {
+	outBuf := &bytes.Buffer{}
+	inBuf := bytes.NewBufferString(`{"items": [{"kind": "ConfigMap", "apiVersion": "v1", "metadata": {"name": "test-configmap", "annotations": {"eno.azure.io/input-key": "test-cm"}}, "data": {"key": "foo"}}, {"kind": "Secret", "apiVersion": "v1", "metadata": {"name": "test-secret", "annotations": {"eno.azure.io/input-key": "test-secret"}}, "data": {"key": "Zm9vYmFyCg=="}}]}`)
+
+	ow := NewOutputWriter(outBuf, nil)
+	ir, err := NewInputReader(inBuf)
+	require.NoError(t, err)
+
+	fn := func(inputs testSimpleInputs) ([]client.Object, error) {
+		return []client.Object{}, fmt.Errorf("foobar")
+	}
+
+	require.NoError(t, main(fn, ir, ow))
+	assert.Equal(t, "{\"apiVersion\":\"config.kubernetes.io/v1\",\"kind\":\"ResourceList\",\"items\":[],\"results\":[{\"message\":\"foobar\",\"severity\":\"error\"}]}\n", outBuf.String())
+}
+
+type testSimpleInputs struct {
+	MyConfigmap *corev1.ConfigMap `eno_key:"test-cm"`
+	MySecret    *corev1.Secret    `eno_key:"test-secret"`
+}
+
+func newTestInputReader() *InputReader {
+	inBuf := bytes.NewBufferString(`{"items": [{"kind": "ConfigMap", "apiVersion": "v1", "metadata": {"name": "test-configmap", "annotations": {"eno.azure.io/input-key": "test-cm"}}, "data": {"key": "foo"}}, {"kind": "Secret", "apiVersion": "v1", "metadata": {"name": "test-secret", "annotations": {"eno.azure.io/input-key": "test-secret"}}, "data": {"key": "Zm9vYmFyCg=="}}]}`)
+	ir, err := NewInputReader(inBuf)
+	if err != nil {
+		panic(err)
+	}
+	return ir
+}

--- a/pkg/function/outputs.go
+++ b/pkg/function/outputs.go
@@ -14,6 +14,7 @@ import (
 
 type OutputWriter struct {
 	outputs   []*unstructured.Unstructured
+	results   []*krmv1.Result
 	io        io.Writer
 	committed bool
 	munge     MungeFunc
@@ -32,6 +33,10 @@ func NewOutputWriter(w io.Writer, munge MungeFunc) *OutputWriter {
 		committed: false,
 		munge:     munge,
 	}
+}
+
+func (w *OutputWriter) AddResult(result *krmv1.Result) {
+	w.results = append(w.results, result)
 }
 
 func (w *OutputWriter) Add(outs ...client.Object) error {
@@ -67,6 +72,7 @@ func (w *OutputWriter) Write() error {
 		Kind:       krmv1.ResourceListKind,
 		APIVersion: krmv1.SchemeGroupVersion.String(),
 		Items:      w.outputs,
+		Results:    w.results,
 	}
 
 	err := json.NewEncoder(w.io).Encode(rl)

--- a/pkg/function/outputs_test.go
+++ b/pkg/function/outputs_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"testing"
 
+	krmv1 "github.com/Azure/eno/pkg/krm/functions/api/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
@@ -19,10 +20,11 @@ func TestOutputWriter(t *testing.T) {
 
 	require.NoError(t, w.Add(nil))
 	require.NoError(t, w.Add(cm))
+	w.AddResult(&krmv1.Result{Message: "test message", Severity: krmv1.ResultSeverityError})
 	assert.Equal(t, 0, out.Len())
 
 	require.NoError(t, w.Write())
-	assert.Equal(t, "{\"apiVersion\":\"config.kubernetes.io/v1\",\"kind\":\"ResourceList\",\"items\":[{\"metadata\":{\"creationTimestamp\":null,\"name\":\"test-cm\"}}]}\n", out.String())
+	assert.Equal(t, "{\"apiVersion\":\"config.kubernetes.io/v1\",\"kind\":\"ResourceList\",\"items\":[{\"metadata\":{\"creationTimestamp\":null,\"name\":\"test-cm\"}}],\"results\":[{\"message\":\"test message\",\"severity\":\"error\"}]}\n", out.String())
 
 	require.Error(t, w.Add(nil))
 }


### PR DESCRIPTION
The input reader and output writer interfaces are useful for synthesizers like `helmshim`, but too low-level for hand written synthesizers.

This change adds a new entrypoint for customer Go synths that uses reflection to populate an inputs struct using the underlying input reader.