### PR TITLE
Block reconciliation on bad override expression

### DIFF
--- a/internal/resource/mutation/mutation.go
+++ b/internal/resource/mutation/mutation.go
@@ -65,7 +65,7 @@ func (o *Op) Apply(ctx context.Context, comp *apiv1.Composition, current, mutate
 	if o.Condition != nil {
 		val, err := enocel.Eval(ctx, o.Condition, comp, current, o.Path)
 		if err != nil {
-			return nil // fail closed (too noisy to log)
+			return fmt.Errorf("evaluating condition: %w", err)
 		}
 		if b, ok := val.Value().(bool); !ok || !b {
 			return nil // condition not met


### PR DESCRIPTION
The permissive logic was originally intended to avoid deadlocks caused by cel expressions that don't evaluate successfully given some states or the resource. But I've witnessed a few cases where it's dangerous: overrides can't necessarily fail open safely. 