### PR TITLE
Updating Docs for Deletion Strategy

### DIFF
--- a/docs/reconciliation.md
+++ b/docs/reconciliation.md
@@ -88,6 +88,7 @@ annotations:
 
 The `orphan` deletion strategy disables deletion caused by composition deletion.
 The resource will still be deleted if it's not included in the latest synthesis, or if a `Patch` resource explicitly deletes it.
+Note that this annotation must be applied to the composition itself.
 
 ```yaml
 annotations:


### PR DESCRIPTION
Adding a note that annotation must be applied to the composition itself for orphan delete strategy