### PR TITLE
Reduce log noise

### DIFF
--- a/internal/controllers/composition/controller.go
+++ b/internal/controllers/composition/controller.go
@@ -63,9 +63,12 @@ func (c *compositionController) Reconcile(ctx context.Context, req ctrl.Request)
 	logger := logr.FromContextOrDiscard(ctx)
 	comp := &apiv1.Composition{}
 	err := c.client.Get(ctx, req.NamespacedName, comp)
+	if errors.IsNotFound(err) {
+		return ctrl.Result{}, nil
+	}
 	if err != nil {
-		logger.Error(err, "failed to get composition resource")
-		return ctrl.Result{}, client.IgnoreNotFound(err)
+		logger.Error(err, "failed to get composition")
+		return ctrl.Result{}, err
 	}
 
 	logger = logger.WithValues("compositionName", comp.Name, "compositionNamespace", comp.Namespace, "compositionGeneration", comp.Generation, "synthesisUUID", comp.Status.GetCurrentSynthesisUUID())

--- a/internal/controllers/resourceslice/slice.go
+++ b/internal/controllers/resourceslice/slice.go
@@ -97,6 +97,9 @@ func (s *sliceController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 		return ctrl.Result{}, nil
 	}
 	err = s.client.Status().Update(ctx, comp)
+	if errors.IsConflict(err) {
+		return ctrl.Result{}, fmt.Errorf("conflict while updating composition status to reflect resource slices - will retry")
+	}
 	if err != nil {
 		logger.Error(err, "failed to update composition status")
 		return ctrl.Result{}, err

--- a/internal/controllers/symphony/controller.go
+++ b/internal/controllers/symphony/controller.go
@@ -11,6 +11,7 @@ import (
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/api/errors"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -39,9 +40,12 @@ func (c *symphonyController) Reconcile(ctx context.Context, req ctrl.Request) (c
 
 	symph := &apiv1.Symphony{}
 	err := c.client.Get(ctx, req.NamespacedName, symph)
+	if errors.IsNotFound(err) {
+		return ctrl.Result{}, nil
+	}
 	if err != nil {
 		logger.Error(err, "failed to get symphony")
-		return ctrl.Result{}, client.IgnoreNotFound(err)
+		return ctrl.Result{}, err
 	}
 	logger = logger.WithValues("symphonyName", symph.Name, "symphonyNamespace", symph.Namespace, "symphonyGeneration", symph.Generation)
 	ctx = logr.NewContext(ctx, logger)

--- a/internal/controllers/watch/pruning.go
+++ b/internal/controllers/watch/pruning.go
@@ -5,6 +5,7 @@ import (
 
 	apiv1 "github.com/Azure/eno/api/v1"
 	"github.com/go-logr/logr"
+	"k8s.io/apimachinery/pkg/api/errors"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -18,9 +19,12 @@ func (c *pruningController) Reconcile(ctx context.Context, req ctrl.Request) (ct
 
 	comp := &apiv1.Composition{}
 	err := c.client.Get(ctx, req.NamespacedName, comp)
+	if errors.IsNotFound(err) {
+		return ctrl.Result{}, nil
+	}
 	if err != nil {
 		logger.Error(err, "failed to get composition")
-		return ctrl.Result{}, client.IgnoreNotFound(err)
+		return ctrl.Result{}, err
 	}
 
 	logger = logger.WithValues("compositionName", comp.Name, "compositionNamespace", comp.Namespace, "synthesizerName", comp.Spec.Synthesizer.Name)


### PR DESCRIPTION
There are a few places where Eno logs errors that it doesn't actually act on. For example: 404s that are expected/ignored.