### PR TITLE
Avoid hardcoding Go version in CI

### DIFF
--- a/.github/workflows/k8scompat.yaml
+++ b/.github/workflows/k8scompat.yaml
@@ -20,8 +20,6 @@ jobs:
     steps:
       - name: Set up Go
         uses: actions/setup-go@v5
-        with:
-          go-version: '1.23'
 
       - name: Generate test matrix using setup-envtest
         id: build
@@ -44,7 +42,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.23'
+          go-version-file: go.mod
 
       - name: Download kubebuilder assets
         run: |

--- a/.github/workflows/unit.yaml
+++ b/.github/workflows/unit.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.23'
+          go-version-file: go.mod
 
       - name: Download kubebuilder assets
         run: |


### PR DESCRIPTION
The setup-go GH action actually supports reading the version from go.mod. Will make updating Go easier in the future.