### PR TITLE
Support partial reconciliation

### DIFF
--- a/docs/reconciliation.md
+++ b/docs/reconciliation.md
@@ -91,16 +91,23 @@ annotations:
     ]
 ```
 
+This is commonly used to make a subset of properties managed by Eno optional i.e. allow other clients to override them.
+For example:
+
+```json
+{ "path": "self.data.foo", "value": "default value", "condition": "!has(self.data.foo)" }
+```
+
 #### Path Expression Syntax
 
-Overrides use a jsonpath-esque syntax to target properties.
+Overrides use a CEL-like syntax to reference properties.
 
-- `/field/anotherfield`: Traverse object fields
-- `/field[2]`: Access array elements by index
-- `/field[*]`: Match all elements in an array
-- `/field[someKey="value"]`: Match array elements by a key-value pair
+- `field.anotherfield`: Traverse object fields
+- `field[2]`: Access array elements by index
+- `field[*]`: Match all elements in an array
+- `field[someKey="value"]`: Match array elements by a key-value pair
 
-Paths can be chained, e.g., `/field/anotherfield[2]/yetAnotherField`.
+Paths can be chained, e.g., `self.field.anotherfield[2].yetAnotherField`.
 If any segment of the path is nil or missing, the override will not be applied.
 
 ### Replace

--- a/docs/reconciliation.md
+++ b/docs/reconciliation.md
@@ -87,7 +87,7 @@ This allows Eno synthesizers to specify basic runtime behavior without requiring
 annotations:
   eno.azure.io/overrides: |
     [
-      { "path": "/self/data/foo", "value": "new conditional value", "condition": "self.data.bar == 'baz'" }
+      { "path": "self.data.foo", "value": "new conditional value", "condition": "self.data.bar == 'baz'" }
     ]
 ```
 

--- a/docs/reconciliation.md
+++ b/docs/reconciliation.md
@@ -87,7 +87,7 @@ This allows Eno synthesizers to specify basic runtime behavior without requiring
 annotations:
   eno.azure.io/overrides: |
     [
-      { "path": "/data/foo", "value": "new conditional value", "condition": "self.data.bar == 'baz'" }
+      { "path": "/self/data/foo", "value": "new conditional value", "condition": "self.data.bar == 'baz'" }
     ]
 ```
 

--- a/docs/reconciliation.md
+++ b/docs/reconciliation.md
@@ -73,6 +73,36 @@ annotations:
   eno.azure.io/disable-updates: "true"
 ```
 
+### Overrides
+
+Overrides let you modify specific fields of a resource during reconciliation.
+These modifications are applied on top of the synthesized resource and can be conditional.
+Conditions are CEL expressions that are evaluated against the current state of the resource at reconciliation time.
+
+This allows Eno synthesizers to specify basic runtime behavior without requiring resynthesis.
+
+> Overrides are applied during reconciliation, so in most cases they should be used alongside `eno.azure.io/reconcile-interval`.
+
+```yaml
+annotations:
+  eno.azure.io/overrides: |
+    [
+      { "path": "/data/foo", "value": "new conditional value", "condition": "self.data.bar == 'baz'" }
+    ]
+```
+
+#### Path Expression Syntax
+
+Overrides use a jsonpath-esque syntax to target properties.
+
+- `/field/anotherfield`: Traverse object fields
+- `/field[2]`: Access array elements by index
+- `/field[*]`: Match all elements in an array
+- `/field[someKey="value"]`: Match array elements by a key-value pair
+
+Paths can be chained, e.g., `/field/anotherfield[2]/yetAnotherField`.
+If any segment of the path is nil or missing, the override will not be applied.
+
 ### Replace
 
 Designating a resource to be replaced means that updates will use the normal update endpoint instead of server-side apply.

