### PR TITLE
Potential fix for code scanning alert no. 6: Incorrect conversion between integer types

### DIFF
--- a/examples/02-go-synthesizer/main.go
+++ b/examples/02-go-synthesizer/main.go
@@ -24,7 +24,7 @@ func synthesize(inputs Inputs) ([]client.Object, error) {
 	deploy.Kind = "Deployment"
 	deploy.Name = "example-nginx-deployment"
 	deploy.Namespace = "default"
-	deploy.Spec.Replicas = ptr.To(replicas)
+	deploy.Spec.Replicas = ptr.To(int32(replicas))
 	deploy.Spec.Selector = &metav1.LabelSelector{MatchLabels: map[string]string{"app": "nginx-example"}}
 	deploy.Spec.Template = corev1.PodTemplateSpec{
 		ObjectMeta: metav1.ObjectMeta{

--- a/examples/02-go-synthesizer/main.go
+++ b/examples/02-go-synthesizer/main.go
@@ -16,10 +16,7 @@ type Inputs struct {
 }
 
 func synthesize(inputs Inputs) ([]client.Object, error) {
-	replicas64, err := strconv.ParseInt(inputs.Config.Data["replicas"], 10, 32)
-	if err != nil {
-		return nil, err
-	}
+	replicas, _ := strconv.ParseInt(inputs.Config.Data["replicas"], 10, 32)
 	replicas := int32(replicas64)
 
 	deploy := &appsv1.Deployment{}

--- a/examples/02-go-synthesizer/main.go
+++ b/examples/02-go-synthesizer/main.go
@@ -17,7 +17,6 @@ type Inputs struct {
 
 func synthesize(inputs Inputs) ([]client.Object, error) {
 	replicas, _ := strconv.ParseInt(inputs.Config.Data["replicas"], 10, 32)
-	replicas := int32(replicas64)
 
 	deploy := &appsv1.Deployment{}
 	deploy.APIVersion = "apps/v1"

--- a/examples/02-go-synthesizer/main.go
+++ b/examples/02-go-synthesizer/main.go
@@ -16,14 +16,18 @@ type Inputs struct {
 }
 
 func synthesize(inputs Inputs) ([]client.Object, error) {
-	replicas, _ := strconv.Atoi(inputs.Config.Data["replicas"])
+	replicas64, err := strconv.ParseInt(inputs.Config.Data["replicas"], 10, 32)
+	if err != nil {
+		return nil, err
+	}
+	replicas := int32(replicas64)
 
 	deploy := &appsv1.Deployment{}
 	deploy.APIVersion = "apps/v1"
 	deploy.Kind = "Deployment"
 	deploy.Name = "example-nginx-deployment"
 	deploy.Namespace = "default"
-	deploy.Spec.Replicas = ptr.To(int32(replicas))
+	deploy.Spec.Replicas = ptr.To(replicas)
 	deploy.Spec.Selector = &metav1.LabelSelector{MatchLabels: map[string]string{"app": "nginx-example"}}
 	deploy.Spec.Template = corev1.PodTemplateSpec{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
Potential fix for [https://github.com/Azure/eno/security/code-scanning/6](https://github.com/Azure/eno/security/code-scanning/6)

To fix the issue, we need to ensure that the conversion from `int` to `int32` is safe. This can be achieved by:
1. Adding bounds checks to ensure the parsed value is within the valid range for `int32` before performing the conversion.
2. Alternatively, using `strconv.ParseInt` with a bit size of 32 to directly parse the string into a value that fits within the `int32` range.

The best approach is to use `strconv.ParseInt` with a bit size of 32, as it simplifies the code and avoids the need for manual bounds checking. If the parsed value exceeds the bounds of `int32`, `strconv.ParseInt` will return an error.

Changes to make:
- Replace `strconv.Atoi` with `strconv.ParseInt` specifying a bit size of 32.
- Handle any parsing errors appropriately.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
