### PR TITLE
Count deleting compositions against the stuck method

### DIFF
--- a/internal/controllers/scheduling/metrics.go
+++ b/internal/controllers/scheduling/metrics.go
@@ -38,5 +38,8 @@ func init() {
 
 func missedReconciliation(comp *apiv1.Composition, threshold time.Duration) bool {
 	syn := comp.Status.CurrentSynthesis
-	return comp.DeletionTimestamp == nil && syn != nil && syn.Reconciled == nil && syn.Initialized != nil && time.Since(syn.Initialized.Time) > threshold
+	if comp.DeletionTimestamp != nil {
+		return time.Since(comp.DeletionTimestamp.Time) > threshold
+	}
+	return syn != nil && syn.Reconciled == nil && syn.Initialized != nil && time.Since(syn.Initialized.Time) > threshold
 }

--- a/internal/controllers/scheduling/metrics_test.go
+++ b/internal/controllers/scheduling/metrics_test.go
@@ -82,6 +82,27 @@ func TestMissedReconciliation(t *testing.T) {
 			},
 			expected: false,
 		},
+		{
+			name: "Composition Being Deleted",
+			comp: &apiv1.Composition{
+				ObjectMeta: metav1.ObjectMeta{
+					DeletionTimestamp: &metav1.Time{Time: time.Now()},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "Composition Being Deleted, Missed",
+			comp: &apiv1.Composition{
+				ObjectMeta: metav1.ObjectMeta{
+					DeletionTimestamp: &metav1.Time{Time: time.Now().Add(-3 * time.Hour)},
+				},
+				Status: apiv1.CompositionStatus{
+					CurrentSynthesis: &apiv1.Synthesis{},
+				},
+			},
+			expected: true,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
There's a monitoring gap where deleting compositions aren't captured by the "stuck reconciling" metric