### PR TITLE
Fix disable-reconciliation during composition deletion

### DIFF
--- a/internal/controllers/reconciliation/controller.go
+++ b/internal/controllers/reconciliation/controller.go
@@ -161,7 +161,7 @@ func (c *Controller) Reconcile(ctx context.Context, req resource.Request) (ctrl.
 
 	deleted := current == nil ||
 		current.GetDeletionTimestamp() != nil ||
-		(snap.Deleted(comp) && snap.Orphan) // orphaning should be reflected on the status.
+		(snap.Deleted(comp) && (snap.Orphan || snap.Disable)) // orphaning should be reflected on the status.
 	c.writeBuffer.PatchStatusAsync(ctx, &resource.ManifestRef, patchResourceState(deleted, ready))
 
 	return c.requeue(logger, comp, snap, ready)


### PR DESCRIPTION
The resource slice controller prevents compositions with `DeletionTimestamp != nil` from being marked as reconciled if any of their resources have `Deleted==false`.

https://github.com/Azure/eno/blob/0e363bb2e88a8ff2c6243637bdfc784eadbae69a/internal/controllers/resourceslice/slice.go#L177

Setting the `eno.azure.io/disable-reconcilation` annotation causes resource deletion to be skipped __and__ it prevents `Deleted=true` from being set in the resource slice status, which causes a deadlock.

The fix is the handle `disable-reconciliation: true` in the same way that we handle `deletion-mode: orphan`