### PR TITLE
Fix overrides when applied to container resource fields

### DIFF
--- a/internal/resource/mutation/mutation.go
+++ b/internal/resource/mutation/mutation.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"regexp"
-	"strconv"
 
 	apiv1 "github.com/Azure/eno/api/v1"
 	"github.com/google/cel-go/cel"
@@ -14,7 +13,11 @@ import (
 	enocel "github.com/Azure/eno/internal/cel"
 )
 
-var quotedStringRegex = regexp.MustCompile(`^(['"])(.*?)(['"])$`)
+var (
+	quotedStringRegex       = regexp.MustCompile(`^(['"])(.*?)(['"])$`)
+	escapedDoubleQuoteRegex = regexp.MustCompile(`\\"`)
+	escapedSingleQuoteRegex = regexp.MustCompile(`\\'`)
+)
 
 // Op is an operation that conditionally assigns a value to a path within an object.
 // Designed to be sent over the wire as JSON.
@@ -74,12 +77,20 @@ func (o *Op) Apply(ctx context.Context, comp *apiv1.Composition, current, mutate
 
 // unquoteKey removes quotes from a key string, handling both single and double quotes
 func unquoteKey(key string) string {
-	if matches := quotedStringRegex.FindStringSubmatch(key); matches != nil {
-		if matches[1] == matches[3] {
-			return matches[2]
-		}
+	matches := quotedStringRegex.FindStringSubmatch(key)
+	if matches == nil || matches[1] != matches[3] {
+		return key
 	}
-	return key
+
+	content := matches[2]
+	switch matches[1] {
+	case `"`:
+		return escapedDoubleQuoteRegex.ReplaceAllString(content, `"`)
+	case `'`:
+		return escapedSingleQuoteRegex.ReplaceAllString(content, `'`)
+	default:
+		return content
+	}
 }
 
 // Apply applies a mutation i.e. sets the value(s) referred to by the path expression.
@@ -103,36 +114,23 @@ func apply(path *PathExpr, startIndex int, obj any, value any) error {
 	state := obj
 
 	for i, section := range path.ast.Sections[startIndex:] {
+		isLastSection := startIndex+i == len(path.ast.Sections)-1
+
 		// Map field indexing
-		if section.Field != nil {
+		if section.Field != nil || (section.Index != nil && section.Index.Key != nil) {
 			m, ok := state.(map[string]any)
 			if !ok {
 				continue
 			}
-			if startIndex+i == len(path.ast.Sections)-1 {
-				if value == nil {
-					delete(m, *section.Field)
-				} else {
-					m[*section.Field] = value
-				}
-				return nil
-			}
-			state = m[*section.Field]
-			continue
-		}
 
-		if section.Index == nil {
-			continue // should be impossible
-		}
-
-		// Alternative map field indexing
-		if key := section.Index.Key; key != nil {
-			m, ok := state.(map[string]any)
-			if !ok {
-				continue
+			var keyStr string
+			if section.Field != nil {
+				keyStr = *section.Field
+			} else {
+				keyStr = unquoteKey(*section.Index.Key)
 			}
-			keyStr := unquoteKey(*key)
-			if startIndex+i == len(path.ast.Sections)-1 {
+
+			if isLastSection {
 				if value == nil {
 					delete(m, keyStr)
 				} else {
@@ -140,7 +138,23 @@ func apply(path *PathExpr, startIndex int, obj any, value any) error {
 				}
 				return nil
 			}
-			state = m[keyStr]
+
+			nextState := m[keyStr]
+			if nextState != nil {
+				err := apply(path, startIndex+i+1, nextState, value)
+				if err != nil {
+					return err
+				}
+				if value == nil {
+					if nextMap, ok := nextState.(map[string]any); ok && len(nextMap) == 0 {
+						delete(m, keyStr)
+					}
+				}
+			}
+			return nil
+		}
+
+		if section.Index == nil {
 			continue
 		}
 
@@ -154,12 +168,18 @@ func apply(path *PathExpr, startIndex int, obj any, value any) error {
 			if *el < 0 || *el >= len(slice) {
 				return fmt.Errorf("index %d out of range for slice of length %d", *el, len(slice))
 			}
-			if startIndex+i == len(path.ast.Sections)-1 {
+			if isLastSection {
 				slice[*el] = value
 				return nil
 			}
-			state = slice[*el]
-			continue
+			nextState := slice[*el]
+			if nextState != nil {
+				err := apply(path, startIndex+i+1, nextState, value)
+				if err != nil {
+					return err
+				}
+			}
+			return nil
 		}
 
 		// Complex array indexing (wildcard or matcher)
@@ -175,14 +195,14 @@ func apply(path *PathExpr, startIndex int, obj any, value any) error {
 				}
 				val := m[section.Index.Matcher.Key]
 				str, ok := val.(string)
-				expected, _ := strconv.Unquote(section.Index.Matcher.Value)
+				expected := unquoteKey(section.Index.Matcher.Value)
 				if !ok || str != expected {
 					continue // not matched by the matcher
 				}
 			}
 
-			if isMap && startIndex+i < len(path.ast.Sections)-1 {
-				err := apply(path, i+1, cur, value) // recurse into object
+			if isMap && !isLastSection {
+				err := apply(path, startIndex+i+1, cur, value)
 				if err != nil {
 					return err
 				}

--- a/internal/resource/mutation/mutation_test.go
+++ b/internal/resource/mutation/mutation_test.go
@@ -186,7 +186,6 @@ func TestApply(t *testing.T) {
 				map[string]any{"name": 234},
 			}},
 		},
-
 		{
 			name: "Slice_MapMatcherEscapedQuote",
 			path: "self.foo[name=\"test-\\\"-1\"].bar",
@@ -229,6 +228,72 @@ func TestApply(t *testing.T) {
 				map[string]any{"name": "test-2"},
 				map[string]any{"name": 234},
 			}},
+		},
+		{
+			name:  "Complex_Nil",
+			path:  "self.spec.template.spec.containers[name='foo'].resources.limits.cpu",
+			value: nil,
+			obj: map[string]any{
+				"spec": map[string]any{
+					"selector": map[string]any{
+						"matchLabels": map[string]any{
+							"foo": "bar",
+						},
+					},
+					"template": map[string]any{
+						"metadata": map[string]any{
+							"labels": map[string]any{
+								"foo": "bar",
+							},
+						},
+						"spec": map[string]any{
+							"containers": []any{
+								map[string]any{
+									"name":  "foo",
+									"image": "bar",
+									"resources": map[string]any{
+										"requests": map[string]any{
+											"cpu": "5m",
+										},
+										"limits": map[string]any{
+											"cpu": "10m",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: map[string]any{
+				"spec": map[string]any{
+					"selector": map[string]any{
+						"matchLabels": map[string]any{
+							"foo": "bar",
+						},
+					},
+					"template": map[string]any{
+						"metadata": map[string]any{
+							"labels": map[string]any{
+								"foo": "bar",
+							},
+						},
+						"spec": map[string]any{
+							"containers": []any{
+								map[string]any{
+									"name":  "foo",
+									"image": "bar",
+									"resources": map[string]any{
+										"requests": map[string]any{
+											"cpu": "5m",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
 		},
 		{
 			name:    "Empty",


### PR DESCRIPTION
- Single quotes are handled correctly by SMD expressions (e.g. field ownership checks) but not when actually applying overrides (leftover of #444)
- The override `Apply` func doesn't prune maps that are empty after overrides, which apiserver expects

This PR also does a bit of refactoring to both `Apply` and `unquoteKey` - hopefully the diff isn't too difficult to read.