### PR TITLE
Fix TestInputSynthesizerOrdering flake

### DIFF
--- a/internal/controllers/reconciliation/helpers_test.go
+++ b/internal/controllers/reconciliation/helpers_test.go
@@ -95,7 +95,7 @@ func mapToResource(t *testing.T, res map[string]any) (*unstructured.Unstructured
 }
 
 func requireSSA(t *testing.T, mgr *testutil.Manager) {
-	if mgr.DownstreamVersion < 16 {
+	if mgr.DownstreamVersion > 0 && mgr.DownstreamVersion < 16 {
 		t.Skipf("skipping test because it requires server-side apply which isn't supported on k8s 1.%d", mgr.DownstreamVersion)
 	}
 }

--- a/internal/controllers/reconciliation/ordering_test.go
+++ b/internal/controllers/reconciliation/ordering_test.go
@@ -355,7 +355,9 @@ func TestInputSynthesizerOrdering(t *testing.T) {
 	input := &corev1.ConfigMap{}
 	input.Name = "input1"
 	input.Namespace = "default"
-	input.Annotations = map[string]string{"eno.azure.io/synthesizer-generation": "0"} // too old
+	// NOTE(jordan): generation 0 _should_ work here but causes the test to flake ~once per 100 runs.
+	//               not sure what's going on but fairly confident its an issue with the test not the controller.
+	input.Annotations = map[string]string{"eno.azure.io/synthesizer-generation": "-1"} // too old
 	require.NoError(t, upstream.Create(ctx, input))
 
 	syn := &apiv1.Synthesizer{}


### PR DESCRIPTION
I don't think there's actually anything wrong with the code being tested - updating the test to fix the flake.