### PR TITLE
Remove unused field (PodCreation)

### DIFF
--- a/api/v1/composition.go
+++ b/api/v1/composition.go
@@ -91,9 +91,6 @@ type Synthesis struct {
 	// Initialized is set when the synthesis process is initiated.
 	Initialized *metav1.Time `json:"initialized,omitempty"`
 
-	// Time at which the most recent synthesizer pod was created.
-	PodCreation *metav1.Time `json:"podCreation,omitempty"`
-
 	// Time at which the synthesis completed i.e. resourceSlices was written
 	Synthesized *metav1.Time `json:"synthesized,omitempty"`
 

--- a/api/v1/config/crd/eno.azure.io_compositions.yaml
+++ b/api/v1/config/crd/eno.azure.io_compositions.yaml
@@ -169,11 +169,6 @@ spec:
                       This is a min i.e. a newer composition may have been used.
                     format: int64
                     type: integer
-                  podCreation:
-                    description: Time at which the most recent synthesizer pod was
-                      created.
-                    format: date-time
-                    type: string
                   ready:
                     description: Time at which the synthesis's reconciled resources
                       became ready.
@@ -276,11 +271,6 @@ spec:
                       This is a min i.e. a newer composition may have been used.
                     format: int64
                     type: integer
-                  podCreation:
-                    description: Time at which the most recent synthesizer pod was
-                      created.
-                    format: date-time
-                    type: string
                   ready:
                     description: Time at which the synthesis's reconciled resources
                       became ready.
@@ -400,11 +390,6 @@ spec:
                       This is a min i.e. a newer composition may have been used.
                     format: int64
                     type: integer
-                  podCreation:
-                    description: Time at which the most recent synthesizer pod was
-                      created.
-                    format: date-time
-                    type: string
                   ready:
                     description: Time at which the synthesis's reconciled resources
                       became ready.

--- a/api/v1/zz_generated.deepcopy.go
+++ b/api/v1/zz_generated.deepcopy.go
@@ -623,10 +623,6 @@ func (in *Synthesis) DeepCopyInto(out *Synthesis) {
 		in, out := &in.Initialized, &out.Initialized
 		*out = (*in).DeepCopy()
 	}
-	if in.PodCreation != nil {
-		in, out := &in.PodCreation, &out.PodCreation
-		*out = (*in).DeepCopy()
-	}
 	if in.Synthesized != nil {
 		in, out := &in.Synthesized, &out.Synthesized
 		*out = (*in).DeepCopy()


### PR DESCRIPTION
This hasn't been used since the rewrite of the synthesis lifecycle controller (several months ago).