### PR TITLE
Better error handling for invalid synth json

### DIFF
--- a/internal/execution/handler.go
+++ b/internal/execution/handler.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"os"
 	"os/exec"
 
@@ -36,7 +37,7 @@ func NewExecHandler() SynthesizerHandle {
 
 		err := json.NewEncoder(stdin).Encode(rl)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("encoding stdin buffer: %w", err)
 		}
 
 		command := s.Spec.Command
@@ -50,13 +51,13 @@ func NewExecHandler() SynthesizerHandle {
 		cmd.Stdout = stdout
 		err = cmd.Run()
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("executing command: %w", err)
 		}
 
 		output := &krmv1.ResourceList{}
-		err = json.NewDecoder(stdout).Decode(output)
+		err = json.Unmarshal(stdout.Bytes(), output)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("error while parsing synthesizer's stdout as json %q - raw output: %s", err, stdout)
 		}
 
 		return output, nil

--- a/internal/execution/handler_test.go
+++ b/internal/execution/handler_test.go
@@ -39,5 +39,15 @@ func TestExecHandlerEmpty(t *testing.T) {
 	rl := &krmv1.ResourceList{}
 
 	_, err := handle(context.Background(), syn, rl)
-	require.EqualError(t, err, "exec: \"synthesize\": executable file not found in $PATH")
+	require.EqualError(t, err, "executing command: exec: \"synthesize\": executable file not found in $PATH")
+}
+
+func TestExecHandlerInvalidJSON(t *testing.T) {
+	handle := NewExecHandler()
+
+	syn := &apiv1.Synthesizer{}
+	syn.Spec.Command = []string{"/bin/sh", "-c", "echo 'Invalid JSON' > /dev/stdout"}
+	rl := &krmv1.ResourceList{}
+	_, err := handle(context.Background(), syn, rl)
+	require.EqualError(t, err, `error while parsing synthesizer's stdout as json "invalid character 'I' looking for beginning of value" - raw output: Invalid JSON`+"\n")
 }


### PR DESCRIPTION
Causes the raw output string to be logged through the executor wrapper process, which will hopefully help diagnose unexpected/invalid output from synthesizers.