### PR TITLE
Improve error logging fields

### DIFF
--- a/internal/controllers/composition/controller.go
+++ b/internal/controllers/composition/controller.go
@@ -39,7 +39,8 @@ func (c *compositionController) Reconcile(ctx context.Context, req ctrl.Request)
 	comp := &apiv1.Composition{}
 	err := c.client.Get(ctx, req.NamespacedName, comp)
 	if err != nil {
-		return ctrl.Result{}, client.IgnoreNotFound(fmt.Errorf("getting composition resource: %w", err))
+		logger.Error(err, "failed to get composition resource")
+		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
 	logger = logger.WithValues("compositionName", comp.Name, "compositionNamespace", comp.Namespace, "compositionGeneration", comp.Generation, "synthesisID", comp.Status.GetCurrentSynthesisUUID())
@@ -51,7 +52,8 @@ func (c *compositionController) Reconcile(ctx context.Context, req ctrl.Request)
 	if controllerutil.AddFinalizer(comp, "eno.azure.io/cleanup") {
 		err = c.client.Update(ctx, comp)
 		if err != nil {
-			return ctrl.Result{}, fmt.Errorf("updating composition: %w", err)
+			logger.Error(err, "failed to update composition")
+			return ctrl.Result{}, err
 		}
 		logger.V(1).Info("added cleanup finalizer to composition")
 		return ctrl.Result{}, nil
@@ -65,7 +67,8 @@ func (c *compositionController) Reconcile(ctx context.Context, req ctrl.Request)
 		err = nil
 	}
 	if err != nil {
-		return ctrl.Result{}, fmt.Errorf("getting synthesizer: %w", err)
+		logger.Error(err, "failed to get synthesizer")
+		return ctrl.Result{}, err
 	}
 	if synth != nil {
 		logger = logger.WithValues("synthesizerName", synth.Name, "synthesizerGeneration", synth.Generation)
@@ -73,8 +76,12 @@ func (c *compositionController) Reconcile(ctx context.Context, req ctrl.Request)
 
 	// Write the simplified status
 	modified, err := c.reconcileSimplifiedStatus(ctx, synth, comp)
-	if err != nil || modified || synth == nil {
+	if err != nil {
+		logger.Error(err, "failed to reconcile simplified status")
 		return ctrl.Result{}, err
+	}
+	if modified || synth == nil {
+		return ctrl.Result{}, nil
 	}
 
 	// Enforce the synthesis timeout period
@@ -85,7 +92,8 @@ func (c *compositionController) Reconcile(ctx context.Context, req ctrl.Request)
 		}
 		syn.Canceled = ptr.To(metav1.Now())
 		if err := c.client.Status().Update(ctx, comp); err != nil {
-			return ctrl.Result{}, fmt.Errorf("updating compostion to reflect synthesis timeout: %w", err)
+			logger.Error(err, "failed to update composition status to reflect synthesis timeout")
+			return ctrl.Result{}, err
 		}
 		logger.V(0).Info("synthesis timed out")
 		return ctrl.Result{}, nil
@@ -111,7 +119,8 @@ func (c *compositionController) reconcileDeletedComposition(ctx context.Context,
 			comp.Status.CurrentSynthesis.Ready = nil
 			err := c.client.Status().Update(ctx, comp)
 			if err != nil {
-				return ctrl.Result{}, fmt.Errorf("updating current composition generation: %w", err)
+				logger.Error(err, "failed to update current composition generation")
+				return ctrl.Result{}, err
 			}
 			logger.V(0).Info("updated composition status to reflect deletion", "synthesisID", comp.Status.CurrentSynthesis.UUID)
 			return ctrl.Result{}, nil
@@ -126,7 +135,8 @@ func (c *compositionController) reconcileDeletedComposition(ctx context.Context,
 	if controllerutil.RemoveFinalizer(comp, "eno.azure.io/cleanup") {
 		err := c.client.Update(ctx, comp)
 		if err != nil {
-			return ctrl.Result{}, fmt.Errorf("removing finalizer: %w", err)
+			logger.Error(err, "failed to remove finalizer")
+			return ctrl.Result{}, err
 		}
 
 		logger.V(0).Info("removed finalizer from composition")

--- a/internal/controllers/synthesis/lifecycle.go
+++ b/internal/controllers/synthesis/lifecycle.go
@@ -76,7 +76,8 @@ func (c *podLifecycleController) Reconcile(ctx context.Context, req ctrl.Request
 	comp := &apiv1.Composition{}
 	err := c.client.Get(ctx, req.NamespacedName, comp)
 	if err != nil {
-		return ctrl.Result{}, client.IgnoreNotFound(fmt.Errorf("getting composition resource: %w", err))
+		logger.Error(err, "failed to get composition resource")
+		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 	if comp.DeletionTimestamp != nil ||
 		!controllerutil.ContainsFinalizer(comp, "eno.azure.io/cleanup") ||
@@ -91,7 +92,8 @@ func (c *podLifecycleController) Reconcile(ctx context.Context, req ctrl.Request
 	syn.Name = comp.Spec.Synthesizer.Name
 	err = c.client.Get(ctx, client.ObjectKeyFromObject(syn), syn)
 	if err != nil {
-		return ctrl.Result{}, client.IgnoreNotFound(fmt.Errorf("getting synthesizer: %w", err))
+		logger.Error(err, "failed to get synthesizer")
+		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 	if syn != nil {
 		logger = logger.WithValues("synthesizerName", syn.Name, "synthesizerGeneration", syn.Generation)

--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -183,19 +183,12 @@ func newMgr(logger logr.Logger, opts *Options, isController, isReconciler bool) 
 }
 
 func NewLogConstructor(mgr ctrl.Manager, controllerName string) func(*reconcile.Request) logr.Logger {
-	return func(req *reconcile.Request) logr.Logger {
-		l := mgr.GetLogger().WithValues("controller", controllerName)
-		if req != nil {
-			l.WithValues("requestName", req.Name, "requestNamespace", req.Namespace)
-		}
-		return l
-	}
+	return NewTypedLogConstructor[*reconcile.Request](mgr, controllerName)
 }
 
 func NewTypedLogConstructor[T any](mgr ctrl.Manager, controllerName string) func(T) logr.Logger {
 	return func(req T) logr.Logger {
 		l := mgr.GetLogger().WithValues("controller", controllerName)
-		// TODO: Improve log fields and merge NewLogConstructor into NewTypedLogConstructor
 		return l
 	}
 }


### PR DESCRIPTION
Currently errors are wrapped and returned by the controller, and logged by controller-runtime internals. This is nice since it avoids the common issue of logging the same error multiple times, but it doesn't provide a good way to include the log fields that have accumulated on the logger through the Reconcile call.

I think we should break down and just log the errors from the Reconcile function to preserve the logger fields.