--- a/examples/104-overrides/example.yaml
+++ b/examples/104-overrides/example.yaml
@@ -1,0 +1,39 @@
+apiVersion: eno.azure.io/v1
+kind: Synthesizer
+metadata:
+  name: overrides-example
+spec:
+  image: docker.io/ubuntu:latest
+  command:
+  - /bin/bash
+  - -c
+  - |
+    echo '
+      {
+        "apiVersion":"config.kubernetes.io/v1",
+        "kind":"ResourceList",
+        "items":[
+          {
+            "apiVersion":"v1",
+            "data":{"someKey":"someVal"},
+            "kind":"ConfigMap",
+            "metadata":{
+              "name":"some-config",
+              "namespace": "default",
+              "annotations": {
+                "eno.azure.io/overrides": "[{ \"path\": \"self.data.someKey\", \"value\": \"overrideValue\", \"condition\": \"!has(self.data.disableOverrides)\" }]"
+              }
+            }
+          }
+        ]
+      }'
+---
+
+apiVersion: eno.azure.io/v1
+kind: Composition
+metadata:
+  name: overrides-example
+  namespace: default
+spec:
+  synthesizer:
+    name: overrides-example

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.24.0
 toolchain go1.24.3
 
 require (
+	github.com/alecthomas/participle/v2 v2.1.4
 	github.com/emirpasic/gods/v2 v2.0.0-alpha
 	github.com/evanphx/json-patch/v5 v5.9.11
 	github.com/go-logr/logr v1.4.3

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,11 @@
 cel.dev/expr v0.23.1 h1:K4KOtPCJQjVggkARsjG9RWXP6O4R73aHeJMa/dmCQQg=
 cel.dev/expr v0.23.1/go.mod h1:hLPLo1W4QUmuYdA72RBX06QTs6MXw941piREPl3Yfiw=
+github.com/alecthomas/assert/v2 v2.11.0 h1:2Q9r3ki8+JYXvGsDyBXwH3LcJ+WK5D0gc5E8vS6K3D0=
+github.com/alecthomas/assert/v2 v2.11.0/go.mod h1:Bze95FyfUr7x34QZrjL+XP+0qgp/zg8yS+TtBj1WA3k=
+github.com/alecthomas/participle/v2 v2.1.4 h1:W/H79S8Sat/krZ3el6sQMvMaahJ+XcM9WSI2naI7w2U=
+github.com/alecthomas/participle/v2 v2.1.4/go.mod h1:8tqVbpTX20Ru4NfYQgZf4mP18eXPTBViyMWiArNEgGI=
+github.com/alecthomas/repr v0.4.0 h1:GhI2A8MACjfegCPVq9f1FLvIBS+DrQ2KQBFZP1iFzXc=
+github.com/alecthomas/repr v0.4.0/go.mod h1:Fr0507jx4eOXV7AlPV6AVZLYrLIuIeSOWtW57eE/O/4=
 github.com/antlr4-go/antlr/v4 v4.13.1 h1:SqQKkuVZ+zWkMMNkjy5FZe5mr5WURWnlpmOuzYWrPrQ=
 github.com/antlr4-go/antlr/v4 v4.13.1/go.mod h1:GKmUxMtwp6ZgGwZSva4eWPC5mS6vUAmOABFgjdkM7Nw=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
@@ -54,6 +60,8 @@ github.com/google/pprof v0.0.0-20241210010833-40e02aabc2ad h1:a6HEuzUHeKH6hwfN/Z
 github.com/google/pprof v0.0.0-20241210010833-40e02aabc2ad/go.mod h1:vavhavw2zAxS5dIdcRluK6cSGGPlZynqzFM8NdvU144=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUqJM=
+github.com/hexops/gotextdiff v1.0.3/go.mod h1:pSWU5MAI3yDq+fZBTazCSJysOMbxWL1BSow5/V2vxeg=
 github.com/imdario/mergo v0.3.16 h1:wwQJbIsHYGMUyLSPrEq1CT16AhnhNJQ51+4fdHUnCl4=
 github.com/imdario/mergo v0.3.16/go.mod h1:WBLT9ZmE3lPoWsEzCh9LPo3TiwVN+ZKEjmz+hD27ysY=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=

--- a/go.work.sum
+++ b/go.work.sum
@@ -455,6 +455,7 @@ github.com/Microsoft/go-winio v0.4.17-0.20210211115548-6eac466e5fa3/go.mod h1:JP
 github.com/Microsoft/go-winio v0.4.17-0.20210324224401-5516f17a5958/go.mod h1:JPGBdM1cNvN/6ISo+n8V5iA4v8pBzdOpzfwIujj1a84=
 github.com/Microsoft/go-winio v0.4.17/go.mod h1:JPGBdM1cNvN/6ISo+n8V5iA4v8pBzdOpzfwIujj1a84=
 github.com/Microsoft/go-winio v0.5.1/go.mod h1:JPGBdM1cNvN/6ISo+n8V5iA4v8pBzdOpzfwIujj1a84=
+github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/Microsoft/hcsshim v0.8.6/go.mod h1:Op3hHsoHPAvb6lceZHDtd9OkTew38wNoXnJs8iY7rUg=
 github.com/Microsoft/hcsshim v0.8.7-0.20190325164909-8abdbb8205e4/go.mod h1:Op3hHsoHPAvb6lceZHDtd9OkTew38wNoXnJs8iY7rUg=
 github.com/Microsoft/hcsshim v0.8.7/go.mod h1:OHd7sQqRFrYd3RmSgbgji+ctCwkbq2wbEYNSzOYtcBQ=
@@ -467,6 +468,7 @@ github.com/Microsoft/hcsshim v0.8.21/go.mod h1:+w2gRZ5ReXQhFOrvSQeNfhrYB/dg3oDwT
 github.com/Microsoft/hcsshim v0.8.23/go.mod h1:4zegtUJth7lAvFyc6cH2gGQ5B3OFQim01nnU2M8jKDg=
 github.com/Microsoft/hcsshim v0.9.2/go.mod h1:7pLA8lDk46WKDWlVsENo92gC0XFa8rbKfyFRBqxEbCc=
 github.com/Microsoft/hcsshim v0.9.3/go.mod h1:7pLA8lDk46WKDWlVsENo92gC0XFa8rbKfyFRBqxEbCc=
+github.com/Microsoft/hcsshim v0.11.7/go.mod h1:MV8xMfmECjl5HdO7U/3/hFVnkmSBjAjmA09d4bExKcU=
 github.com/Microsoft/hcsshim/test v0.0.0-20201218223536-d3e5debf77da/go.mod h1:5hlzMzRKMLyo42nCZ9oml8AdTlq/0cvIaBv6tK1RehU=
 github.com/Microsoft/hcsshim/test v0.0.0-20210227013316-43a75bb4edd3 h1:4FA+QBaydEHlwxg0lMN3rhwoDaQy6LKhVWR4qvq4BuA=
 github.com/Microsoft/hcsshim/test v0.0.0-20210227013316-43a75bb4edd3/go.mod h1:mw7qgWloBUl75W/gVH3cQszUg1+gUITj7D6NY7ywVnY=
@@ -639,6 +641,7 @@ github.com/containerd/cgroups v0.0.0-20200824123100-0b889c03f102/go.mod h1:s5q4S
 github.com/containerd/cgroups v0.0.0-20210114181951-8a68de567b68/go.mod h1:ZJeTFisyysqgcCdecO57Dj79RfL0LNeGiFUqLYQRYLE=
 github.com/containerd/cgroups v1.0.1/go.mod h1:0SJrPIenamHDcZhEcJMNBB85rHcUsw4f25ZfBiPYRkU=
 github.com/containerd/cgroups v1.0.3/go.mod h1:/ofk34relqNjSGyqPrmEULrO4Sc8LJhvJmWbUCUKqj8=
+github.com/containerd/cgroups v1.1.0/go.mod h1:6ppBcbh/NOOUU+dMKrykgaBnK9lCIBxHqJDGwsa1mIw=
 github.com/containerd/cgroups/v3 v3.0.2 h1:f5WFqIVSgo5IZmtTT3qVBo6TzI1ON6sycSBKkymb9L0=
 github.com/containerd/cgroups/v3 v3.0.2/go.mod h1:JUgITrzdFqp42uI2ryGA+ge0ap/nxzYgkGmIcetmErE=
 github.com/containerd/console v0.0.0-20180822173158-c12b1e7919c1/go.mod h1:Tj/on1eG8kiEhd0+fhSDzsPAFESxzBBvdyEgyryXffw=
@@ -1023,6 +1026,7 @@ github.com/golang/groupcache v0.0.0-20190129154638-5b532d6fd5ef/go.mod h1:cIg4er
 github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20191227052852-215e87163ea7/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
+github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
 github.com/golang/mock v1.2.0/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
 github.com/golang/mock v1.3.1/go.mod h1:sBzyDLLjw3U8JLTeZvSv8jJB+tU5PVekmnlKIyFUx0Y=
@@ -1222,6 +1226,7 @@ github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/julienschmidt/httprouter v1.3.0 h1:U0609e9tgbseu3rBINet9P48AI/D3oJs4dN7jwJOQ1U=
 github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
+github.com/keybase/go-keychain v0.0.1/go.mod h1:PdEILRW3i9D8JcdM+FmY6RwkHGnhHxXwkPPMeUgOK1k=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/errcheck v1.5.0 h1:e8esj/e4R+SAOwFwN+n3zr0nYeCyeweozKfO23MvHzY=
@@ -1516,6 +1521,7 @@ github.com/rogpeppe/go-internal v1.10.0/go.mod h1:UQnix2H7Ngw/k4C5ijL5+65zddjncj
 github.com/rogpeppe/go-internal v1.11.0/go.mod h1:ddIwULY96R17DhadqLgMfk9H9tvdUzkipdSkR5nkCZA=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
 github.com/russross/blackfriday v1.6.0 h1:KqfZb0pUVN2lYqZUYRddxF4OR8ZMURnJIG5Y3VRLtww=
+github.com/russross/blackfriday v1.6.0/go.mod h1:ti0ldHuxg49ri4ksnFxlkCfN+hvslNlmVHqNRXXJNAY=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f h1:UFr9zpz4xgTnIE5yIMtWAMngCdZ9p/+q6lTbgelo80M=
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
@@ -1523,6 +1529,7 @@ github.com/safchain/ethtool v0.0.0-20190326074333-42ed695e3de8/go.mod h1:Z0q5wiB
 github.com/safchain/ethtool v0.0.0-20210803160452-9aa261dae9b1/go.mod h1:Z0q5wiBQGYcxhMZ6gUqHn6pYNLypFAvaL3UvgZLR0U4=
 github.com/safchain/ethtool v0.2.0 h1:dILxMBqDnQfX192cCAPjZr9v2IgVXeElHPy435Z/IdE=
 github.com/safchain/ethtool v0.2.0/go.mod h1:WkKB1DnNtvsMlDmQ50sgwowDJV/hGbJSOvJoEXs1AJQ=
+github.com/santhosh-tekuri/jsonschema/v5 v5.3.1/go.mod h1:uToXkOrWAZ6/Oc07xWQrPOhJotwFIyu2bBVN41fcDUY=
 github.com/satori/go.uuid v1.2.0 h1:0uYX9dsZ2yD7q2RtLRtPSdGDWzjeM3TbMJP9utgA0ww=
 github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
 github.com/sclevine/agouti v3.0.0+incompatible h1:8IBJS6PWz3uTlMP3YBIR5f+KAldcGuOeFkFbUWfBgK4=
@@ -1717,6 +1724,7 @@ go.opencensus.io v0.22.3/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=
 go.opencensus.io v0.22.4/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=
 go.opencensus.io v0.22.5/go.mod h1:5pWMHQbX5EPX2/62yrJeAkowc+lfs/XD7Uxpq3pI6kk=
 go.opencensus.io v0.23.0/go.mod h1:XItmlyltB5F7CS4xOC1DcqMoFqwtC6OG2xF7mCv7P7E=
+go.opencensus.io v0.24.0/go.mod h1:vNK8G9p7aAivkbmorf4v+7Hgx+Zs0yY+0fOtgBfjQKo=
 go.opentelemetry.io/contrib v0.20.0 h1:ubFQUn0VCZ0gPwIoJfBJVpeBlyRMxu8Mm/huKWYd9p0=
 go.opentelemetry.io/contrib v0.20.0/go.mod h1:G/EtFaa6qaN7+LxqfIAT3GiZa7Wv5DTBUzl5H4LY0Kc=
 go.opentelemetry.io/contrib/detectors/gcp v1.34.0/go.mod h1:cV4BMFcscUR/ckqLkbfQmF0PRsq8w/lMGzdbCSveBHo=

--- a/internal/cel/cel.go
+++ b/internal/cel/cel.go
@@ -1,0 +1,37 @@
+package cel
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/cel-go/cel"
+	"github.com/google/cel-go/common/types/ref"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+var Env *cel.Env
+
+func init() {
+	initDefaultEnv()
+}
+
+func initDefaultEnv() {
+	var err error
+	Env, err = cel.NewEnv(cel.Variable("self", cel.DynType))
+	if err != nil {
+		panic(fmt.Sprintf("failed to create default CEL environment: %v", err))
+	}
+}
+
+func Parse(expr string) (cel.Program, error) {
+	ast, iss := Env.Compile(expr)
+	if iss != nil && iss.Err() != nil {
+		return nil, iss.Err()
+	}
+	return Env.Program(ast, cel.InterruptCheckFrequency(10))
+}
+
+func Eval(ctx context.Context, prgm cel.Program, self *unstructured.Unstructured) (ref.Val, error) {
+	val, _, err := prgm.Eval(map[string]any{"self": self.Object})
+	return val, err
+}

--- a/internal/controllers/reconciliation/controller_test.go
+++ b/internal/controllers/reconciliation/controller_test.go
@@ -95,7 +95,8 @@ func TestBuildNonStrategicPatch_NilPrevious(t *testing.T) {
 	// Patch
 	expected := actual.DeepCopy()
 	expected.Data = map[string]string{"added": "value"}
-	patch:= buildNonStrategicPatch(nil)
+	patch, err := buildNonStrategicPatch(ctx, nil, nil)
+	require.NoError(t, err)
 	require.NoError(t, cli.Patch(ctx, expected, patch))
 
 	// Verify

--- a/internal/controllers/reconciliation/controller_test.go
+++ b/internal/controllers/reconciliation/controller_test.go
@@ -95,7 +95,7 @@ func TestBuildNonStrategicPatch_NilPrevious(t *testing.T) {
 	// Patch
 	expected := actual.DeepCopy()
 	expected.Data = map[string]string{"added": "value"}
-	patch := buildNonStrategicPatch(nil)
+	patch:= buildNonStrategicPatch(nil)
 	require.NoError(t, cli.Patch(ctx, expected, patch))
 
 	// Verify

--- a/internal/controllers/reconciliation/overrides_test.go
+++ b/internal/controllers/reconciliation/overrides_test.go
@@ -1,0 +1,82 @@
+package reconciliation
+
+import (
+	"context"
+	"testing"
+
+	apiv1 "github.com/Azure/eno/api/v1"
+	"github.com/Azure/eno/internal/testutil"
+	krmv1 "github.com/Azure/eno/pkg/krm/functions/api/v1"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/client-go/util/retry"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func TestOverrideBasics(t *testing.T) {
+	ctx := testutil.NewContext(t)
+	mgr := testutil.NewManager(t)
+	upstream := mgr.GetClient()
+
+	registerControllers(t, mgr)
+	testutil.WithFakeExecutor(t, mgr, func(ctx context.Context, s *apiv1.Synthesizer, input *krmv1.ResourceList) (*krmv1.ResourceList, error) {
+		output := &krmv1.ResourceList{}
+		output.Items = []*unstructured.Unstructured{{
+			Object: map[string]any{
+				"apiVersion": "v1",
+				"kind":       "ConfigMap",
+				"metadata": map[string]any{
+					"name":      "test-obj",
+					"namespace": "default",
+					"annotations": map[string]any{
+						"eno.azure.io/overrides": `[{"path": "self.data.foo", "value": "eno-value", "condition": "!has(self.data.foo)"}]`,
+					},
+				},
+				"data": map[string]any{"foo": "eno-value"},
+			},
+		}}
+		return output, nil
+	})
+
+	setupTestSubject(t, mgr)
+	mgr.Start(t)
+	_, comp := writeGenericComposition(t, upstream)
+
+	// Wait for initial reconciliation
+	testutil.Eventually(t, func() bool {
+		return upstream.Get(ctx, client.ObjectKeyFromObject(comp), comp) == nil && comp.Status.CurrentSynthesis != nil && comp.Status.CurrentSynthesis.Ready != nil
+	})
+
+	// Simulate another client setting the field to a different value
+	cm := &corev1.ConfigMap{}
+	cm.Name = "test-obj"
+	cm.Namespace = "default"
+	err := retry.RetryOnConflict(testutil.Backoff, func() error {
+		err := mgr.DownstreamClient.Get(ctx, client.ObjectKeyFromObject(cm), cm)
+		if err != nil {
+			return err
+		}
+		cm.Data["foo"] = "external-value"
+		return mgr.DownstreamClient.Update(ctx, cm)
+	})
+	require.NoError(t, err)
+
+	// Resynthesize to trigger reconciliation
+	err = retry.RetryOnConflict(testutil.Backoff, func() error {
+		upstream.Get(ctx, client.ObjectKeyFromObject(comp), comp)
+		comp.Spec.SynthesisEnv = []apiv1.EnvVar{{Name: "FORCE_SYNTHESIS", Value: "true"}}
+		return upstream.Update(ctx, comp)
+	})
+	require.NoError(t, err)
+
+	testutil.Eventually(t, func() bool {
+		return upstream.Get(ctx, client.ObjectKeyFromObject(comp), comp) == nil && comp.Status.CurrentSynthesis != nil && comp.Status.CurrentSynthesis.Ready != nil
+	})
+
+	// The external value should still be present
+	testutil.Eventually(t, func() bool {
+		mgr.DownstreamClient.Get(ctx, client.ObjectKeyFromObject(cm), cm)
+		return cm.Data["foo"] == "external-value"
+	})
+}

--- a/internal/controllers/reconciliation/overrides_test.go
+++ b/internal/controllers/reconciliation/overrides_test.go
@@ -185,3 +185,47 @@ func TestOverridePrecedence(t *testing.T) {
 		return cm.Data["foo"] == "value-3"
 	})
 }
+
+func TestOverrideObject(t *testing.T) {
+	ctx := testutil.NewContext(t)
+	mgr := testutil.NewManager(t)
+	upstream := mgr.GetClient()
+
+	registerControllers(t, mgr)
+	testutil.WithFakeExecutor(t, mgr, func(ctx context.Context, s *apiv1.Synthesizer, input *krmv1.ResourceList) (*krmv1.ResourceList, error) {
+		output := &krmv1.ResourceList{}
+		output.Items = []*unstructured.Unstructured{{
+			Object: map[string]any{
+				"apiVersion": "v1",
+				"kind":       "ConfigMap",
+				"metadata": map[string]any{
+					"name":      "test-obj",
+					"namespace": "default",
+					"annotations": map[string]any{
+						"eno.azure.io/overrides": `[
+							{"path": "self.data", "value": {"foo": "val-1", "bar": "val-2"}}
+						]`,
+					},
+				},
+				"data": map[string]any{"baz": "not the value"},
+			},
+		}}
+		return output, nil
+	})
+
+	setupTestSubject(t, mgr)
+	mgr.Start(t)
+	_, comp := writeGenericComposition(t, upstream)
+
+	testutil.Eventually(t, func() bool {
+		return upstream.Get(ctx, client.ObjectKeyFromObject(comp), comp) == nil && comp.Status.CurrentSynthesis != nil && comp.Status.CurrentSynthesis.Ready != nil
+	})
+
+	cm := &corev1.ConfigMap{}
+	cm.Name = "test-obj"
+	cm.Namespace = "default"
+	testutil.Eventually(t, func() bool {
+		mgr.DownstreamClient.Get(ctx, client.ObjectKeyFromObject(cm), cm)
+		return cm.Data["foo"] == "val-1" && cm.Data["bar"] == "val-2" && cm.Data["baz"] == ""
+	})
+}

--- a/internal/readiness/readiness_test.go
+++ b/internal/readiness/readiness_test.go
@@ -283,7 +283,6 @@ func TestTimeouts(t *testing.T) {
 }
 
 func mustParse(expr string) *Check {
-	initDefaultEnv() // it's possible that the tests variables are evaluated before the init function is called
 	check, err := ParseCheck(expr)
 	if err != nil {
 		panic(err)

--- a/internal/resource/mutation/mutation.go
+++ b/internal/resource/mutation/mutation.go
@@ -51,8 +51,8 @@ func (o *Op) UnmarshalJSON(data []byte) error {
 
 // Apply applies the operation to the "mutated" object if the condition is met by the "current" object.
 func (o *Op) Apply(ctx context.Context, current, mutated *unstructured.Unstructured) error {
-	if current == nil {
-		return nil // nothing to do
+	if current == nil && o.Condition != nil {
+		return nil // impossible condition
 	}
 
 	if o.Condition != nil {

--- a/internal/resource/mutation/mutation.go
+++ b/internal/resource/mutation/mutation.go
@@ -51,6 +51,10 @@ func (o *Op) UnmarshalJSON(data []byte) error {
 
 // Apply applies the operation to the "mutated" object if the condition is met by the "current" object.
 func (o *Op) Apply(ctx context.Context, current, mutated *unstructured.Unstructured) error {
+	if current == nil {
+		return nil // nothing to do
+	}
+
 	if o.Condition != nil {
 		val, err := enocel.Eval(ctx, o.Condition, current)
 		if err != nil {

--- a/internal/resource/mutation/mutation.go
+++ b/internal/resource/mutation/mutation.go
@@ -140,7 +140,10 @@ func apply(path *PathExpr, startIndex int, obj any, value any) error {
 			}
 
 			if isMap && startIndex+i < len(path.ast.Sections)-1 {
-				apply(path, i+1, cur, value) // recurse into object
+				err := apply(path, i+1, cur, value) // recurse into object
+				if err != nil {
+					return err
+				}
 				continue
 			}
 			slice[j] = value

--- a/internal/resource/mutation/mutation.go
+++ b/internal/resource/mutation/mutation.go
@@ -67,6 +67,11 @@ func (o *Op) Apply(ctx context.Context, current, mutated *unstructured.Unstructu
 // Apply applies a mutation i.e. sets the value(s) referred to by the path expression.
 // Missing or nil values in the path will not be created, and will cause an error.
 func Apply(path *PathExpr, obj, value any) error {
+	if s := path.ast.Sections; len(s) == 0 || s[0].Field == nil || *s[0].Field != "self" {
+		return fmt.Errorf("cannot apply mutation to non-self path")
+	}
+	path.ast.Sections = path.ast.Sections[1:] // remove the "self" section
+
 	return apply(path, 0, obj, value)
 }
 

--- a/internal/resource/mutation/mutation.go
+++ b/internal/resource/mutation/mutation.go
@@ -1,0 +1,141 @@
+package mutation
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strconv"
+
+	"github.com/google/cel-go/cel"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	enocel "github.com/Azure/eno/internal/cel"
+)
+
+// Op is an operation that conditionally assigns a value to a path within an object.
+// Designed to be sent over the wire as JSON.
+type Op struct {
+	Path      *PathExpr
+	Condition cel.Program
+	Value     any
+}
+
+type jsonOp struct {
+	Path      string `json:"path"`
+	Condition string `json:"condition"`
+	Value     any    `json:"value"`
+}
+
+func (o *Op) UnmarshalJSON(data []byte) error {
+	var j jsonOp
+	err := json.Unmarshal(data, &j)
+	if err != nil {
+		return err
+	}
+	o.Value = j.Value
+
+	o.Path, err = ParsePathExpr(j.Path)
+	if err != nil {
+		return fmt.Errorf("parsing path: %w", err)
+	}
+
+	if j.Condition != "" {
+		o.Condition, err = enocel.Parse(j.Condition)
+		if err != nil {
+			return fmt.Errorf("parsing condition: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// Apply applies the operation to the "mutated" object if the condition is met by the "current" object.
+func (o *Op) Apply(ctx context.Context, current, mutated *unstructured.Unstructured) error {
+	if o.Condition != nil {
+		val, err := enocel.Eval(ctx, o.Condition, current)
+		if err != nil {
+			return fmt.Errorf("evaluating condition: %w", err)
+		}
+		if b, ok := val.Value().(bool); !ok || !b {
+			return nil // condition not met
+		}
+	}
+
+	return Apply(o.Path, mutated.Object, o.Value)
+}
+
+// Apply applies a mutation i.e. sets the value(s) referred to by the path expression.
+// Missing or nil values in the path will not be created, and will cause an error.
+func Apply(path *PathExpr, obj, value any) error {
+	return apply(path, 0, obj, value)
+}
+
+func apply(path *PathExpr, startIndex int, obj any, value any) error {
+	state := obj
+
+	for i, section := range path.ast.Sections[startIndex:] {
+		// Map field indexing
+		if section.Field != nil {
+			m, ok := state.(map[string]any)
+			if !ok {
+				continue
+			}
+			if startIndex+i == len(path.ast.Sections)-1 {
+				m[*section.Field] = value
+				return nil
+			}
+			state = m[*section.Field]
+			continue
+		}
+
+		if section.Index == nil {
+			continue // should be impossible
+		}
+		slice, ok := state.([]any)
+		if !ok {
+			return fmt.Errorf("cannot apply wildcard to non-slice value")
+		}
+
+		// Simple array indexing
+		if el := section.Index.Element; el != nil {
+			if *el < 0 || *el >= len(slice) {
+				return fmt.Errorf("index %d out of range for slice of length %d", *el, len(slice))
+			}
+			if startIndex+i == len(path.ast.Sections)-1 {
+				slice[*el] = value
+				return nil
+			}
+			state = slice[*el]
+			continue
+		}
+
+		// Complex array indexing (wildcard or matcher)
+		if !section.Index.Wildcard && section.Index.Matcher == nil {
+			continue // should be impossible
+		}
+		for j, cur := range slice {
+			m, isMap := cur.(map[string]any)
+
+			if section.Index.Matcher != nil {
+				if !isMap {
+					continue // can't apply matcher to non-map value
+				}
+				val := m[section.Index.Matcher.Key]
+				str, ok := val.(string)
+				expected, _ := strconv.Unquote(section.Index.Matcher.Value)
+				if !ok || str != expected {
+					continue // not matched by the matcher
+				}
+			}
+
+			if isMap && startIndex+i < len(path.ast.Sections)-1 {
+				apply(path, i+1, cur, value) // recurse into object
+				continue
+			}
+			slice[j] = value
+		}
+		break
+	}
+
+	return nil
+}

--- a/internal/resource/mutation/mutation_test.go
+++ b/internal/resource/mutation/mutation_test.go
@@ -87,6 +87,15 @@ func TestApply(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "Slice_WildcardAndOutOfRange",
+			path: "self.foo[*][123]",
+			obj: map[string]any{"foo": []any{
+				map[string]any{"name": "test-2"},
+				map[string]any{"name": 234},
+			}},
+			wantErr: true,
+		},
+		{
 			name: "Slice_MapMatcher",
 			path: "self.foo[name=\"test-1\"].bar",
 			obj: map[string]any{"foo": []any{

--- a/internal/resource/mutation/mutation_test.go
+++ b/internal/resource/mutation/mutation_test.go
@@ -18,77 +18,77 @@ func TestApply(t *testing.T) {
 	}{
 		{
 			name:     "Map_TopLevel",
-			path:     "/foo",
+			path:     "/self/foo",
 			obj:      map[string]any{},
 			value:    123,
 			expected: map[string]any{"foo": 123},
 		},
 		{
 			name:     "Map_Nested",
-			path:     "/foo/bar",
+			path:     "/self/foo/bar",
 			obj:      map[string]any{"foo": map[string]any{}, "another": "baz"},
 			value:    123,
 			expected: map[string]any{"foo": map[string]any{"bar": 123}, "another": "baz"},
 		},
 		{
 			name:     "Map_NestedNil",
-			path:     "/foo/bar",
+			path:     "/self/foo/bar",
 			obj:      map[string]any{"foo": nil, "another": "baz"},
 			value:    123,
 			expected: map[string]any{"foo": nil, "another": "baz"},
 		},
 		{
 			name:     "Map_NestedMissing",
-			path:     "/foo/bar",
+			path:     "/self/foo/bar",
 			obj:      map[string]any{"another": "baz"},
 			value:    123,
 			expected: map[string]any{"another": "baz"},
 		},
 		{
 			name:     "Slice_ScalarIndex",
-			path:     "/foo[1]",
+			path:     "/self/foo[1]",
 			obj:      map[string]any{"foo": []any{1, 2, 3}},
 			value:    123,
 			expected: map[string]any{"foo": []any{1, 123, 3}},
 		},
 		{
 			name:    "Slice_ScalarIndexOutOfRange",
-			path:    "/foo[9001]",
+			path:    "/self/foo[9001]",
 			obj:     map[string]any{"foo": []any{1, 2, 3}},
 			value:   123,
 			wantErr: true,
 		},
 		{
 			name:     "Slice_NestedMap",
-			path:     "/foo[0]/bar",
+			path:     "/self/foo[0]/bar",
 			obj:      map[string]any{"foo": []any{map[string]any{"bar": 1}, map[string]any{"bar": 2}, map[string]any{"bar": 3}}},
 			value:    123,
 			expected: map[string]any{"foo": []any{map[string]any{"bar": 123}, map[string]any{"bar": 2}, map[string]any{"bar": 3}}},
 		},
 		{
 			name:     "Slice_ScalarWildcard",
-			path:     "/foo[*]",
+			path:     "/self/foo[*]",
 			obj:      map[string]any{"foo": []any{1, 2, 3}},
 			value:    123,
 			expected: map[string]any{"foo": []any{123, 123, 123}},
 		},
 		{
 			name:     "Slice_MapWildcard",
-			path:     "/foo[*]/bar",
+			path:     "/self/foo[*]/bar",
 			obj:      map[string]any{"foo": []any{map[string]any{"bar": 1}, map[string]any{"bar": 2}, map[string]any{"bar": 3}}},
 			value:    123,
 			expected: map[string]any{"foo": []any{map[string]any{"bar": 123}, map[string]any{"bar": 123}, map[string]any{"bar": 123}}},
 		},
 		{
 			name:    "Slice_NonMapWildcard",
-			path:    "/foo[*]",
+			path:    "/self/foo[*]",
 			obj:     map[string]any{"foo": 1},
 			value:   123,
 			wantErr: true,
 		},
 		{
 			name: "Slice_MapMatcher",
-			path: `/foo[name="test-1"]/bar`,
+			path: `/self/foo[name="test-1"]/bar`,
 			obj: map[string]any{"foo": []any{
 				map[string]any{"name": "test-2"},
 				map[string]any{"name": "test-1"},
@@ -110,7 +110,7 @@ func TestApply(t *testing.T) {
 
 		{
 			name: "Slice_MapMatcherEscapedQuote",
-			path: `/foo[name="test-\"-1"]/bar`,
+			path: `/self/foo[name="test-\"-1"]/bar`,
 			obj: map[string]any{"foo": []any{
 				map[string]any{"name": "test-2"},
 				map[string]any{"name": `test-"-1`},
@@ -125,7 +125,7 @@ func TestApply(t *testing.T) {
 		},
 		{
 			name: "Slice_MapMatcherScalarAssignment",
-			path: `/foo[name="test-1"]`,
+			path: `/self/foo[name="test-1"]`,
 			obj: map[string]any{"foo": []any{
 				map[string]any{"name": "test-2"},
 				map[string]any{"name": `test-1`},
@@ -140,7 +140,7 @@ func TestApply(t *testing.T) {
 		},
 		{
 			name: "Slice_MapMatcherMissing",
-			path: `/foo[name="test-1"]/bar`,
+			path: `/self/foo[name="test-1"]/bar`,
 			obj: map[string]any{"foo": []any{
 				map[string]any{"name": "test-2"},
 				map[string]any{"name": 234},
@@ -152,8 +152,13 @@ func TestApply(t *testing.T) {
 			}},
 		},
 		{
-			name:     "Empty",
-			path:     "",
+			name:    "Empty",
+			path:    "",
+			wantErr: true,
+		},
+		{
+			name:     "Root",
+			path:     "/self",
 			obj:      map[string]any{},
 			value:    123,
 			expected: map[string]any{},

--- a/internal/resource/mutation/mutation_test.go
+++ b/internal/resource/mutation/mutation_test.go
@@ -18,77 +18,77 @@ func TestApply(t *testing.T) {
 	}{
 		{
 			name:     "Map_TopLevel",
-			path:     "/self/foo",
+			path:     "self.foo",
 			obj:      map[string]any{},
 			value:    123,
 			expected: map[string]any{"foo": 123},
 		},
 		{
 			name:     "Map_Nested",
-			path:     "/self/foo/bar",
+			path:     "self.foo.bar",
 			obj:      map[string]any{"foo": map[string]any{}, "another": "baz"},
 			value:    123,
 			expected: map[string]any{"foo": map[string]any{"bar": 123}, "another": "baz"},
 		},
 		{
 			name:     "Map_NestedNil",
-			path:     "/self/foo/bar",
+			path:     "self.foo.bar",
 			obj:      map[string]any{"foo": nil, "another": "baz"},
 			value:    123,
 			expected: map[string]any{"foo": nil, "another": "baz"},
 		},
 		{
 			name:     "Map_NestedMissing",
-			path:     "/self/foo/bar",
+			path:     "self.foo.bar",
 			obj:      map[string]any{"another": "baz"},
 			value:    123,
 			expected: map[string]any{"another": "baz"},
 		},
 		{
 			name:     "Slice_ScalarIndex",
-			path:     "/self/foo[1]",
+			path:     "self.foo[1]",
 			obj:      map[string]any{"foo": []any{1, 2, 3}},
 			value:    123,
 			expected: map[string]any{"foo": []any{1, 123, 3}},
 		},
 		{
 			name:    "Slice_ScalarIndexOutOfRange",
-			path:    "/self/foo[9001]",
+			path:    "self.foo[9001]",
 			obj:     map[string]any{"foo": []any{1, 2, 3}},
 			value:   123,
 			wantErr: true,
 		},
 		{
 			name:     "Slice_NestedMap",
-			path:     "/self/foo[0]/bar",
+			path:     "self.foo[0].bar",
 			obj:      map[string]any{"foo": []any{map[string]any{"bar": 1}, map[string]any{"bar": 2}, map[string]any{"bar": 3}}},
 			value:    123,
 			expected: map[string]any{"foo": []any{map[string]any{"bar": 123}, map[string]any{"bar": 2}, map[string]any{"bar": 3}}},
 		},
 		{
 			name:     "Slice_ScalarWildcard",
-			path:     "/self/foo[*]",
+			path:     "self.foo[*]",
 			obj:      map[string]any{"foo": []any{1, 2, 3}},
 			value:    123,
 			expected: map[string]any{"foo": []any{123, 123, 123}},
 		},
 		{
 			name:     "Slice_MapWildcard",
-			path:     "/self/foo[*]/bar",
+			path:     "self.foo[*].bar",
 			obj:      map[string]any{"foo": []any{map[string]any{"bar": 1}, map[string]any{"bar": 2}, map[string]any{"bar": 3}}},
 			value:    123,
 			expected: map[string]any{"foo": []any{map[string]any{"bar": 123}, map[string]any{"bar": 123}, map[string]any{"bar": 123}}},
 		},
 		{
 			name:    "Slice_NonMapWildcard",
-			path:    "/self/foo[*]",
+			path:    "self.foo[*]",
 			obj:     map[string]any{"foo": 1},
 			value:   123,
 			wantErr: true,
 		},
 		{
 			name: "Slice_MapMatcher",
-			path: `/self/foo[name="test-1"]/bar`,
+			path: "self.foo[name=\"test-1\"].bar",
 			obj: map[string]any{"foo": []any{
 				map[string]any{"name": "test-2"},
 				map[string]any{"name": "test-1"},
@@ -110,7 +110,7 @@ func TestApply(t *testing.T) {
 
 		{
 			name: "Slice_MapMatcherEscapedQuote",
-			path: `/self/foo[name="test-\"-1"]/bar`,
+			path: "self.foo[name=\"test-\\\"-1\"].bar",
 			obj: map[string]any{"foo": []any{
 				map[string]any{"name": "test-2"},
 				map[string]any{"name": `test-"-1`},
@@ -125,7 +125,7 @@ func TestApply(t *testing.T) {
 		},
 		{
 			name: "Slice_MapMatcherScalarAssignment",
-			path: `/self/foo[name="test-1"]`,
+			path: "self.foo[name=\"test-1\"]",
 			obj: map[string]any{"foo": []any{
 				map[string]any{"name": "test-2"},
 				map[string]any{"name": `test-1`},
@@ -140,7 +140,7 @@ func TestApply(t *testing.T) {
 		},
 		{
 			name: "Slice_MapMatcherMissing",
-			path: `/self/foo[name="test-1"]/bar`,
+			path: "self.foo[name=\"test-1\"].bar",
 			obj: map[string]any{"foo": []any{
 				map[string]any{"name": "test-2"},
 				map[string]any{"name": 234},
@@ -158,7 +158,7 @@ func TestApply(t *testing.T) {
 		},
 		{
 			name:     "Root",
-			path:     "/self",
+			path:     "self",
 			obj:      map[string]any{},
 			value:    123,
 			expected: map[string]any{},

--- a/internal/resource/mutation/mutation_test.go
+++ b/internal/resource/mutation/mutation_test.go
@@ -1,0 +1,178 @@
+package mutation
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestApply(t *testing.T) {
+	testCases := []struct {
+		name     string
+		path     string
+		obj      map[string]any
+		value    any
+		expected map[string]any
+		wantErr  bool
+	}{
+		{
+			name:     "Map_TopLevel",
+			path:     "/foo",
+			obj:      map[string]any{},
+			value:    123,
+			expected: map[string]any{"foo": 123},
+		},
+		{
+			name:     "Map_Nested",
+			path:     "/foo/bar",
+			obj:      map[string]any{"foo": map[string]any{}, "another": "baz"},
+			value:    123,
+			expected: map[string]any{"foo": map[string]any{"bar": 123}, "another": "baz"},
+		},
+		{
+			name:     "Map_NestedNil",
+			path:     "/foo/bar",
+			obj:      map[string]any{"foo": nil, "another": "baz"},
+			value:    123,
+			expected: map[string]any{"foo": nil, "another": "baz"},
+		},
+		{
+			name:     "Map_NestedMissing",
+			path:     "/foo/bar",
+			obj:      map[string]any{"another": "baz"},
+			value:    123,
+			expected: map[string]any{"another": "baz"},
+		},
+		{
+			name:     "Slice_ScalarIndex",
+			path:     "/foo[1]",
+			obj:      map[string]any{"foo": []any{1, 2, 3}},
+			value:    123,
+			expected: map[string]any{"foo": []any{1, 123, 3}},
+		},
+		{
+			name:    "Slice_ScalarIndexOutOfRange",
+			path:    "/foo[9001]",
+			obj:     map[string]any{"foo": []any{1, 2, 3}},
+			value:   123,
+			wantErr: true,
+		},
+		{
+			name:     "Slice_NestedMap",
+			path:     "/foo[0]/bar",
+			obj:      map[string]any{"foo": []any{map[string]any{"bar": 1}, map[string]any{"bar": 2}, map[string]any{"bar": 3}}},
+			value:    123,
+			expected: map[string]any{"foo": []any{map[string]any{"bar": 123}, map[string]any{"bar": 2}, map[string]any{"bar": 3}}},
+		},
+		{
+			name:     "Slice_ScalarWildcard",
+			path:     "/foo[*]",
+			obj:      map[string]any{"foo": []any{1, 2, 3}},
+			value:    123,
+			expected: map[string]any{"foo": []any{123, 123, 123}},
+		},
+		{
+			name:     "Slice_MapWildcard",
+			path:     "/foo[*]/bar",
+			obj:      map[string]any{"foo": []any{map[string]any{"bar": 1}, map[string]any{"bar": 2}, map[string]any{"bar": 3}}},
+			value:    123,
+			expected: map[string]any{"foo": []any{map[string]any{"bar": 123}, map[string]any{"bar": 123}, map[string]any{"bar": 123}}},
+		},
+		{
+			name:    "Slice_NonMapWildcard",
+			path:    "/foo[*]",
+			obj:     map[string]any{"foo": 1},
+			value:   123,
+			wantErr: true,
+		},
+		{
+			name: "Slice_MapMatcher",
+			path: `/foo[name="test-1"]/bar`,
+			obj: map[string]any{"foo": []any{
+				map[string]any{"name": "test-2"},
+				map[string]any{"name": "test-1"},
+				[]any{"string slice"},
+				9001,
+				true,
+				map[string]any{"name": 234},
+			}},
+			value: 123,
+			expected: map[string]any{"foo": []any{
+				map[string]any{"name": "test-2"},
+				map[string]any{"name": "test-1", "bar": 123},
+				[]any{"string slice"},
+				9001,
+				true,
+				map[string]any{"name": 234},
+			}},
+		},
+
+		{
+			name: "Slice_MapMatcherEscapedQuote",
+			path: `/foo[name="test-\"-1"]/bar`,
+			obj: map[string]any{"foo": []any{
+				map[string]any{"name": "test-2"},
+				map[string]any{"name": `test-"-1`},
+				map[string]any{"name": 234},
+			}},
+			value: 123,
+			expected: map[string]any{"foo": []any{
+				map[string]any{"name": "test-2"},
+				map[string]any{"name": `test-"-1`, "bar": 123},
+				map[string]any{"name": 234},
+			}},
+		},
+		{
+			name: "Slice_MapMatcherScalarAssignment",
+			path: `/foo[name="test-1"]`,
+			obj: map[string]any{"foo": []any{
+				map[string]any{"name": "test-2"},
+				map[string]any{"name": `test-1`},
+				map[string]any{"name": 234},
+			}},
+			value: 123,
+			expected: map[string]any{"foo": []any{
+				map[string]any{"name": "test-2"},
+				123,
+				map[string]any{"name": 234},
+			}},
+		},
+		{
+			name: "Slice_MapMatcherMissing",
+			path: `/foo[name="test-1"]/bar`,
+			obj: map[string]any{"foo": []any{
+				map[string]any{"name": "test-2"},
+				map[string]any{"name": 234},
+			}},
+			value: 123,
+			expected: map[string]any{"foo": []any{
+				map[string]any{"name": "test-2"},
+				map[string]any{"name": 234},
+			}},
+		},
+		{
+			name:     "Empty",
+			path:     "",
+			obj:      map[string]any{},
+			value:    123,
+			expected: map[string]any{},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			expr, err := ParsePathExpr(tc.path)
+			require.NoError(t, err)
+
+			err = Apply(expr, tc.obj, tc.value)
+
+			if tc.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tc.expected, tc.obj)
+			}
+		})
+	}
+}

--- a/internal/resource/mutation/parser.go
+++ b/internal/resource/mutation/parser.go
@@ -12,12 +12,12 @@ type PathExpr struct {
 // ParsePathExpr parses a path expression string.
 //
 // Supported syntax:
-// - `/field/anotherfield`: object field traversal
-// - `/field[2]`: array indexing
-// - `/field[*]`: array wildcards
-// - `/field[someKey="value"]`: object array field matchers
+// - `field.anotherfield`: object field traversal
+// - `field[2]`: array indexing
+// - `field[*]`: array wildcards
+// - `field[someKey="value"]`: object array field matchers
 //
-// Expressions can be chained, e.g. `/field/anotherfield[2]/yetAnotherField`.
+// Expressions can be chained, e.g. `field.anotherfield[2].yetAnotherField`.
 func ParsePathExpr(expr string) (*PathExpr, error) {
 	ast, err := parser.ParseString("", expr)
 	if err != nil {
@@ -33,7 +33,7 @@ type pathExprAST struct {
 }
 
 type section struct {
-	Field *string `"/"* (@Ident`
+	Field *string `"."* (@Ident`
 	Index *index  `| "[" @@ "]")`
 }
 

--- a/internal/resource/mutation/parser.go
+++ b/internal/resource/mutation/parser.go
@@ -1,0 +1,49 @@
+package mutation
+
+import (
+	"github.com/alecthomas/participle/v2"
+)
+
+// PathExpr represents an expression that can be used to access or modify values in a nested structure.
+type PathExpr struct {
+	ast *pathExprAST
+}
+
+// ParsePathExpr parses a path expression string.
+//
+// Supported syntax:
+// - `/field/anotherfield`: object field traversal
+// - `/field[2]`: array indexing
+// - `/field[*]`: array wildcards
+// - `/field[someKey="value"]`: object array field matchers
+//
+// Expressions can be chained, e.g. `/field/anotherfield[2]/yetAnotherField`.
+func ParsePathExpr(expr string) (*PathExpr, error) {
+	ast, err := parser.ParseString("", expr)
+	if err != nil {
+		return nil, err
+	}
+	return &PathExpr{ast: ast}, nil
+}
+
+var parser = participle.MustBuild[pathExprAST]()
+
+type pathExprAST struct {
+	Sections []*section `@@*`
+}
+
+type section struct {
+	Field *string `"/"* (@Ident`
+	Index *index  `| "[" @@ "]")`
+}
+
+type index struct {
+	Wildcard bool          `@"*"`
+	Element  *int          `| @Int`
+	Matcher  *indexMatcher `| @@`
+}
+
+type indexMatcher struct {
+	Key   string `@Ident "="`
+	Value string `@String`
+}

--- a/internal/resource/resource_test.go
+++ b/internal/resource/resource_test.go
@@ -40,7 +40,7 @@ var newResourceTests = []struct {
 					"eno.azure.io/readiness-test": "false",
 					"eno.azure.io/replace": "true",
 					"eno.azure.io/disable-updates": "true",
-					"eno.azure.io/overrides": "[{\"path\":\"/foo\"}, {\"path\":\"/bar\"}]"
+					"eno.azure.io/overrides": "[{\"path\":\".foo\"}, {\"path\":\".bar\"}]"
 				}
 			}
 		}`,

--- a/internal/resource/resource_test.go
+++ b/internal/resource/resource_test.go
@@ -39,7 +39,8 @@ var newResourceTests = []struct {
 					"eno.azure.io/readiness": "true",
 					"eno.azure.io/readiness-test": "false",
 					"eno.azure.io/replace": "true",
-					"eno.azure.io/disable-updates": "true"
+					"eno.azure.io/disable-updates": "true",
+					"eno.azure.io/overrides": "[{\"path\":\"/foo\"}, {\"path\":\"/bar\"}]"
 				}
 			}
 		}`,
@@ -56,6 +57,7 @@ var newResourceTests = []struct {
 			assert.True(t, r.DisableUpdates)
 			assert.True(t, r.Replace)
 			assert.Equal(t, int(250), r.ReadinessGroup)
+			assert.Len(t, r.Overrides, 2)
 		},
 	},
 	{
@@ -224,7 +226,7 @@ var newResourceTests = []struct {
 						"labels":      map[string]any{"test-label": "should not be pruned"},
 					},
 				},
-			}, r.Unstructured())
+			}, r.parsed)
 		},
 	},
 	{
@@ -251,7 +253,23 @@ var newResourceTests = []struct {
 						"name": "foo",
 					},
 				},
-			}, r.Unstructured())
+			}, r.parsed)
+		},
+	},
+	{
+		Name: "invalid-override-json",
+		Manifest: `{
+			"apiVersion": "v1",
+			"kind": "ConfigMap",
+			"metadata": {
+				"name": "foo",
+				"annotations": {
+					"eno.azure.io/overrides": "not json"
+				}
+			}
+		}`,
+		Assert: func(t *testing.T, r *Resource) {
+			assert.Len(t, r.Overrides, 0)
 		},
 	},
 	{
@@ -279,7 +297,7 @@ var newResourceTests = []struct {
 						},
 					},
 				},
-			}, r.Unstructured())
+			}, r.parsed)
 
 			assert.Equal(t, map[string]string{
 				"test-label":               "label-value",


### PR DESCRIPTION
Some synthesizers may need to allow other clients to modify fields they set. Rather than feedback the current state of every resource into the synthesizer (expensive, confusing), let's support a simple jsonpatch-style interface.