### PR TITLE
Handle slow synthesis pod deletion

### DIFF
--- a/internal/controllers/synthesis/gc.go
+++ b/internal/controllers/synthesis/gc.go
@@ -36,9 +36,12 @@ func (p *podGarbageCollector) Reconcile(ctx context.Context, req ctrl.Request) (
 
 	pod := &corev1.Pod{}
 	err := p.client.Get(ctx, req.NamespacedName, pod)
-	if err != nil || pod.DeletionTimestamp != nil {
-		logger.Error(err, "failed to get pod or pod is marked for deletion")
+	if err != nil {
+		logger.Error(err, "failed to get pod")
 		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
+	if pod.DeletionTimestamp != nil {
+		return ctrl.Result{}, nil
 	}
 	logger = logger.WithValues("podName", pod.Name, "podNamespace", pod.Namespace)
 

--- a/internal/controllers/synthesis/lifecycle.go
+++ b/internal/controllers/synthesis/lifecycle.go
@@ -57,6 +57,14 @@ func (c *podLifecycleController) newPodEventHandler() handler.TypedEventHandler[
 		CreateFunc: func(ctx context.Context, e event.TypedCreateEvent[*corev1.Pod], q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
 		},
 		UpdateFunc: func(ctx context.Context, e event.TypedUpdateEvent[*corev1.Pod], q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+			if e.ObjectNew.DeletionTimestamp == nil || e.ObjectOld.DeletionTimestamp != nil || e.ObjectNew.Labels == nil {
+				return
+			}
+			nsn := types.NamespacedName{
+				Name:      e.ObjectNew.GetLabels()[compositionNameLabelKey],
+				Namespace: e.ObjectNew.GetLabels()[compositionNamespaceLabelKey],
+			}
+			q.Add(reconcile.Request{NamespacedName: nsn})
 		},
 		DeleteFunc: func(ctx context.Context, e event.TypedDeleteEvent[*corev1.Pod], q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
 			if e.DeleteStateUnknown || e.Object.Labels == nil {


### PR DESCRIPTION
Currently replacement synthesis pods are only created after the existing pods are fully deleted i.e. gone from the informer entirely. The intention of the design was to create a new pod as soon as the old pod is marked for deletion, so we need to also enqueue when the deletion timestamp transitions from nil to non-nil.

