### PR TITLE
Remove bad example from override docs

### DIFF
--- a/docs/reconciliation.md
+++ b/docs/reconciliation.md
@@ -95,7 +95,7 @@ This is commonly used to make a subset of properties managed by Eno optional i.e
 For example:
 
 ```json
-{ "path": "self.data.foo", "value": "default value", "condition": "!has(self.data.foo)" }
+{ "path": "self.data.foo", "value": "default value", "condition": "self.data.foo != 'default value'" }
 ```
 
 It's also possible to access composition metadata in condition expressions.


### PR DESCRIPTION
Setting a condition of `!has(theOverridePath)` will cause Eno to oscillate between the overridden and non-overridden states.