### PR TITLE
Fix ownership checks for single quoted index strings

### DIFF
--- a/internal/resource/mutation/mutation.go
+++ b/internal/resource/mutation/mutation.go
@@ -75,15 +75,7 @@ func (o *Op) Apply(ctx context.Context, comp *apiv1.Composition, current, mutate
 // unquoteKey removes quotes from a key string, handling both single and double quotes
 func unquoteKey(key string) string {
 	if matches := quotedStringRegex.FindStringSubmatch(key); matches != nil {
-		// Ensure opening and closing quotes match
 		if matches[1] == matches[3] {
-			// For double quotes, use strconv.Unquote to handle escape sequences properly
-			if matches[1] == `"` {
-				if unquoted, err := strconv.Unquote(key); err == nil {
-					return unquoted
-				}
-			}
-			// For single quotes or if strconv.Unquote fails, return the content between quotes
 			return matches[2]
 		}
 	}

--- a/internal/resource/mutation/parser.go
+++ b/internal/resource/mutation/parser.go
@@ -3,7 +3,6 @@ package mutation
 import (
 	"bytes"
 	"context"
-	"strconv"
 
 	"github.com/alecthomas/participle/v2"
 	"github.com/alecthomas/participle/v2/lexer"
@@ -121,10 +120,10 @@ func (s *section) toPathElement() fieldpath.PathElement {
 		case s.Index.Element != nil:
 			return fieldpath.PathElement{Index: s.Index.Element}
 		case s.Index.Key != nil:
-			unquoted, _ := strconv.Unquote(*s.Index.Key)
+			unquoted := unquoteKey(*s.Index.Key)
 			return fieldpath.PathElement{FieldName: &unquoted}
 		case s.Index.Matcher != nil:
-			unquotedValue, _ := strconv.Unquote(s.Index.Matcher.Value)
+			unquotedValue := unquoteKey(s.Index.Matcher.Value)
 			fieldList := value.FieldList{{
 				Name:  s.Index.Matcher.Key,
 				Value: value.NewValueInterface(unquotedValue),

--- a/internal/resource/mutation/parser_test.go
+++ b/internal/resource/mutation/parser_test.go
@@ -32,6 +32,20 @@ func TestPathExprManagedByEno(t *testing.T) {
 			expected: true,
 		},
 		{
+			name: "FieldOwnedByEno_QuotedIndex",
+			path: "self.data['foo']",
+			managedFields: []metav1.ManagedFieldsEntry{
+				{
+					Manager:   "eno",
+					Operation: metav1.ManagedFieldsOperationApply,
+					FieldsV1: &metav1.FieldsV1{
+						Raw: createFieldSetJSON(t, "data", "foo"),
+					},
+				},
+			},
+			expected: true,
+		},
+		{
 			name: "FieldOwnedByOther",
 			path: "self.data.foo",
 			managedFields: []metav1.ManagedFieldsEntry{

--- a/internal/resource/mutation/parser_test.go
+++ b/internal/resource/mutation/parser_test.go
@@ -32,8 +32,22 @@ func TestPathExprManagedByEno(t *testing.T) {
 			expected: true,
 		},
 		{
-			name: "FieldOwnedByEno_QuotedIndex",
+			name: "FieldOwnedByEno_SingleQuotedIndex",
 			path: "self.data['foo']",
+			managedFields: []metav1.ManagedFieldsEntry{
+				{
+					Manager:   "eno",
+					Operation: metav1.ManagedFieldsOperationApply,
+					FieldsV1: &metav1.FieldsV1{
+						Raw: createFieldSetJSON(t, "data", "foo"),
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "FieldOwnedByEno_DoubleQuotedIndex",
+			path: `self.data["foo"]`,
 			managedFields: []metav1.ManagedFieldsEntry{
 				{
 					Manager:   "eno",


### PR DESCRIPTION
#444 Changed the way that path expression index strings are parsed, but didn't update the corresponding logic in `toPathElement`. I'll refactor to merge them so this kind of thing doesn't happen again, but for now let's just quickly fix it.