### PR TITLE
Fix ownership backfill race

### DIFF
--- a/internal/controllers/reconciliation/controller.go
+++ b/internal/controllers/reconciliation/controller.go
@@ -232,29 +232,15 @@ func (c *Controller) reconcileResource(ctx context.Context, comp *apiv1.Composit
 
 		// When using server side apply, make sure we haven't lost any managedFields metadata.
 		// Eno should always remove fields that are no longer set by the synthesizer, even if another client messed with managedFields.
-		if current != nil && !res.Replace {
-			var dryRunPrev *unstructured.Unstructured
-			if prev != nil {
-				dryRunPrev = prev.Unstructured()
-				err = c.upstreamClient.Patch(ctx, dryRunPrev, client.Apply, client.ForceOwnership, client.FieldOwner("eno"), client.DryRunAll)
-				if err != nil {
-					return false, fmt.Errorf("getting managed fields values for previous version: %w", err)
-				}
+		if current != nil && prev != nil && !res.Replace {
+			dryRunPrev := prev.Unstructured()
+			err := c.upstreamClient.Patch(ctx, dryRunPrev, client.Apply, client.ForceOwnership, client.FieldOwner("eno"), client.DryRunAll)
+			if err != nil {
+				return false, fmt.Errorf("getting managed fields values for previous version: %w", err)
 			}
 
-			outOfSyncWithPrevious := dryRunPrev != nil && !resource.CompareEnoManagedFields(dryRunPrev.GetManagedFields(), current.GetManagedFields())
-			outOfSyncWithCurrent := !resource.CompareEnoManagedFields(dryRun.GetManagedFields(), current.GetManagedFields())
-
-			if (outOfSyncWithPrevious && outOfSyncWithCurrent) || (outOfSyncWithCurrent && dryRunPrev == nil) {
-				if dryRunPrev == nil {
-					current.SetManagedFields(
-						resource.MergeEnoManagedFields(
-							current.GetManagedFields(), dryRun.GetManagedFields()))
-				} else {
-					current.SetManagedFields(
-						resource.MergeEnoManagedFields(
-							current.GetManagedFields(), dryRunPrev.GetManagedFields()))
-				}
+			if !resource.CompareEnoManagedFields(dryRunPrev.GetManagedFields(), current.GetManagedFields()) {
+				current.SetManagedFields(resource.MergeEnoManagedFields(current.GetManagedFields(), dryRunPrev.GetManagedFields()))
 
 				err := c.upstreamClient.Update(ctx, current, client.FieldOwner("eno"))
 				if err != nil {

--- a/internal/resource/resource.go
+++ b/internal/resource/resource.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"hash/fnv"
 	"maps"
-	"reflect"
 	"slices"
 	"sort"
 	"strconv"
@@ -314,7 +313,7 @@ func CompareEnoManagedFields(a, b []metav1.ManagedFieldsEntry) bool {
 	if ai == -1 || ab == -1 {
 		return false
 	}
-	return reflect.DeepEqual(a[ai], b[ab])
+	return equality.Semantic.DeepEqual(a[ai], b[ab])
 }
 
 // Compare compares two unstructured resources while ignoring:
@@ -335,7 +334,7 @@ func Compare(a, b *unstructured.Unstructured) bool {
 	if !CompareEnoManagedFields(a.GetManagedFields(), b.GetManagedFields()) {
 		return false
 	}
-	return reflect.DeepEqual(stripInsignificantFields(a), stripInsignificantFields(b))
+	return equality.Semantic.DeepEqual(stripInsignificantFields(a), stripInsignificantFields(b))
 }
 
 func stripInsignificantFields(u *unstructured.Unstructured) *unstructured.Unstructured {


### PR DESCRIPTION
Currently Eno will attempt to backfill missing managedFields metadata by comparing the current value against a dryrun of applying the previous and next versions of the resource. This works for the previous state since the goal is to avoid removing properties without ensuring that they will be pruned properly. But it makes _zero_ sense for the next state - it may contain properties that haven't been applied yet.

Adding the managedFields early isn't inherently a bad idea, except that apiserver asynchronously prunes them. So _sometimes_ the values will be removed faster than Eno's retry interval, which effectively deadlocks reconciliation.

There isn't a good way to integration test this behavior, but I've run 10+ iterations of the integration tests and this fixes the most common flake.