### PR TITLE
Fix smoke test flake

### DIFF
--- a/examples/104-overrides/example.yaml
+++ b/examples/104-overrides/example.yaml
@@ -18,7 +18,7 @@ spec:
             "data":{"someKey":"someVal"},
             "kind":"ConfigMap",
             "metadata":{
-              "name":"some-config",
+              "name":"overridden-config",
               "namespace": "default",
               "annotations": {
                 "eno.azure.io/overrides": "[{ \"path\": \"self.data.someKey\", \"value\": \"overrideValue\", \"condition\": \"!has(self.data.disableOverrides)\" }]"


### PR DESCRIPTION
The minimal and override example have a resource that shares the same kind/name so sometimes they fight