### PR TITLE
Allow override conditions to check if their path is owned by Eno

### DIFF
--- a/docs/reconciliation.md
+++ b/docs/reconciliation.md
@@ -104,7 +104,18 @@ It's also possible to access composition metadata in condition expressions.
 annotations:
   eno.azure.io/overrides: |
     [
-      { "path": "spec.cleaningUp", "value": true, "condition": "composition.metadata.deletionTimestamp != null" }
+      { "path": "self.spec.cleaningUp", "value": true, "condition": "composition.metadata.deletionTimestamp != null" }
+    ]
+```
+
+Conditions can match on the ownership status of the field matched by `path`.
+This is useful for dropping particular fields when another field manager has set a value.
+
+```yaml
+annotations:
+  eno.azure.io/overrides: |
+    [
+      { "path": "self.data.foo", "value": null, "condition": "has(self.data.foo) && !pathManagedByEno" }
     ]
 ```
 

--- a/go.work.sum
+++ b/go.work.sum
@@ -2092,6 +2092,7 @@ golang.org/x/crypto v0.32.0/go.mod h1:ZnnJkOaASj8g0AjIduWNlq2NRxL0PlBrbKVyZ6V/Ug
 golang.org/x/crypto v0.33.0/go.mod h1:bVdXmD7IV/4GdElGPozy6U7lWdRXA4qyRVGJV57uQ5M=
 golang.org/x/crypto v0.35.0/go.mod h1:dy7dXNW32cAb/6/PRuTNsix8T+vJAqvuIy5Bli/x0YQ=
 golang.org/x/crypto v0.36.0/go.mod h1:Y4J0ReaxCR1IMaabaSMugxJES1EpwhBHhv2bDHklZvc=
+golang.org/x/crypto v0.38.0/go.mod h1:MvrbAqul58NNYPKnOra203SB9vpuZW0e+RRZV+Ggqjw=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190510132918-efd6b22b2522/go.mod h1:ZjyILWgesfNpC6sMxTJOJm9Kp84zZh5NQWvqDGG3Qr8=

--- a/internal/cel/cel_test.go
+++ b/internal/cel/cel_test.go
@@ -16,7 +16,7 @@ func TestEvalCompositionBasics(t *testing.T) {
 	comp := &apiv1.Composition{}
 	comp.Name = "test-comp"
 
-	val, err := Eval(t.Context(), p, comp, &unstructured.Unstructured{})
+	val, err := Eval(t.Context(), p, comp, &unstructured.Unstructured{}, nil)
 	require.NoError(t, err)
 	assert.Equal(t, "test-comp", val.Value())
 }

--- a/internal/controllers/reconciliation/overrides_test.go
+++ b/internal/controllers/reconciliation/overrides_test.go
@@ -3,6 +3,7 @@ package reconciliation
 import (
 	"context"
 	"testing"
+	"time"
 
 	apiv1 "github.com/Azure/eno/api/v1"
 	"github.com/Azure/eno/internal/testutil"
@@ -272,5 +273,79 @@ func TestOverrideAndReplace(t *testing.T) {
 	testutil.Eventually(t, func() bool {
 		mgr.DownstreamClient.Get(ctx, client.ObjectKeyFromObject(cm), cm)
 		return cm.Data["foo"] == "val-1" && cm.Data["bar"] == "val-2" && cm.Data["baz"] == ""
+	})
+}
+
+func TestOverrideManagedFields(t *testing.T) {
+	ctx := testutil.NewContext(t)
+	mgr := testutil.NewManager(t)
+	upstream := mgr.GetClient()
+
+	registerControllers(t, mgr)
+	testutil.WithFakeExecutor(t, mgr, func(ctx context.Context, s *apiv1.Synthesizer, input *krmv1.ResourceList) (*krmv1.ResourceList, error) {
+		output := &krmv1.ResourceList{}
+		output.Items = []*unstructured.Unstructured{{
+			Object: map[string]any{
+				"apiVersion": "v1",
+				"kind":       "ConfigMap",
+				"metadata": map[string]any{
+					"name":      "test-obj",
+					"namespace": "default",
+					"annotations": map[string]any{
+						"eno.azure.io/reconcile-interval": "20ms",
+						"eno.azure.io/overrides": `[
+							{"path": "self.data.foo", "value": null, "condition": "has(self.data.foo) && !pathManagedByEno"}
+						]`,
+					},
+				},
+				"data": map[string]any{"foo": "bar", "another": "baz"},
+			},
+		}}
+		return output, nil
+	})
+
+	setupTestSubject(t, mgr)
+	mgr.Start(t)
+	_, comp := writeGenericComposition(t, upstream)
+
+	testutil.Eventually(t, func() bool {
+		return upstream.Get(ctx, client.ObjectKeyFromObject(comp), comp) == nil && comp.Status.CurrentSynthesis != nil && comp.Status.CurrentSynthesis.Ready != nil
+	})
+
+	// Configmap is populated with the defaults
+	cm := &corev1.ConfigMap{}
+	cm.Name = "test-obj"
+	cm.Namespace = "default"
+	testutil.Eventually(t, func() bool {
+		mgr.DownstreamClient.Get(ctx, client.ObjectKeyFromObject(cm), cm)
+		return cm.Data["foo"] == "bar"
+	})
+
+	// Override the values with another field manager (test client)
+	retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		mgr.DownstreamClient.Get(ctx, client.ObjectKeyFromObject(cm), cm)
+		cm.Data["foo"] = "baz"
+		return mgr.DownstreamClient.Update(ctx, cm)
+	})
+
+	time.Sleep(time.Millisecond * 40) // wait at least one reconile interval
+
+	// The overridden value should not be overwritten by Eno
+	testutil.Eventually(t, func() bool {
+		mgr.DownstreamClient.Get(ctx, client.ObjectKeyFromObject(cm), cm)
+		return cm.Data["foo"] == "baz"
+	})
+
+	// Remove the field entirely
+	retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		mgr.DownstreamClient.Get(ctx, client.ObjectKeyFromObject(cm), cm)
+		cm.Data = nil
+		return mgr.DownstreamClient.Update(ctx, cm)
+	})
+
+	// Prove the value is repopulated
+	testutil.Eventually(t, func() bool {
+		mgr.DownstreamClient.Get(ctx, client.ObjectKeyFromObject(cm), cm)
+		return cm.Data["foo"] == "bar"
 	})
 }

--- a/internal/readiness/readiness.go
+++ b/internal/readiness/readiness.go
@@ -37,7 +37,7 @@ func (r *Check) Eval(ctx context.Context, comp *apiv1.Composition, resource *uns
 	if resource == nil {
 		return nil, false
 	}
-	val, err := enocel.Eval(ctx, r.program, comp, resource)
+	val, err := enocel.Eval(ctx, r.program, comp, resource, nil)
 	if err != nil {
 		return nil, false
 	}

--- a/internal/resource/mutation/mutation.go
+++ b/internal/resource/mutation/mutation.go
@@ -57,7 +57,7 @@ func (o *Op) Apply(ctx context.Context, comp *apiv1.Composition, current, mutate
 	}
 
 	if o.Condition != nil {
-		val, err := enocel.Eval(ctx, o.Condition, comp, current)
+		val, err := enocel.Eval(ctx, o.Condition, comp, current, o.Path)
 		if err != nil {
 			return nil // fail closed (too noisy to log)
 		}
@@ -97,7 +97,11 @@ func apply(path *PathExpr, startIndex int, obj any, value any) error {
 				continue
 			}
 			if startIndex+i == len(path.ast.Sections)-1 {
-				m[*section.Field] = value
+				if value == nil {
+					delete(m, *section.Field)
+				} else {
+					m[*section.Field] = value
+				}
 				return nil
 			}
 			state = m[*section.Field]
@@ -116,7 +120,11 @@ func apply(path *PathExpr, startIndex int, obj any, value any) error {
 			}
 			keyStr := (*key)[1 : len(*key)-1] // remove quotes
 			if startIndex+i == len(path.ast.Sections)-1 {
-				m[keyStr] = value
+				if value == nil {
+					delete(m, keyStr)
+				} else {
+					m[keyStr] = value
+				}
 				return nil
 			}
 			state = m[keyStr]

--- a/internal/resource/mutation/mutation_test.go
+++ b/internal/resource/mutation/mutation_test.go
@@ -31,6 +31,20 @@ func TestApply(t *testing.T) {
 			expected: map[string]any{"foo": 123},
 		},
 		{
+			name:     "Map_Nil",
+			path:     "self.foo",
+			obj:      map[string]any{},
+			value:    nil,
+			expected: map[string]any{},
+		},
+		{
+			name:     "Alternative_Map_Nil",
+			path:     `self["foo"]`,
+			obj:      map[string]any{},
+			value:    nil,
+			expected: map[string]any{},
+		},
+		{
 			name:     "Map_Nested",
 			path:     "self.foo.bar",
 			obj:      map[string]any{"foo": map[string]any{}, "another": "baz"},
@@ -308,13 +322,17 @@ func TestOpApply(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			err := tc.op.Apply(ctx, &apiv1.Composition{}, tc.current,  tc.mutated)
+			err := tc.op.Apply(ctx, &apiv1.Composition{}, tc.current, tc.mutated)
 			if tc.wantErr {
 				require.Error(t, err)
 			} else {
 				require.NoError(t, err)
 				assert.Equal(t, tc.expectedMutated, tc.mutated)
 			}
+
+			// Also make sure the path can be successfully converted to the SMD representation
+			_, err = tc.op.Path.toSMDPath()
+			assert.NoError(t, err)
 		})
 	}
 }

--- a/internal/resource/mutation/parser_test.go
+++ b/internal/resource/mutation/parser_test.go
@@ -1,0 +1,176 @@
+package mutation
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/structured-merge-diff/v4/fieldpath"
+)
+
+func TestPathExprManagedByEno(t *testing.T) {
+	testCases := []struct {
+		name          string
+		path          string
+		managedFields []metav1.ManagedFieldsEntry
+		expected      bool
+	}{
+		{
+			name: "FieldOwnedByEno",
+			path: "self.data.foo",
+			managedFields: []metav1.ManagedFieldsEntry{
+				{
+					Manager:   "eno",
+					Operation: metav1.ManagedFieldsOperationApply,
+					FieldsV1: &metav1.FieldsV1{
+						Raw: createFieldSetJSON(t, "data", "foo"),
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "FieldOwnedByOther",
+			path: "self.data.foo",
+			managedFields: []metav1.ManagedFieldsEntry{
+				{
+					Manager:   "other-manager",
+					Operation: metav1.ManagedFieldsOperationApply,
+					FieldsV1: &metav1.FieldsV1{
+						Raw: createFieldSetJSON(t, "data", "foo"),
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "MultipleManagers_EnoOwnsField",
+			path: "self.data.foo",
+			managedFields: []metav1.ManagedFieldsEntry{
+				{
+					Manager:   "other-manager",
+					Operation: metav1.ManagedFieldsOperationApply,
+					FieldsV1: &metav1.FieldsV1{
+						Raw: createFieldSetJSON(t, "data", "foo"),
+					},
+				},
+				{
+					Manager:   "eno",
+					Operation: metav1.ManagedFieldsOperationApply,
+					FieldsV1: &metav1.FieldsV1{
+						Raw: createFieldSetJSON(t, "data", "foo"),
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "NestedPath",
+			path: "self.spec.containers[0].image",
+			managedFields: []metav1.ManagedFieldsEntry{
+				{
+					Manager:   "eno",
+					Operation: metav1.ManagedFieldsOperationApply,
+					FieldsV1: &metav1.FieldsV1{
+						Raw: createFieldSetJSONWithIndex(t, "spec", "containers", 0, "image"),
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name:          "NoManagedFields",
+			path:          "self.data.foo",
+			managedFields: []metav1.ManagedFieldsEntry{},
+			expected:      false,
+		},
+		{
+			name: "NilPath",
+			path: "",
+			managedFields: []metav1.ManagedFieldsEntry{
+				{
+					Manager:   "eno",
+					Operation: metav1.ManagedFieldsOperationApply,
+					FieldsV1: &metav1.FieldsV1{
+						Raw: createFieldSetJSON(t, "data", "foo"),
+					},
+				},
+			},
+			expected: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			obj := &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "v1",
+					"kind":       "ConfigMap",
+					"metadata": map[string]interface{}{
+						"name":      "test-obj",
+						"namespace": "default",
+					},
+					"data": map[string]interface{}{
+						"foo": "bar",
+					},
+				},
+			}
+			obj.SetManagedFields(tc.managedFields)
+
+			var pathExpr *PathExpr
+			if tc.path != "" {
+				var err error
+				pathExpr, err = ParsePathExpr(tc.path)
+				require.NoError(t, err)
+			}
+
+			owned := pathExpr.ManagedByEno(t.Context(), obj)
+			assert.Equal(t, tc.expected, owned)
+		})
+	}
+}
+
+func createFieldSetJSON(t *testing.T, fieldNames ...string) []byte {
+	fieldSet := &fieldpath.Set{}
+
+	pathElements := make([]interface{}, len(fieldNames))
+	for i, name := range fieldNames {
+		fieldName := name
+		pathElements[i] = fieldpath.PathElement{FieldName: &fieldName}
+	}
+
+	path, err := fieldpath.MakePath(pathElements...)
+	require.NoError(t, err)
+
+	fieldSet.Insert(path)
+
+	jsonBytes, err := fieldSet.ToJSON()
+	require.NoError(t, err)
+
+	return jsonBytes
+}
+
+func createFieldSetJSONWithIndex(t *testing.T, fieldName1, fieldName2 string, index int, fieldName3 string) []byte {
+	fieldSet := &fieldpath.Set{}
+
+	field1 := fieldName1
+	field2 := fieldName2
+	field3 := fieldName3
+
+	path, err := fieldpath.MakePath(
+		fieldpath.PathElement{FieldName: &field1},
+		fieldpath.PathElement{FieldName: &field2},
+		fieldpath.PathElement{Index: &index},
+		fieldpath.PathElement{FieldName: &field3},
+	)
+	require.NoError(t, err)
+
+	fieldSet.Insert(path)
+
+	jsonBytes, err := fieldSet.ToJSON()
+	require.NoError(t, err)
+
+	return jsonBytes
+}


### PR DESCRIPTION
This helps implement a pattern where some fields normally managed by Eno can be overridden by other field managers (clients).