### PR TITLE
Test against older k8s versions

### DIFF
--- a/hack/build-k8s-matrix.sh
+++ b/hack/build-k8s-matrix.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-start_minor=22 # TODO: lower this to ~10
+start_minor=10
 latest=$(curl -sL https://dl.k8s.io/release/stable.txt) # e.g. "v1.33.1"
 latest_minor=$(echo "$latest" | cut -d. -f2)
 seq $start_minor $latest_minor | jq --raw-input --slurp -c 'split("\n") | map(select(. != ""))'

--- a/internal/controllers/reconciliation/crud_test.go
+++ b/internal/controllers/reconciliation/crud_test.go
@@ -211,6 +211,10 @@ func TestCRUD(t *testing.T) {
 			upstream := mgr.GetClient()
 			downstream := mgr.DownstreamClient
 
+			if test.Name == "strategic-merge" {
+				requireSSA(t, mgr)
+			}
+
 			registerControllers(t, mgr)
 			testutil.WithFakeExecutor(t, mgr, newSliceBuilder(t, scheme, &test))
 

--- a/internal/controllers/reconciliation/edgecase_test.go
+++ b/internal/controllers/reconciliation/edgecase_test.go
@@ -229,6 +229,10 @@ func TestPatchStrategyReplace(t *testing.T) {
 	mgr := testutil.NewManager(t)
 	upstream := mgr.GetClient()
 
+	if mgr.DownstreamVersion < 21 {
+		t.Skipf("skipping test for downstream version %d because it doesn't support policy/v1", mgr.DownstreamVersion)
+	}
+
 	registerControllers(t, mgr)
 	testutil.WithFakeExecutor(t, mgr, func(ctx context.Context, s *apiv1.Synthesizer, input *krmv1.ResourceList) (*krmv1.ResourceList, error) {
 		output := &krmv1.ResourceList{}

--- a/internal/controllers/reconciliation/helm_test.go
+++ b/internal/controllers/reconciliation/helm_test.go
@@ -32,6 +32,7 @@ func TestHelmOwnershipTransfer(t *testing.T) {
 
 	ctx := testutil.NewContext(t)
 	mgr := testutil.NewManager(t)
+	requireSSA(t, mgr)
 	upstream := mgr.GetClient()
 	downstream := mgr.DownstreamClient
 

--- a/internal/controllers/reconciliation/helpers_test.go
+++ b/internal/controllers/reconciliation/helpers_test.go
@@ -93,3 +93,9 @@ func mapToResource(t *testing.T, res map[string]any) (*unstructured.Unstructured
 
 	return obj, rr
 }
+
+func requireSSA(t *testing.T, mgr *testutil.Manager) {
+	if mgr.DownstreamVersion < 16 {
+		t.Skipf("skipping test because it requires server-side apply which isn't supported on k8s 1.%d", mgr.DownstreamVersion)
+	}
+}

--- a/internal/controllers/reconciliation/merge_test.go
+++ b/internal/controllers/reconciliation/merge_test.go
@@ -153,6 +153,7 @@ func TestRemoveProperty(t *testing.T) {
 func TestRemovePropertyAndOwnership(t *testing.T) {
 	ctx := testutil.NewContext(t)
 	mgr := testutil.NewManager(t)
+	requireSSA(t, mgr)
 	upstream := mgr.GetClient()
 
 	registerControllers(t, mgr)
@@ -226,6 +227,7 @@ func TestRemovePropertyAndOwnership(t *testing.T) {
 func TestReplaceProperty(t *testing.T) {
 	ctx := testutil.NewContext(t)
 	mgr := testutil.NewManager(t)
+	requireSSA(t, mgr)
 	upstream := mgr.GetClient()
 
 	registerControllers(t, mgr)
@@ -296,6 +298,7 @@ func TestReplaceProperty(t *testing.T) {
 func TestReplacePropertyAndRemoveOwnership(t *testing.T) {
 	ctx := testutil.NewContext(t)
 	mgr := testutil.NewManager(t)
+	requireSSA(t, mgr)
 	upstream := mgr.GetClient()
 
 	registerControllers(t, mgr)

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -183,6 +183,7 @@ func NewManager(t *testing.T, testOpts ...TestManagerOption) *Manager {
 		return m // only one env needed
 	}
 	version, _ := strconv.Atoi(os.Getenv("DOWNSTREAM_VERSION_MINOR"))
+	m.DownstreamVersion = version
 
 	downstreamEnv := &envtest.Environment{
 		BinaryAssetsDirectory:    dir,
@@ -260,6 +261,7 @@ type Manager struct {
 	DownstreamRestConfig *rest.Config  // may or may not == RestConfig
 	DownstreamClient     client.Client // may or may not == Manager.GetClient()
 	DownstreamEnv        *envtest.Environment
+	DownstreamVersion    int
 
 	// NoSsaSupport is true if the cluster does not support server-side-apply
 	NoSsaSupport bool


### PR DESCRIPTION
Expands the test matrix back to k8s 1.10 while adding exceptions for specific test cases that require server-side apply.