### PR TITLE
Use latest k8s version in CI

### DIFF
--- a/.github/workflows/unit.yaml
+++ b/.github/workflows/unit.yaml
@@ -11,8 +11,6 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    env:
-      APISERVER_VERSION: 1.28.x
     steps:
       - uses: actions/checkout@v4
 
@@ -23,7 +21,7 @@ jobs:
 
       - name: Download kubebuilder assets
         run: |
-          echo "KUBEBUILDER_ASSETS=$(go run sigs.k8s.io/controller-runtime/tools/setup-envtest@latest use -p path $APISERVER_VERSION)" >> $GITHUB_ENV
+          echo "KUBEBUILDER_ASSETS=$(go run sigs.k8s.io/controller-runtime/tools/setup-envtest@latest use -p path)" >> $GITHUB_ENV
 
       - name: Run tests
         run: go test -v ./...


### PR DESCRIPTION
For whatever reason we hardcoded a k8s version for the unit test pipeline at some point. Better to use the latest version so the nightlies will fail if there are breaking changes upstream.