### PR TITLE
Validate before swap

### DIFF
--- a/internal/execution/executor.go
+++ b/internal/execution/executor.go
@@ -190,7 +190,7 @@ func (e *Executor) fetchPreviousSlices(ctx context.Context, comp *apiv1.Composit
 		slice.Namespace = comp.Namespace
 		err := e.Reader.Get(ctx, client.ObjectKeyFromObject(slice), slice)
 		if errors.IsNotFound(err) {
-			logger.V(0).Info("resource slice referenced by composition was not found - skipping", "resourceSliceName", slice.Name)
+			logger.Error(nil, "resource slice referenced by composition was not found - skipping", "resourceSliceName", slice.Name)
 			continue
 		}
 		if err != nil {


### PR DESCRIPTION
Currently eno-reconciler ignores any invalid `eno.azure.io*` annotations - essentially failing open when parsing them.

Mostly this is fine but can result in unexpected behavior. This change prevents a new synthesis from being swapped into the `currentSynthesis` slot if any resources fail the existing validations.