### PR TITLE
Test helper for resource metadata

### DIFF
--- a/internal/controllers/reconciliation/helpers_test.go
+++ b/internal/controllers/reconciliation/helpers_test.go
@@ -88,7 +88,7 @@ func mapToResource(t *testing.T, res map[string]any) (*unstructured.Unstructured
 
 	slice := &apiv1.ResourceSlice{}
 	slice.Spec.Resources = []apiv1.Manifest{{Manifest: string(js)}}
-	rr, err := resource.NewResource(context.Background(), slice, 0)
+	rr, err := resource.FromSlice(context.Background(), slice, 0)
 	require.NoError(t, err)
 
 	return obj, rr

--- a/internal/resource/cache.go
+++ b/internal/resource/cache.go
@@ -98,7 +98,7 @@ func (c *Cache) Fill(ctx context.Context, comp types.NamespacedName, synUUID str
 	for _, slice := range items {
 		slice := slice
 		for i := range slice.Spec.Resources {
-			res, err := NewResource(ctx, &slice, i)
+			res, err := FromSlice(ctx, &slice, i)
 			if err != nil {
 				// This should be impossible since the synthesis executor process will not produce invalid resources
 				logger.Error(err, "invalid resource - cannot load into cache", "resourceSliceName", slice.Name, "resourceIndex", i)

--- a/internal/resource/resource_test.go
+++ b/internal/resource/resource_test.go
@@ -368,7 +368,7 @@ func TestNewResource(t *testing.T) {
 	ctx := context.Background()
 	for _, tc := range newResourceTests {
 		t.Run(tc.Name, func(t *testing.T) {
-			r, err := NewResource(ctx, &apiv1.ResourceSlice{
+			r, err := FromSlice(ctx, &apiv1.ResourceSlice{
 				Spec: apiv1.ResourceSliceSpec{
 					Resources: []apiv1.Manifest{{Manifest: tc.Manifest}},
 				},
@@ -814,7 +814,7 @@ func TestSnapshotPatch(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.Name, func(t *testing.T) {
-			r, err := NewResource(ctx, &apiv1.ResourceSlice{
+			r, err := FromSlice(ctx, &apiv1.ResourceSlice{
 				Spec: apiv1.ResourceSliceSpec{
 					Resources: []apiv1.Manifest{{Manifest: tc.Manifest}},
 				},

--- a/pkg/functiontest/synthlint.go
+++ b/pkg/functiontest/synthlint.go
@@ -1,11 +1,13 @@
 package functiontest
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"reflect"
 	"testing"
 
+	apiv1 "github.com/Azure/eno/api/v1"
 	enov1 "github.com/Azure/eno/api/v1"
 	"github.com/Azure/eno/internal/resource"
 	"github.com/Azure/eno/pkg/function"
@@ -121,10 +123,18 @@ func validateResourceMeta(t require.TestingT, outputs []client.Object) {
 			t.Errorf("resource at index=%d, kind=%s, name=%s could not be converted to unstructured: %s", i, output.GetObjectKind(), output.GetName(), err)
 			continue
 		}
+		u := &unstructured.Unstructured{Object: obj}
 
-		_, err = resource.FromUnstructured(&unstructured.Unstructured{Object: obj})
+		res, err := resource.FromUnstructured(u)
 		if err != nil {
 			t.Errorf("resource at index=%d, kind=%s, name=%s is invalid: %s", i, output.GetObjectKind(), output.GetName(), err)
+			continue
+		}
+
+		_, err = res.Snapshot(context.Background(), &apiv1.Composition{}, u)
+		if err != nil {
+			t.Errorf("resource at index=%d, kind=%s, name=%s is invalid: %s", i, output.GetObjectKind(), output.GetName(), err)
+			continue
 		}
 	}
 }

--- a/pkg/functiontest/synthlint.go
+++ b/pkg/functiontest/synthlint.go
@@ -110,17 +110,21 @@ func loadSynthesizerRefs(synthesizerPath string) ([]string, error) {
 // e.g. contain only valid metadata like eno.azure.io/* annotations.
 func ValidateResourceMeta[T function.Inputs]() Assertion[T] {
 	return func(t *testing.T, s *Scenario[T], outputs []client.Object) {
-		for i, output := range outputs {
-			obj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(output)
-			if err != nil {
-				t.Errorf("resource at index=%d, kind=%s, name=%s could not be converted to unstructured: %s", i, output.GetObjectKind(), output.GetName(), err)
-				continue
-			}
+		validateResourceMeta(t, outputs)
+	}
+}
 
-			_, err = resource.FromUnstructured(&unstructured.Unstructured{Object: obj})
-			if err != nil {
-				t.Errorf("resource at index=%d, kind=%s, name=%s is invalid: %s", i, output.GetObjectKind(), output.GetName(), err)
-			}
+func validateResourceMeta(t require.TestingT, outputs []client.Object) {
+	for i, output := range outputs {
+		obj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(output)
+		if err != nil {
+			t.Errorf("resource at index=%d, kind=%s, name=%s could not be converted to unstructured: %s", i, output.GetObjectKind(), output.GetName(), err)
+			continue
+		}
+
+		_, err = resource.FromUnstructured(&unstructured.Unstructured{Object: obj})
+		if err != nil {
+			t.Errorf("resource at index=%d, kind=%s, name=%s is invalid: %s", i, output.GetObjectKind(), output.GetName(), err)
 		}
 	}
 }

--- a/pkg/functiontest/synthlint_test.go
+++ b/pkg/functiontest/synthlint_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // Test structures with eno_key tags
@@ -57,6 +59,22 @@ func TestInputsMatchSynthesizerRefs(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestEvaluateValidateResourceMeta(t *testing.T) {
+	fn := func(inputs struct{}) ([]client.Object, error) {
+		output := &corev1.Pod{}
+		output.APIVersion = "v1"
+		output.Kind = "Pod"
+		output.Name = "test-pod"
+		return []client.Object{output}, nil
+	}
+
+	Evaluate(t, fn, Scenario[struct{}]{
+		Name:      "example-test",
+		Inputs:    struct{}{},
+		Assertion: ValidateResourceMeta[struct{}](),
+	})
 }
 
 // Mock implementation of require.TestingT to capture test failures

--- a/pkg/functiontest/synthlint_test.go
+++ b/pkg/functiontest/synthlint_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -75,6 +76,13 @@ func TestEvaluateValidateResourceMeta(t *testing.T) {
 		Inputs:    struct{}{},
 		Assertion: ValidateResourceMeta[struct{}](),
 	})
+}
+
+func TestValidateResourceMetaFailure(t *testing.T) {
+	mockT := &mockTestingT{}
+	validateResourceMeta(mockT, []client.Object{&unstructured.Unstructured{}})
+	assert.True(t, mockT.failed)
+	assert.Contains(t, mockT.errorMsg, "missing")
 }
 
 // Mock implementation of require.TestingT to capture test failures


### PR DESCRIPTION
Adds `ValidateResourceMeta` which will fail if any of the synthesized resources aren't valid from Eno's perspective i.e. have invalid eno.azure.io/* annotations.