### PR TITLE
Support overriding internal annotations

### DIFF
--- a/internal/controllers/reconciliation/controller_test.go
+++ b/internal/controllers/reconciliation/controller_test.go
@@ -19,7 +19,7 @@ func TestRequeue(t *testing.T) {
 	tests := []struct {
 		name           string
 		comp           *apiv1.Composition
-		resource       *resource.Resource
+		resource       *resource.Snapshot
 		ready          *metav1.Time
 		minReconcile   time.Duration
 		expectedResult time.Duration
@@ -27,7 +27,7 @@ func TestRequeue(t *testing.T) {
 		{
 			name: "resource is not ready, requeue after readiness poll interval",
 			comp: &apiv1.Composition{},
-			resource: &resource.Resource{
+			resource: &resource.Snapshot{
 				ReconcileInterval: nil,
 			},
 			ready:          nil,
@@ -37,7 +37,7 @@ func TestRequeue(t *testing.T) {
 		{
 			name: "resource is deleted, no requeue",
 			comp: &apiv1.Composition{},
-			resource: &resource.Resource{
+			resource: &resource.Snapshot{
 				ReconcileInterval: nil,
 			},
 			ready:          &metav1.Time{},
@@ -47,7 +47,7 @@ func TestRequeue(t *testing.T) {
 		{
 			name: "resource has reconcile interval less than minReconcileInterval",
 			comp: &apiv1.Composition{},
-			resource: &resource.Resource{
+			resource: &resource.Snapshot{
 				ReconcileInterval: &metav1.Duration{Duration: 5 * time.Second},
 			},
 			ready:          &metav1.Time{},
@@ -57,7 +57,7 @@ func TestRequeue(t *testing.T) {
 		{
 			name: "resource has valid reconcile interval",
 			comp: &apiv1.Composition{},
-			resource: &resource.Resource{
+			resource: &resource.Snapshot{
 				ReconcileInterval: &metav1.Duration{Duration: 15 * time.Second},
 			},
 			ready:          &metav1.Time{},
@@ -73,8 +73,11 @@ func TestRequeue(t *testing.T) {
 				readinessPollInterval: 10 * time.Second,
 				minReconcileInterval:  tt.minReconcile,
 			}
+			if tt.resource.Resource == nil {
+				tt.resource.Resource = &resource.Resource{}
+			}
 
-			result, err := c.requeue(logger, tt.comp, &resource.Snapshot{Resource: tt.resource}, tt.ready)
+			result, err := c.requeue(logger, tt.comp, tt.resource, tt.ready)
 			assert.NoError(t, err)
 			assert.InDelta(t, tt.expectedResult, result.RequeueAfter, float64(2*time.Second))
 		})

--- a/internal/resource/tree.go
+++ b/internal/resource/tree.go
@@ -70,8 +70,8 @@ func (b *treeBuilder) Add(resource *Resource) {
 		Dependents:          map[Ref]*indexedResource{},
 	}
 	b.byRef[resource.Ref] = idx
-	current, _ := b.byGroup.Get(resource.ReadinessGroup)
-	b.byGroup.Put(resource.ReadinessGroup, append(current, idx))
+	current, _ := b.byGroup.Get(resource.readinessGroup)
+	b.byGroup.Put(resource.readinessGroup, append(current, idx))
 	b.byGK[resource.GVK.GroupKind()] = idx
 	if resource.DefinedGroupKind != nil {
 		b.byDefiningGK[*resource.DefinedGroupKind] = idx
@@ -88,7 +88,7 @@ func (b *treeBuilder) Build() *tree {
 		t.byManiRef[idx.Resource.ManifestRef] = idx
 
 		// CRs are dependent on their CRDs
-		i := b.byGroup.IteratorAt(b.byGroup.GetNode(idx.Resource.ReadinessGroup))
+		i := b.byGroup.IteratorAt(b.byGroup.GetNode(idx.Resource.readinessGroup))
 		crd, ok := b.byDefiningGK[idx.Resource.GVK.GroupKind()]
 		if ok {
 			idx.PendingDependencies[crd.Resource.Ref] = struct{}{}
@@ -104,7 +104,7 @@ func (b *treeBuilder) Build() *tree {
 		i.Next() // Prev always moves the cursor, even if it returns false
 
 		// Any resources in the next readiness group depend on us
-		if i.Next() && i.Key() > idx.Resource.ReadinessGroup {
+		if i.Next() && i.Key() > idx.Resource.readinessGroup {
 			for _, cur := range i.Value() {
 				idx.Dependents[cur.Resource.Ref] = cur
 			}

--- a/internal/resource/tree_test.go
+++ b/internal/resource/tree_test.go
@@ -32,18 +32,18 @@ func TestTreeBuilderSanity(t *testing.T) {
 			Resources: []*Resource{
 				{
 					Ref:            newTestRef("test-negative-2"),
-					ReadinessGroup: -2,
+					readinessGroup: -2,
 				},
 				{
 					Ref:            newTestRef("test-1"),
-					ReadinessGroup: 1,
+					readinessGroup: 1,
 				},
 				{
 					Ref: newTestRef("test-0"),
 				},
 				{
 					Ref:            newTestRef("test-4"),
-					ReadinessGroup: 4,
+					readinessGroup: 4,
 				},
 			},
 		},
@@ -52,15 +52,15 @@ func TestTreeBuilderSanity(t *testing.T) {
 			Resources: []*Resource{
 				{
 					Ref:            newTestRef("test-1"),
-					ReadinessGroup: 4,
+					readinessGroup: 4,
 				},
 				{
 					Ref:            newTestRef("test-2-a"),
-					ReadinessGroup: 8,
+					readinessGroup: 8,
 				},
 				{
 					Ref:            newTestRef("test-2-b"),
-					ReadinessGroup: 8,
+					readinessGroup: 8,
 				},
 			},
 		},
@@ -83,20 +83,20 @@ func TestTreeBuilderSanity(t *testing.T) {
 				{
 					Ref:            newTestRef("test-cr"),
 					GVK:            schema.GroupVersionKind{Group: "test.group", Version: "v1", Kind: "TestCRDKind"},
-					ReadinessGroup: 5,
+					readinessGroup: 5,
 				},
 				{
 					Ref:              newTestRef("test-crd"),
 					DefinedGroupKind: &schema.GroupKind{Group: "test.group", Kind: "TestCRDKind"},
-					ReadinessGroup:   3,
+					readinessGroup:   3,
 				},
 				{
 					Ref:            newTestRef("also-not-a-crd"),
-					ReadinessGroup: 10,
+					readinessGroup: 10,
 				},
 				{
 					Ref:            newTestRef("not-a-crd"),
-					ReadinessGroup: 1,
+					readinessGroup: 1,
 				},
 			},
 		},
@@ -106,12 +106,12 @@ func TestTreeBuilderSanity(t *testing.T) {
 				{
 					Ref:            newTestRef("test-cr"),
 					GVK:            schema.GroupVersionKind{Group: "test.group", Version: "v1", Kind: "TestCRDKind"},
-					ReadinessGroup: 3,
+					readinessGroup: 3,
 				},
 				{
 					Ref:              newTestRef("test-crd"),
 					DefinedGroupKind: &schema.GroupKind{Group: "test.group", Kind: "TestCRDKind"},
-					ReadinessGroup:   5,
+					readinessGroup:   5,
 				},
 			},
 		},
@@ -153,22 +153,22 @@ func TestTreeVisibility(t *testing.T) {
 	var b treeBuilder
 	b.Add(&Resource{
 		Ref:            newTestRef("test-resource-4"),
-		ReadinessGroup: 4,
+		readinessGroup: 4,
 		ManifestRef:    ManifestRef{Index: 4},
 	})
 	b.Add(&Resource{
 		Ref:            newTestRef("test-resource-1"),
-		ReadinessGroup: 1,
+		readinessGroup: 1,
 		ManifestRef:    ManifestRef{Index: 1},
 	})
 	b.Add(&Resource{
 		Ref:            newTestRef("test-resource-3"),
-		ReadinessGroup: 3,
+		readinessGroup: 3,
 		ManifestRef:    ManifestRef{Index: 3},
 	})
 	b.Add(&Resource{
 		Ref:            newTestRef("test-resource-2"),
-		ReadinessGroup: 2,
+		readinessGroup: 2,
 		ManifestRef:    ManifestRef{Index: 2},
 	})
 	names := []string{"test-resource-1", "test-resource-2", "test-resource-3", "test-resource-4"}
@@ -237,17 +237,17 @@ func TestTreeDeletion(t *testing.T) {
 	var b treeBuilder
 	b.Add(&Resource{
 		Ref:            newTestRef("test-resource-1"),
-		ReadinessGroup: 1,
+		readinessGroup: 1,
 		ManifestRef:    ManifestRef{Index: 1},
 	})
 	b.Add(&Resource{
 		Ref:            newTestRef("test-resource-3"),
-		ReadinessGroup: 3,
+		readinessGroup: 3,
 		ManifestRef:    ManifestRef{Index: 3},
 	})
 	b.Add(&Resource{
 		Ref:            newTestRef("test-resource-2"),
-		ReadinessGroup: 2,
+		readinessGroup: 2,
 		ManifestRef:    ManifestRef{Index: 2},
 	})
 
@@ -303,11 +303,11 @@ func TestTreeRefConflicts(t *testing.T) {
 	var b treeBuilder
 	b.Add(&Resource{
 		Ref:          newTestRef("test-resource"),
-		ManifestHash: []byte("b"),
+		manifestHash: []byte("b"),
 	})
 	b.Add(&Resource{
 		Ref:          newTestRef("test-resource"),
-		ManifestHash: []byte("a"),
+		manifestHash: []byte("a"),
 	})
 
 	tree := b.Build()
@@ -315,7 +315,7 @@ func TestTreeRefConflicts(t *testing.T) {
 	res, visible, found := tree.Get(newTestRef("test-resource"))
 	assert.True(t, found)
 	assert.True(t, visible)
-	assert.Equal(t, "b", string(res.ManifestHash))
+	assert.Equal(t, "b", string(res.manifestHash))
 }
 func TestIndexedResourceBacktracks(t *testing.T) {
 	baseGVK := schema.GroupVersionKind{Group: "test.group", Version: "v1", Kind: "TestKind"}
@@ -325,7 +325,7 @@ func TestIndexedResourceBacktracks(t *testing.T) {
 			Resource: &Resource{
 				Ref:            newTestRef(name),
 				GVK:            baseGVK,
-				ReadinessGroup: group,
+				readinessGroup: group,
 			},
 			PendingDependencies: map[Ref]struct{}{},
 			Dependents:          map[Ref]*indexedResource{},
@@ -343,7 +343,7 @@ func TestIndexedResourceBacktracks(t *testing.T) {
 			Resource: &Resource{
 				Ref:            newTestRef("a"),
 				GVK:            schema.GroupVersionKind{Group: "other.group", Version: "v1", Kind: "OtherKind"},
-				ReadinessGroup: 2,
+				readinessGroup: 2,
 			},
 			PendingDependencies: map[Ref]struct{}{},
 			Dependents:          map[Ref]*indexedResource{},


### PR DESCRIPTION
Allowing Eno's internal resource annotations to be mutated by override expressions opens up some interesting possibilities for more dynamic runtime behavior (e.g. without requiring resynthesis).

I think this might be a good way to address the long standing cleanup problem where a Patch resource needs to be deferred until composition deletion. In this case the patch could have a nil deletionTimestamp _until_ overridden based on the state of the composition (more details to work out here but you get the idea).
