### PR TITLE
Support slice types with AddCustomInputType

### DIFF
--- a/pkg/function/main.go
+++ b/pkg/function/main.go
@@ -104,7 +104,11 @@ func newInput(ir *InputReader, field reflect.Value) (*input, error) {
 
 	// Allocate values for nil pointers
 	if field.IsNil() {
-		field.Set(reflect.New(field.Type().Elem()))
+		if field.Kind() == reflect.Slice {
+			field.Set(reflect.MakeSlice(field.Type(), 0, 0))
+		} else {
+			field.Set(reflect.New(field.Type().Elem()))
+		}
 	}
 
 	// Pass through client.Object types


### PR DESCRIPTION
`AddCustomInputType` isn't currently able to allocate nil slices in input structs.