### PR TITLE
Introduce resource.Snapshot

### DIFF
--- a/internal/controllers/reconciliation/controller_test.go
+++ b/internal/controllers/reconciliation/controller_test.go
@@ -74,7 +74,7 @@ func TestRequeue(t *testing.T) {
 				minReconcileInterval:  tt.minReconcile,
 			}
 
-			result, err := c.requeue(logger, tt.comp, tt.resource, tt.ready)
+			result, err := c.requeue(logger, tt.comp, &resource.Snapshot{Resource: tt.resource}, tt.ready)
 			assert.NoError(t, err)
 			assert.InDelta(t, tt.expectedResult, result.RequeueAfter, float64(2*time.Second))
 		})

--- a/internal/resource/resource_test.go
+++ b/internal/resource/resource_test.go
@@ -134,9 +134,12 @@ var newResourceTests = []struct {
 			}
 		}`,
 		Assert: func(t *testing.T, r *Resource) {
+			rs, err := r.Snapshot(t.Context(), nil)
+			require.NoError(t, err)
+
 			assert.Equal(t, schema.GroupVersionKind{Version: "v1", Kind: "ConfigMap"}, r.GVK)
 			assert.Len(t, r.Patch, 1)
-			assert.False(t, r.patchSetsDeletionTimestamp())
+			assert.False(t, rs.patchSetsDeletionTimestamp())
 		},
 	},
 	{
@@ -157,9 +160,12 @@ var newResourceTests = []struct {
 			}
 		}`,
 		Assert: func(t *testing.T, r *Resource) {
+			rs, err := r.Snapshot(t.Context(), nil)
+			require.NoError(t, err)
+
 			assert.Equal(t, schema.GroupVersionKind{Version: "v1", Kind: "ConfigMap"}, r.GVK)
 			assert.Len(t, r.Patch, 1)
-			assert.True(t, r.patchSetsDeletionTimestamp())
+			assert.True(t, rs.patchSetsDeletionTimestamp())
 		},
 	},
 	{


### PR DESCRIPTION
Small refactor to enable an upcoming change.

The idea is to more explicitly capture the expected state of a resource at a particular point in (resourceVersion) time given its overrides. Currently we just apply the overrides when they're needed, which is surprisingly difficult to reason about and in some cases generates unnecessary garbage.