### PR TITLE
Orphan managed resources during symphony deletion

### DIFF
--- a/internal/controllers/reconciliation/controller.go
+++ b/internal/controllers/reconciliation/controller.go
@@ -172,7 +172,7 @@ func (c *Controller) reconcileResource(ctx context.Context, comp *apiv1.Composit
 	}()
 
 	if res.Deleted(comp) {
-		if current == nil || current.GetDeletionTimestamp() != nil {
+		if current == nil || current.GetDeletionTimestamp() != nil || (comp.Labels != nil && comp.Labels["eno.azure.io/symphony-deleting"] == "true") {
 			return false, nil // already deleted - nothing to do
 		}
 

--- a/internal/controllers/resourceslice/slice.go
+++ b/internal/controllers/resourceslice/slice.go
@@ -65,6 +65,11 @@ func (s *sliceController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 			return ctrl.Result{}, err
 		}
 
+		// All active slices should be orphaned if composition deletion was caused by symphony deletion
+		if comp.Labels != nil && comp.Labels["eno.azure.io/symphony-deleting"] == "true" {
+			continue
+		}
+
 		// Handle a case where the reconciliation controller hasn't updated the slice's status yet
 		if len(slice.Status.Resources) == 0 && len(slice.Spec.Resources) > 0 {
 			snapshot.Ready = false


### PR DESCRIPTION
# (kind of a) breaking change!

Cascading deletion caused by the deletion of a symphony will no longer wait for managed resources to be cleaned up. For the sake of maintaining deterministic behavior, they won't be deleted at all in this case.

The idea is to protect against deadlock states introduced by impossible cleanup steps - either imposed by the synthesizer's logic (structure of the resources themselves), availability of apiserver, or availability of the eno-reconciler process.