### PR TITLE
Don't compare timestamps when checking fix missing managedFields

### DIFF
--- a/internal/resource/resource.go
+++ b/internal/resource/resource.go
@@ -313,7 +313,7 @@ func CompareEnoManagedFields(a, b []metav1.ManagedFieldsEntry) bool {
 	if ai == -1 || ab == -1 {
 		return false
 	}
-	return equality.Semantic.DeepEqual(a[ai], b[ab])
+	return equality.Semantic.DeepEqual(a[ai].FieldsV1, b[ab].FieldsV1)
 }
 
 // Compare compares two unstructured resources while ignoring:

--- a/internal/resource/resource_test.go
+++ b/internal/resource/resource_test.go
@@ -328,36 +328,36 @@ func TestResourceOrdering(t *testing.T) {
 func TestManagedFields(t *testing.T) {
 	current := []metav1.ManagedFieldsEntry{
 		{
-			Manager:   "something-else",
-			Operation: "Update",
+			Manager:  "something-else",
+			FieldsV1: &metav1.FieldsV1{Raw: []byte("1")},
 		},
 		{
-			Manager:   "another-thing",
-			Operation: "Update",
+			Manager:  "another-thing",
+			FieldsV1: &metav1.FieldsV1{Raw: []byte("1")},
 		},
 		{
-			Manager:   "eno",
-			Operation: "Update",
+			Manager:  "eno",
+			FieldsV1: &metav1.FieldsV1{Raw: []byte("1")},
 		},
 	}
 	expected := []metav1.ManagedFieldsEntry{{
-		Manager:   "eno",
-		Operation: "Apply",
+		Manager:  "eno",
+		FieldsV1: &metav1.FieldsV1{Raw: []byte("2")},
 	}}
 
 	merged := MergeEnoManagedFields(current, expected)
 	assert.Equal(t, []metav1.ManagedFieldsEntry{
 		{
-			Manager:   "eno",
-			Operation: "Apply",
+			Manager:  "eno",
+			FieldsV1: &metav1.FieldsV1{Raw: []byte("2")},
 		},
 		{
-			Manager:   "something-else",
-			Operation: "Update",
+			Manager:  "something-else",
+			FieldsV1: &metav1.FieldsV1{Raw: []byte("1")},
 		},
 		{
-			Manager:   "another-thing",
-			Operation: "Update",
+			Manager:  "another-thing",
+			FieldsV1: &metav1.FieldsV1{Raw: []byte("1")},
 		},
 	}, merged)
 


### PR DESCRIPTION
Currently the `managedFields` metadata backfilling logic only works when the time between the last update to the managedFields and the current time (during reconciliation) is <1s. It was overlooked because the reconciliation controller is generally pretty fast - it's only an issue when apiserver is loaded down and slow to respond.

This PR fixes the bug by only comparing the fields themselves, which naturally excludes the last update timestamp from the comparison.