### PR TITLE
Quiet noisy synthesis timeout logs

### DIFF
--- a/internal/controllers/composition/controller.go
+++ b/internal/controllers/composition/controller.go
@@ -87,7 +87,7 @@ func (c *compositionController) Reconcile(ctx context.Context, req ctrl.Request)
 	}
 
 	// Enforce the synthesis timeout period
-	if syn := comp.Status.InFlightSynthesis; syn != nil && syn.Initialized != nil && synth.Spec.PodTimeout != nil {
+	if syn := comp.Status.InFlightSynthesis; syn != nil && syn.Canceled == nil && syn.Initialized != nil && synth.Spec.PodTimeout != nil {
 		delta := time.Until(syn.Initialized.Time.Add(synth.Spec.PodTimeout.Duration))
 		if delta > 0 {
 			return ctrl.Result{RequeueAfter: delta}, nil

--- a/internal/controllers/composition/controller_test.go
+++ b/internal/controllers/composition/controller_test.go
@@ -148,6 +148,16 @@ func TestTimeoutCancelation(t *testing.T) {
 
 	require.NoError(t, cli.Get(ctx, client.ObjectKeyFromObject(comp), comp))
 	assert.NotNil(t, comp.Status.InFlightSynthesis.Canceled)
+
+	res, err = c.Reconcile(ctx, req) // status update
+	require.NoError(t, err)
+	assert.Zero(t, res.RequeueAfter)
+
+	// Idempotence check
+	require.NoError(t, cli.Get(ctx, client.ObjectKeyFromObject(comp), comp))
+	c.client = testutil.NewReadOnlyClient(t, comp, synth)
+	res, err = c.Reconcile(ctx, req)
+	assert.NoError(t, err)
 }
 
 func TestSimplifiedStatus(t *testing.T) {

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -79,6 +79,12 @@ func NewReadOnlyClient(t testing.TB, objs ...runtime.Object) client.Client {
 		Delete: func(ctx context.Context, client client.WithWatch, obj client.Object, opts ...client.DeleteOption) error {
 			return errors.New("no writes allowed")
 		},
+		SubResourceUpdate: func(ctx context.Context, client client.Client, subResourceName string, obj client.Object, opts ...client.SubResourceUpdateOption) error {
+			return errors.New("no writes allowed")
+		},
+		SubResourcePatch: func(ctx context.Context, client client.Client, subResourceName string, obj client.Object, patch client.Patch, opts ...client.SubResourcePatchOption) error {
+			return errors.New("no writes allowed")
+		},
 	})
 
 	return builder.Build()


### PR DESCRIPTION
The composition controller will keep setting the `Canceled` field after timeout. This is pretty benign - it shouldn't cause any unexpected behaviors. But the logs are noisy.