### PR TITLE
Fix broken test

### DIFF
--- a/internal/resource/resource_test.go
+++ b/internal/resource/resource_test.go
@@ -98,42 +98,6 @@ var newResourceTests = []struct {
 		},
 	},
 	{
-		Name: "conditional replace override, positive",
-		Manifest: `{
-			"apiVersion": "apps/v1",
-			"kind": "Deployment",
-			"metadata": {
-				"name": "foo",
-				"namespace": "bar",
-				"annotations": {
-					"trigger-replace": "yespls",
-					"eno.azure.io/overrides": "[{\"path\":\"self.metadata.annotations[\\\"eno.azure.io/replace\\\"]\", \"value\":\"true\", \"condition\": \"self.metadata.annotations[\\\"trigger-replace\\\"] == 'yespls'\"}]"
-				}
-			}
-		}`,
-		Assert: func(t *testing.T, r *Snapshot) {
-			assert.True(t, r.Replace)
-		},
-	},
-	{
-		Name: "conditional replace override, negative",
-		Manifest: `{
-			"apiVersion": "apps/v1",
-			"kind": "Deployment",
-			"metadata": {
-				"name": "foo",
-				"namespace": "bar",
-				"annotations": {
-					"trigger-replace": "nothx",
-					"eno.azure.io/overrides": "[{\"path\":\"self.metadata.annotations[\\\"eno.azure.io/replace\\\"]\", \"value\":\"true\", \"condition\": \"self.metadata.annotations[\\\"trigger-replace\\\"] == 'yespls'\"}]"
-				}
-			}
-		}`,
-		Assert: func(t *testing.T, r *Snapshot) {
-			assert.False(t, r.Replace)
-		},
-	},
-	{
 		Name: "zero-readiness-group",
 		Manifest: `{
 			"apiVersion": "v1",
@@ -411,7 +375,7 @@ func TestNewResource(t *testing.T) {
 			}, 0)
 			require.NoError(t, err)
 
-			rs, err := r.Snapshot(t.Context(), &apiv1.Composition{}, r.UnstructuredWithoutOverrides())
+			rs, err := r.Snapshot(t.Context(), &apiv1.Composition{}, nil)
 			require.NoError(t, err)
 			tc.Assert(t, rs)
 		})


### PR DESCRIPTION
#461 was merged with stale tests and broke some unit tests due to a conflict with other changes that recently merged.

This quickly fixes the tests by removing some redundant test coverage. Making these tests work after the conflicting change isn't worth the time since we already have coverage of that behavior elsewhere.