### PR TITLE
Fix test flake

### DIFF
--- a/internal/controllers/reconciliation/edgecase_test.go
+++ b/internal/controllers/reconciliation/edgecase_test.go
@@ -416,7 +416,8 @@ func TestDeletedResourceSlice(t *testing.T) {
 					continue
 				}
 				item.Finalizers = []string{}
-				if err := upstream.Update(ctx, &item); err != nil {
+				err := upstream.Update(ctx, &item)
+				if err != nil && !errors.IsNotFound(err) { // it's possible that some have been deleted before getting a finalizer
 					return err
 				}
 			}


### PR DESCRIPTION
I don't know why this flake only showed up now, but I can't see any way it could be caused by the PRs that have landed since it started so should be safe to paper over it.