### PR TITLE
Support eno.azure.io/disable-reconciliation

### DIFF
--- a/internal/controllers/reconciliation/controller.go
+++ b/internal/controllers/reconciliation/controller.go
@@ -168,6 +168,10 @@ func (c *Controller) Reconcile(ctx context.Context, req resource.Request) (ctrl.
 }
 
 func (c *Controller) reconcileResource(ctx context.Context, comp *apiv1.Composition, prev *resource.Resource, res *resource.Snapshot, current *unstructured.Unstructured) (bool, error) {
+	if res.Disable {
+		return false, nil
+	}
+
 	logger := logr.FromContextOrDiscard(ctx)
 	start := time.Now()
 	defer func() {

--- a/internal/resource/resource_test.go
+++ b/internal/resource/resource_test.go
@@ -40,6 +40,7 @@ var newResourceTests = []struct {
 					"eno.azure.io/readiness": "true",
 					"eno.azure.io/readiness-test": "false",
 					"eno.azure.io/replace": "true",
+					"eno.azure.io/disable-reconciliation": "true",
 					"eno.azure.io/disable-updates": "true",
 					"eno.azure.io/deletion-strategy": "orphan",
 					"eno.azure.io/overrides": "[{\"path\":\".self.foo\"}, {\"path\":\".self.bar\"}]"
@@ -56,6 +57,7 @@ var newResourceTests = []struct {
 				Group:     "",
 				Kind:      "ConfigMap",
 			}, r.Ref)
+			assert.True(t, r.Disable)
 			assert.True(t, r.DisableUpdates)
 			assert.True(t, r.Replace)
 			assert.True(t, r.Orphan)


### PR DESCRIPTION
It's like disable-updates but also disables creation and deletion. Mostly useful for gracefully migrating to Eno and moving the ownership of existing resources between synthesizers.