### PR TITLE
Enable transferring resources between compositions

### DIFF
--- a/internal/controllers/reconciliation/controller.go
+++ b/internal/controllers/reconciliation/controller.go
@@ -358,7 +358,7 @@ func (c *Controller) requeue(logger logr.Logger, comp *apiv1.Composition, resour
 		return ctrl.Result{RequeueAfter: wait.Jitter(c.readinessPollInterval, 0.1)}, nil
 	}
 
-	if resource == nil || resource.Deleted(comp) || resource.ReconcileInterval == nil {
+	if resource == nil || (resource.Deleted(comp) && !resource.Disable) || resource.ReconcileInterval == nil {
 		return ctrl.Result{}, nil
 	}
 

--- a/internal/resource/mutation/mutation.go
+++ b/internal/resource/mutation/mutation.go
@@ -58,13 +58,9 @@ func (o *Op) UnmarshalJSON(data []byte) error {
 
 // Apply applies the operation to the "mutated" object if the condition is met by the "current" object.
 func (o *Op) Apply(ctx context.Context, comp *apiv1.Composition, current, mutated *unstructured.Unstructured) error {
-	if current == nil && o.Condition != nil {
-		return nil // impossible condition
-	}
-
 	if o.Condition != nil {
 		val, err := enocel.Eval(ctx, o.Condition, comp, current, o.Path)
-		if err != nil {
+		if err != nil && current == nil { // fail open on eval errors during initial creation (since many exprs require a current state)
 			return nil // fail closed (too noisy to log)
 		}
 		if b, ok := val.Value().(bool); !ok || !b {

--- a/internal/resource/mutation/mutation_test.go
+++ b/internal/resource/mutation/mutation_test.go
@@ -367,7 +367,7 @@ func TestOpApply(t *testing.T) {
 			expectedMutated: &unstructured.Unstructured{Object: map[string]any{}},
 		},
 		{
-			name: "NilCurrentWithCondition_NoMutation",
+			name: "NilCurrentWithStaticCondition_MutationApplied",
 			op: Op{
 				Path:      mustParsePathExpr("self.foo"),
 				Condition: mustParseCondition("true"),
@@ -375,7 +375,41 @@ func TestOpApply(t *testing.T) {
 			},
 			current:         nil,
 			mutated:         &unstructured.Unstructured{Object: map[string]any{}},
+			expectedMutated: &unstructured.Unstructured{Object: map[string]any{"foo": "bar"}},
+		},
+		{
+			name: "NilCurrentWithCondition_NoMutation",
+			op: Op{
+				Path:      mustParsePathExpr("self.foo"),
+				Condition: mustParseCondition("self.bar"),
+				Value:     "bar",
+			},
+			current:         nil,
+			mutated:         &unstructured.Unstructured{Object: map[string]any{}},
 			expectedMutated: &unstructured.Unstructured{Object: map[string]any{}},
+		},
+		{
+			name: "NilCurrentWithFalsyCondition_NoMutation",
+			op: Op{
+				Path:      mustParsePathExpr("self.foo"),
+				Condition: mustParseCondition("false"),
+				Value:     "bar",
+			},
+			current:         nil,
+			mutated:         &unstructured.Unstructured{Object: map[string]any{}},
+			expectedMutated: &unstructured.Unstructured{Object: map[string]any{}},
+		},
+		{
+			name: "NilCurrentWithNoCondition_MutationApplied",
+			op: Op{
+				Path:  mustParsePathExpr("self.foo"),
+				Value: "bar",
+			},
+			current: nil,
+			mutated: &unstructured.Unstructured{Object: map[string]any{}},
+			expectedMutated: &unstructured.Unstructured{Object: map[string]any{
+				"foo": "bar",
+			}},
 		},
 		{
 			name: "NoCondition_MutationApplied",
@@ -396,6 +430,16 @@ func TestOpApply(t *testing.T) {
 				Value: "bar",
 			},
 			current: &unstructured.Unstructured{Object: map[string]any{}},
+			mutated: &unstructured.Unstructured{Object: map[string]any{}},
+			wantErr: true,
+		},
+		{
+			name: "NilCurrent_InvalidPath_Error",
+			op: Op{
+				Path:  mustParsePathExpr("invalid.foo"),
+				Value: "bar",
+			},
+			current: nil,
 			mutated: &unstructured.Unstructured{Object: map[string]any{}},
 			wantErr: true,
 		},


### PR DESCRIPTION
Overrides already have the primitives needed to gracefully transfer the management of resources between synthesizers/compositions using either composition or resource annotations. This PR adds test coverage and makes a couple of small fixes that enable the workflow.

- Honor the `eno.azure.io/reconcile-interval` annotation when `eno.azure.io/disable-reconciliation == 'true'`: this is necessary for cases where the composition receiving ownership of an existing resource is not resynthesized during the migration
- Allow overrides to be applied during initial resource creation: it made sense to block overrides during creation initially since the only value available to override expressions was the current state of the resource, which would naturally be nil. But now that we support composition metadata it doesn't make sense and complicates the resource transfer workflow.