### PR TITLE
Don't send empty patches

### DIFF
--- a/internal/controllers/reconciliation/controller.go
+++ b/internal/controllers/reconciliation/controller.go
@@ -214,6 +214,10 @@ func (c *Controller) reconcileResource(ctx context.Context, comp *apiv1.Composit
 
 	// Apply Eno patches
 	if isPatch {
+		if patchJson == nil {
+			return false, nil // patch is empty
+		}
+
 		reconciliationActions.WithLabelValues("patch").Inc()
 		updated := current.DeepCopy()
 		err := c.upstreamClient.Patch(ctx, updated, client.RawPatch(types.JSONPatchType, patchJson))

--- a/internal/resource/resource.go
+++ b/internal/resource/resource.go
@@ -156,6 +156,9 @@ func (r *Snapshot) Patch() ([]byte, bool, error) {
 	}
 
 	ops, _, _ := unstructured.NestedSlice(r.parsed.Object, "patch", "ops")
+	if len(ops) == 0 {
+		return nil, true, nil // empty patch == empty json
+	}
 	js, err := json.Marshal(&ops)
 	if err != nil {
 		return nil, false, err


### PR DESCRIPTION
Certain cleanup tricks using overrides will declare no-op Patch meta-resources - let's not bother sending the actual (empty) patch request.