### PR TITLE
Support custom input types in pkg/function

### DIFF
--- a/pkg/function/main.go
+++ b/pkg/function/main.go
@@ -10,6 +10,7 @@ import (
 
 // Inputs is satisfied by any struct that defines the inputs required by a SynthFunc.
 // Use the `eno_key` struct tag to specify the corresponding ref key for each input.
+// Each field must either be a client.Object or a custom type registered with AddCustomInputType.
 type Inputs interface{}
 
 // SynthFunc defines a synthesizer function that takes a set of inputs and returns a list of objects.
@@ -44,13 +45,38 @@ func main[T Inputs](fn SynthFunc[T], ir *InputReader, ow *OutputWriter) error {
 		if v.Field(i).IsNil() {
 			v.Field(i).Set(reflect.New(field.Type.Elem()))
 		}
-		err := ReadInput[client.Object](ir, tagValue, v.Field(i).Interface().(client.Object))
+		input := v.Field(i).Interface()
+
+		var obj client.Object
+		var custom bool
+		if o, ok := input.(client.Object); ok {
+			obj = o
+		} else if inputType, ok := customInputSourceTypes[v.Field(i).Type().String()]; ok {
+			obj = reflect.New(inputType.Elem()).Interface().(client.Object)
+			custom = true
+		} else {
+			return fmt.Errorf("input %s is not a known type", tagValue)
+		}
+
+		err := ReadInput[client.Object](ir, tagValue, obj)
 		if err != nil {
 			ow.AddResult(&krmv1.Result{
 				Message:  fmt.Sprintf("error while reading input with key %q: %s", tagValue, err),
 				Severity: krmv1.ResultSeverityError,
 			})
 			return ow.Write()
+		}
+
+		if custom {
+			bind, ok := customInputBindings[v.Field(i).Type().String()]
+			if !ok {
+				return fmt.Errorf("no binding function for input %s", tagValue)
+			}
+			bound, err := bind(obj)
+			if err != nil {
+				return fmt.Errorf("error while binding custom input %s: %s", tagValue, err)
+			}
+			v.Field(i).Set(reflect.ValueOf(bound))
 		}
 	}
 
@@ -69,4 +95,21 @@ func main[T Inputs](fn SynthFunc[T], ir *InputReader, ow *OutputWriter) error {
 		ow.Add(out)
 	}
 	return ow.Write()
+}
+
+var customInputSourceTypes = map[string]reflect.Type{}
+var customInputBindings = map[string]func(any) (any, error){}
+
+// AddCustomInputType allows types that do not implement client.Object to be used as fields of Inputs structs.
+func AddCustomInputType[Resource client.Object, Custom any](bind func(Resource) (Custom, error)) {
+	str := reflect.TypeOf(bind).Out(0).String()
+
+	// Map from custom type name to the underlying k8s input type
+	var res Resource
+	customInputSourceTypes[str] = reflect.TypeOf(res)
+
+	// Map from the custom type name to the binding function
+	customInputBindings[str] = func(in any) (any, error) {
+		return bind(in.(Resource))
+	}
 }

--- a/pkg/function/main.go
+++ b/pkg/function/main.go
@@ -116,12 +116,12 @@ func newInput(ir *InputReader, field reflect.Value) (*input, error) {
 
 	// Resolve custom input types back to their binding functions
 	name := field.Type().String()
-	inputType, ok := customInputSourceTypes[name]
+	inputSourceType, ok := customInputSourceTypes[name]
 	if !ok {
 		return nil, fmt.Errorf("custom input type %q has not been registered", name)
 	}
 
-	fieldVal = reflect.New(inputType.Elem()).Interface()
+	fieldVal = reflect.New(inputSourceType.Elem()).Interface()
 	i.Object = fieldVal.(client.Object)
 	i.bindFn = customInputBindings[name]
 	return i, nil

--- a/pkg/function/main_test.go
+++ b/pkg/function/main_test.go
@@ -38,6 +38,32 @@ func ExampleInputs() {
 	// Output: {"apiVersion":"config.kubernetes.io/v1","kind":"ResourceList","items":[{"metadata":{"creationTimestamp":null,"name":"foobar\n"},"spec":{"containers":null},"status":{}}]}
 }
 
+func ExampleAddCustomInputType() {
+	type myType struct {
+		SecretKey string
+	}
+
+	AddCustomInputType(func(in *corev1.Secret) (*myType, error) {
+		return &myType{
+			SecretKey: string(in.Data["key"]),
+		}, nil
+	})
+
+	type exampleInputs struct {
+		CustomInput *myType `eno_key:"test-secret"`
+	}
+
+	fn := func(inputs exampleInputs) ([]client.Object, error) {
+		output := &corev1.Pod{}
+		output.Name = string(inputs.CustomInput.SecretKey)
+		return []client.Object{output}, nil
+	}
+
+	ir := newTestInputReader()
+	main(fn, ir, NewDefaultOutputWriter())
+	// Output: {"apiVersion":"config.kubernetes.io/v1","kind":"ResourceList","items":[{"metadata":{"creationTimestamp":null,"name":"foobar\n"},"spec":{"containers":null},"status":{}}]}
+}
+
 func TestMain(t *testing.T) {
 	outBuf := &bytes.Buffer{}
 	ow := NewOutputWriter(outBuf, nil)


### PR DESCRIPTION
This change allows non-k8s types to be declared as synthesizer inputs, and bound to some corresponding k8s resource by a reusable function.