### PR TITLE
Add support for resource slice deletion grace period

### DIFF
--- a/internal/controllers/reconciliation/helpers_test.go
+++ b/internal/controllers/reconciliation/helpers_test.go
@@ -30,7 +30,7 @@ func registerControllers(t *testing.T, mgr *testutil.Manager) {
 	require.NoError(t, liveness.NewNamespaceController(mgr.Manager, 3, time.Second))
 	require.NoError(t, watch.NewController(mgr.Manager))
 	require.NoError(t, resourceslice.NewController(mgr.Manager))
-	require.NoError(t, resourceslice.NewCleanupController(mgr.Manager))
+	require.NoError(t, resourceslice.NewCleanupController(mgr.Manager, nil))
 	require.NoError(t, composition.NewController(mgr.Manager))
 	require.NoError(t, symphony.NewController(mgr.Manager))
 }

--- a/internal/controllers/resourceslice/integration_test.go
+++ b/internal/controllers/resourceslice/integration_test.go
@@ -20,7 +20,7 @@ func TestResourceSliceLifecycle(t *testing.T) {
 	mgr := testutil.NewManager(t)
 	cli := mgr.GetClient()
 
-	require.NoError(t, NewCleanupController(mgr.Manager))
+	require.NoError(t, NewCleanupController(mgr.Manager, nil))
 	require.NoError(t, NewController(mgr.Manager))
 	mgr.Start(t)
 

--- a/internal/controllers/synthesis/lifecycle_test.go
+++ b/internal/controllers/synthesis/lifecycle_test.go
@@ -46,7 +46,7 @@ func TestCompositionDeletion(t *testing.T) {
 	})
 
 	require.NoError(t, NewPodLifecycleController(mgr.Manager, minimalTestConfig))
-	require.NoError(t, resourceslice.NewCleanupController(mgr.Manager))
+	require.NoError(t, resourceslice.NewCleanupController(mgr.Manager, nil))
 	require.NoError(t, scheduling.NewController(mgr.Manager, 10, 2*time.Second, time.Second))
 	require.NoError(t, composition.NewController(mgr.Manager))
 	require.NoError(t, NewPodGC(mgr.Manager, 0))


### PR DESCRIPTION
It's possible that a particular composition has an active eno-controller process but not an eno-reconciler. In this case deletion will never succeed so none of the finalizers will be removed. Of course it's also possible that some other deadlock in the reconciler causes a similar issue, so it's worth adding a configurable grace period.