### PR TITLE
Enforce a min reconcile interval

### DIFF
--- a/cmd/eno-reconciler/main.go
+++ b/cmd/eno-reconciler/main.go
@@ -52,6 +52,7 @@ func run() error {
 	flag.Float64Var(&remoteQPS, "remote-qps", 50, "Max requests per second to the remote apiserver")
 	flag.DurationVar(&recOpts.Timeout, "timeout", time.Minute, "Per-resource reconciliation timeout. Avoids cases where client retries/timeouts are configured poorly and the loop gets blocked")
 	flag.DurationVar(&recOpts.ReadinessPollInterval, "readiness-poll-interval", time.Second*5, "Interval at which non-ready resources will be checked for readiness")
+	flag.DurationVar(&recOpts.MinReconcileInterval, "min-reconcile-interval", time.Second, "Minimum value of eno.azure.com/reconcile-interval that will be honored by the controller")
 	flag.StringVar(&compositionSelector, "composition-label-selector", labels.Everything().String(), "Optional label selector for compositions to be reconciled")
 	flag.StringVar(&compositionNamespace, "composition-namespace", metav1.NamespaceAll, "Optional namespace to limit compositions that will be reconciled")
 	flag.DurationVar(&namespaceCreationGracePeriod, "ns-creation-grace-period", time.Second, "A namespace is assumed to be missing if it doesn't exist once one of its resources has existed for this long")

--- a/internal/controllers/reconciliation/controller_test.go
+++ b/internal/controllers/reconciliation/controller_test.go
@@ -1,0 +1,78 @@
+package reconciliation
+
+import (
+	"testing"
+	"time"
+
+	apiv1 "github.com/Azure/eno/api/v1"
+	"github.com/Azure/eno/internal/resource"
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestRequeue(t *testing.T) {
+	tests := []struct {
+		name           string
+		comp           *apiv1.Composition
+		resource       *resource.Resource
+		ready          *metav1.Time
+		minReconcile   time.Duration
+		expectedResult time.Duration
+	}{
+		{
+			name: "resource is not ready, requeue after readiness poll interval",
+			comp: &apiv1.Composition{},
+			resource: &resource.Resource{
+				ReconcileInterval: nil,
+			},
+			ready:          nil,
+			minReconcile:   10 * time.Second,
+			expectedResult: 10 * time.Second,
+		},
+		{
+			name: "resource is deleted, no requeue",
+			comp: &apiv1.Composition{},
+			resource: &resource.Resource{
+				ReconcileInterval: nil,
+			},
+			ready:          &metav1.Time{},
+			minReconcile:   10 * time.Second,
+			expectedResult: 0,
+		},
+		{
+			name: "resource has reconcile interval less than minReconcileInterval",
+			comp: &apiv1.Composition{},
+			resource: &resource.Resource{
+				ReconcileInterval: &metav1.Duration{Duration: 5 * time.Second},
+			},
+			ready:          &metav1.Time{},
+			minReconcile:   10 * time.Second,
+			expectedResult: 10 * time.Second,
+		},
+		{
+			name: "resource has valid reconcile interval",
+			comp: &apiv1.Composition{},
+			resource: &resource.Resource{
+				ReconcileInterval: &metav1.Duration{Duration: 15 * time.Second},
+			},
+			ready:          &metav1.Time{},
+			minReconcile:   10 * time.Second,
+			expectedResult: 15 * time.Second,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logger := logr.Discard()
+			c := &Controller{
+				readinessPollInterval: 10 * time.Second,
+				minReconcileInterval:  tt.minReconcile,
+			}
+
+			result, err := c.requeue(logger, tt.comp, tt.resource, tt.ready)
+			assert.NoError(t, err)
+			assert.InDelta(t, tt.expectedResult, result.RequeueAfter, float64(2*time.Second))
+		})
+	}
+}


### PR DESCRIPTION
Don't let resources block the loop by setting a small or zero reconcile interval.