### PR TITLE
Fix path parser panic

### DIFF
--- a/internal/resource/mutation/mutation.go
+++ b/internal/resource/mutation/mutation.go
@@ -71,6 +71,10 @@ func (o *Op) Apply(ctx context.Context, current, mutated *unstructured.Unstructu
 // Apply applies a mutation i.e. sets the value(s) referred to by the path expression.
 // Missing or nil values in the path will not be created, and will cause an error.
 func Apply(path *PathExpr, obj, value any) error {
+	if path == nil {
+		return nil
+	}
+
 	if s := path.ast.Sections; len(s) == 0 || s[0].Field == nil || *s[0].Field != "self" {
 		return fmt.Errorf("cannot apply mutation to non-self path")
 	}

--- a/internal/resource/mutation/mutation_test.go
+++ b/internal/resource/mutation/mutation_test.go
@@ -2,6 +2,7 @@ package mutation
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"testing"
 
@@ -11,6 +12,16 @@ import (
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
+
+func TestPanic(t *testing.T) {
+	overridesJson := "[\n  { \"path\": \"self.spec.template.spec.containers[name='retina-operator'].resources.requests.cpu\", \"value\": \"250m\", \"condition\": \"self.spec.template.spec.containers[name='retina-operator'].resources.requests.cpu == '250m'\" },\n  { \"path\": \"self.spec.template.spec.containers[name='retina-operator'].resources.requests.memory\", \"value\": \"250Mi\", \"condition\": \"self.spec.template.spec.containers[name='retina-operator'].resources.requests.memory == '250Mi'\" },\n  { \"path\": \"self.spec.template.spec.containers[name='retina-operator'].resources.limits.cpu\", \"value\": \"500m\", \"condition\": \"self.spec.template.spec.containers[name='retina-operator'].resources.limits.cpu == '500m'\" },\n  { \"path\": \"self.spec.template.spec.containers[name='retina-operator'].resources.limits.memory\", \"value\": \"500Mi\", \"condition\": \"self.spec.template.spec.containers[name='retina-operator'].resources.limits.memory == '500Mi'\" }\n]\n"
+	ops := []*Op{}
+	err := json.Unmarshal([]byte(overridesJson), &ops)
+	assert.NoError(t, err)
+	for _, op := range ops {
+		Apply(op.Path, map[string]any{}, op.Value)
+	}
+}
 
 func TestApply(t *testing.T) {
 	testCases := []struct {

--- a/internal/resource/mutation/mutation_test.go
+++ b/internal/resource/mutation/mutation_test.go
@@ -2,6 +2,7 @@ package mutation
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"testing"
 

--- a/internal/resource/mutation/mutation_test.go
+++ b/internal/resource/mutation/mutation_test.go
@@ -2,7 +2,6 @@ package mutation
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"testing"
 
@@ -12,16 +11,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
-
-func TestPanic(t *testing.T) {
-	overridesJson := "[\n  { \"path\": \"self.spec.template.spec.containers[name='retina-operator'].resources.requests.cpu\", \"value\": \"250m\", \"condition\": \"self.spec.template.spec.containers[name='retina-operator'].resources.requests.cpu == '250m'\" },\n  { \"path\": \"self.spec.template.spec.containers[name='retina-operator'].resources.requests.memory\", \"value\": \"250Mi\", \"condition\": \"self.spec.template.spec.containers[name='retina-operator'].resources.requests.memory == '250Mi'\" },\n  { \"path\": \"self.spec.template.spec.containers[name='retina-operator'].resources.limits.cpu\", \"value\": \"500m\", \"condition\": \"self.spec.template.spec.containers[name='retina-operator'].resources.limits.cpu == '500m'\" },\n  { \"path\": \"self.spec.template.spec.containers[name='retina-operator'].resources.limits.memory\", \"value\": \"500Mi\", \"condition\": \"self.spec.template.spec.containers[name='retina-operator'].resources.limits.memory == '500Mi'\" }\n]\n"
-	ops := []*Op{}
-	err := json.Unmarshal([]byte(overridesJson), &ops)
-	assert.NoError(t, err)
-	for _, op := range ops {
-		Apply(op.Path, map[string]any{}, op.Value)
-	}
-}
 
 func TestApply(t *testing.T) {
 	testCases := []struct {

--- a/internal/resource/mutation/mutation_test.go
+++ b/internal/resource/mutation/mutation_test.go
@@ -328,6 +328,18 @@ func TestOpApply(t *testing.T) {
 	}
 }
 
+// TestInvalidPathInJson proves that the non-nil ops with nil paths left after failed unmarshalling will not panic when applied.
+func TestInvalidPathInJson(t *testing.T) {
+	overridesJson := "[\n  { \"path\": \"self.spec.template.spec.containers[name='operator'].resources.requests.cpu\", \"value\": \"250m\", \"condition\": \"self.spec.template.spec.containers[name='operator'].resources.requests.cpu == '250m'\" } ]"
+	ops := []*Op{}
+	err := json.Unmarshal([]byte(overridesJson), &ops)
+	assert.Error(t, err)
+	assert.Len(t, ops, 1)
+	for _, op := range ops {
+		assert.NoError(t, Apply(op.Path, map[string]any{}, op.Value))
+	}
+}
+
 // helper functions for tests
 func mustParsePathExpr(path string) *PathExpr {
 	expr, err := ParsePathExpr(path)


### PR DESCRIPTION
Turns out the json parser will leave non-nil struct pointers in slices when parsing the struct fails. 🤦 