### PR TITLE
Evaluate override conditions during resource creation

### DIFF
--- a/internal/resource/mutation/mutation.go
+++ b/internal/resource/mutation/mutation.go
@@ -58,13 +58,9 @@ func (o *Op) UnmarshalJSON(data []byte) error {
 
 // Apply applies the operation to the "mutated" object if the condition is met by the "current" object.
 func (o *Op) Apply(ctx context.Context, comp *apiv1.Composition, current, mutated *unstructured.Unstructured) error {
-	if current == nil && o.Condition != nil {
-		return nil // impossible condition
-	}
-
 	if o.Condition != nil {
 		val, err := enocel.Eval(ctx, o.Condition, comp, current, o.Path)
-		if err != nil {
+		if err != nil && current == nil {
 			return nil // fail closed (too noisy to log)
 		}
 		if b, ok := val.Value().(bool); !ok || !b {

--- a/internal/resource/mutation/mutation_test.go
+++ b/internal/resource/mutation/mutation_test.go
@@ -367,7 +367,7 @@ func TestOpApply(t *testing.T) {
 			expectedMutated: &unstructured.Unstructured{Object: map[string]any{}},
 		},
 		{
-			name: "NilCurrentWithCondition_NoMutation",
+			name: "NilCurrentWithStaticCondition_MutationApplied",
 			op: Op{
 				Path:      mustParsePathExpr("self.foo"),
 				Condition: mustParseCondition("true"),
@@ -375,7 +375,41 @@ func TestOpApply(t *testing.T) {
 			},
 			current:         nil,
 			mutated:         &unstructured.Unstructured{Object: map[string]any{}},
+			expectedMutated: &unstructured.Unstructured{Object: map[string]any{"foo": "bar"}},
+		},
+		{
+			name: "NilCurrentWithCondition_NoMutation",
+			op: Op{
+				Path:      mustParsePathExpr("self.foo"),
+				Condition: mustParseCondition("self.bar"),
+				Value:     "bar",
+			},
+			current:         nil,
+			mutated:         &unstructured.Unstructured{Object: map[string]any{}},
 			expectedMutated: &unstructured.Unstructured{Object: map[string]any{}},
+		},
+		{
+			name: "NilCurrentWithFalsyCondition_NoMutation",
+			op: Op{
+				Path:      mustParsePathExpr("self.foo"),
+				Condition: mustParseCondition("false"),
+				Value:     "bar",
+			},
+			current:         nil,
+			mutated:         &unstructured.Unstructured{Object: map[string]any{}},
+			expectedMutated: &unstructured.Unstructured{Object: map[string]any{}},
+		},
+		{
+			name: "NilCurrentWithNoCondition_MutationApplied",
+			op: Op{
+				Path:  mustParsePathExpr("self.foo"),
+				Value: "bar",
+			},
+			current: nil,
+			mutated: &unstructured.Unstructured{Object: map[string]any{}},
+			expectedMutated: &unstructured.Unstructured{Object: map[string]any{
+				"foo": "bar",
+			}},
 		},
 		{
 			name: "NoCondition_MutationApplied",


### PR DESCRIPTION
Currently overrides fail closed whenever the resource doesn't exist. This made sense when conditions could only reference the current state of the resource. But now that they can reference the composition metadata it doesn't make sense.