### PR TITLE
Fix --disable-ssa

### DIFF
--- a/.github/workflows/smoke.yaml
+++ b/.github/workflows/smoke.yaml
@@ -10,8 +10,18 @@ on:
 
 jobs:
   test:
-    name: Apply Examples
+    name: Apply Examples (${{ matrix.config.name }})
     runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - name: Default
+            disable_ssa: "false"
+          - name: Disable SSA
+            disable_ssa: "true"
+
     steps:
       - uses: actions/checkout@v4
 
@@ -34,6 +44,7 @@ jobs:
         env:
           REGISTRY: localhost
           SKIP_PUSH: "yes"
+          DISABLE_SSA: "${{ matrix.config.disable_ssa }}"
         run: |
           echo "--- building eno..."
           ./dev/build.sh

--- a/dev/build.sh
+++ b/dev/build.sh
@@ -23,5 +23,6 @@ for f in docker/*; do
 done
 
 # Deploy!
+export DISABLE_SSA="${DISABLE_SSA:=false}"
 cat "$(dirname "$0")/deploy.yaml" | envsubst | kubectl apply -f - -f ./api/v1/config/crd
 echo "Success! You're running tag: $TAG"

--- a/dev/deploy.yaml
+++ b/dev/deploy.yaml
@@ -90,6 +90,7 @@ spec:
         args:
         - --leader-election
         - --leader-election-id=reconciler
+        - --disable-ssa=$DISABLE_SSA
         env:
           - name: POD_NAMESPACE
             valueFrom:

--- a/hack/smoke-test.sh
+++ b/hack/smoke-test.sh
@@ -12,11 +12,12 @@ set +e
 # Tail the controller logs
 function watch_logs() {
     while true; do
-        kubectl logs -f -l app=eno-controller
+        kubectl logs -f -l $1
         sleep 1
     done
 }
-watch_logs &
+watch_logs app=eno-controller &
+watch_logs app=eno-reconciler &
 
 # Wait for the composition to be reconciled
 while true; do

--- a/internal/controllers/reconciliation/merge_test.go
+++ b/internal/controllers/reconciliation/merge_test.go
@@ -10,10 +10,12 @@ import (
 	krmv1 "github.com/Azure/eno/pkg/krm/functions/api/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/retry"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -78,6 +80,37 @@ func TestDisableSSA(t *testing.T) {
 	testutil.Eventually(t, func() bool {
 		err := upstream.Get(ctx, client.ObjectKeyFromObject(comp), comp)
 		return err == nil && comp.Status.CurrentSynthesis != nil && comp.Status.CurrentSynthesis.Ready != nil && comp.Status.CurrentSynthesis.ObservedCompositionGeneration == comp.Generation
+	})
+
+	// Add a field to the deployment
+	dep := &appsv1.Deployment{}
+	dep.Name = "test-obj"
+	dep.Namespace = "default"
+	err := retry.RetryOnConflict(testutil.Backoff, func() error {
+		mgr.DownstreamClient.Get(ctx, client.ObjectKeyFromObject(dep), dep)
+		dep.Spec.ProgressDeadlineSeconds = ptr.To(int32(10))
+		return mgr.DownstreamClient.Update(ctx, dep)
+	})
+	require.NoError(t, err)
+
+	// Resynthesize to guarantee that Eno has reconciled the resource after the mutation
+	err = retry.RetryOnConflict(testutil.Backoff, func() error {
+		upstream.Get(ctx, client.ObjectKeyFromObject(comp), comp)
+		comp.Spec.SynthesisEnv = []apiv1.EnvVar{{Name: "FORCE_SYNTHESIS", Value: "true"}}
+		return upstream.Update(ctx, comp)
+	})
+	require.NoError(t, err)
+
+	latestGen := comp.Generation
+	testutil.Eventually(t, func() bool {
+		err := upstream.Get(ctx, client.ObjectKeyFromObject(comp), comp)
+		return err == nil && comp.Status.CurrentSynthesis != nil && comp.Status.CurrentSynthesis.Ready != nil && comp.Status.CurrentSynthesis.ObservedCompositionGeneration >= latestGen
+	})
+
+	// Prove the field wasn't removed
+	testutil.Eventually(t, func() bool {
+		err := mgr.DownstreamClient.Get(ctx, client.ObjectKeyFromObject(dep), dep)
+		return err == nil && dep.Spec.ProgressDeadlineSeconds != nil && *dep.Spec.ProgressDeadlineSeconds == 10
 	})
 }
 

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -14,6 +14,7 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/go-logr/logr/testr"
 	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
@@ -169,6 +170,7 @@ func NewManager(t *testing.T, testOpts ...TestManagerOption) *Manager {
 	mgr, err := manager.NewTest(logr.FromContextOrDiscard(NewContext(t)), options)
 	require.NoError(t, err)
 	require.NoError(t, testv1.SchemeBuilder.AddToScheme(mgr.GetScheme())) // test-specific CRDs
+	require.NoError(t, appsv1.SchemeBuilder.AddToScheme(mgr.GetScheme()))
 
 	m := &Manager{
 		Manager:              mgr,


### PR DESCRIPTION
Resources that are modified by other clients will not currently work correctly when `--disable-ssa` is set because it computes the merge patch based on the current state - not the previous. So any properties set outside of Eno will be removed during reconciliation.

This fixes the bug by doing `s/current/previous/g` and adds smoke test coverage.