### PR TITLE
Set deadline on synthesis pods

### DIFF
--- a/internal/controllers/synthesis/gc.go
+++ b/internal/controllers/synthesis/gc.go
@@ -51,6 +51,11 @@ func (p *podGarbageCollector) Reconcile(ctx context.Context, req ctrl.Request) (
 		return ctrl.Result{}, nil
 	}
 
+	if pod.Status.Phase == corev1.PodFailed {
+		logger = logger.WithValues("reason", pod.Status.Phase)
+		return ctrl.Result{}, p.deletePod(ctx, pod, logger)
+	}
+
 	// Avoid waiting for the lease to expire for broken nodes
 	if delta := timeWaitingForKubelet(pod, time.Now()); delta > 0 {
 		if delta < p.creationTimeout {

--- a/internal/controllers/synthesis/pod.go
+++ b/internal/controllers/synthesis/pod.go
@@ -57,8 +57,9 @@ func newPod(cfg *Config, comp *apiv1.Composition, syn *apiv1.Synthesizer) *corev
 	}
 
 	pod.Spec = corev1.PodSpec{
-		ServiceAccountName: cfg.PodServiceAccount,
-		RestartPolicy:      corev1.RestartPolicyOnFailure,
+		ServiceAccountName:            cfg.PodServiceAccount,
+		RestartPolicy:                 corev1.RestartPolicyOnFailure,
+		TerminationGracePeriodSeconds: ptr.To(int64(0)),
 		Affinity: &corev1.Affinity{
 			PodAntiAffinity: &corev1.PodAntiAffinity{
 				PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{{
@@ -115,6 +116,10 @@ func newPod(cfg *Config, comp *apiv1.Composition, syn *apiv1.Synthesizer) *corev
 				},
 			},
 		}},
+	}
+
+	if syn.Spec.PodTimeout != nil {
+		pod.Spec.ActiveDeadlineSeconds = ptr.To(int64(syn.Spec.PodTimeout.Seconds()))
 	}
 
 	if cfg.TaintTolerationKey != "" {


### PR DESCRIPTION
Eno has its own timeouts for the synthesis workflow, but it still makes sense to set the built in pod deadline to cover cases where Eno's controllers are able to operate well due to high pod count or rapid churn.

This also reduces the shutdown grace period to 0 since there is no gracefully shutting down synthesizer processes.