### PR TITLE
Tolerate nil current object in CEL runtime

### DIFF
--- a/internal/cel/cel.go
+++ b/internal/cel/cel.go
@@ -49,8 +49,10 @@ func Parse(expr string) (cel.Program, error) {
 
 func Eval(ctx context.Context, prgm cel.Program, comp *apiv1.Composition, self *unstructured.Unstructured, fm FieldMetadata) (ref.Val, error) {
 	args := map[string]any{
-		"self":        self.Object,
-		"composition": func() any { return newCompositionMap(comp) }, // cel will only execute this is the composition is referenced in the expression
+		"composition": func() any { return newCompositionMap(comp) }, // cel will only execute this if the composition is referenced in the expression
+	}
+	if self != nil {
+		args["self"] = self.Object
 	}
 	if fm != nil {
 		args["pathManagedByEno"] = func() any { return fm.ManagedByEno(ctx, self) }

--- a/internal/cel/cel_test.go
+++ b/internal/cel/cel_test.go
@@ -16,7 +16,7 @@ func TestEvalCompositionBasics(t *testing.T) {
 	comp := &apiv1.Composition{}
 	comp.Name = "test-comp"
 
-	val, err := Eval(t.Context(), p, comp, &unstructured.Unstructured{}, nil)
+	val, err := Eval(t.Context(), p, comp, nil, nil)
 	require.NoError(t, err)
 	assert.Equal(t, "test-comp", val.Value())
 }


### PR DESCRIPTION
Currently the `internal/cel` package assumes that the current object is non-nil. There are checks in the caller to guarantee this, but the behavior doesn't actually make sense - users may want conditions that match on the composition metadata regardless of if the resource already exists.

So this change just updates the cel package in anticipation of the caller-side change.