### PR TITLE
Add composition status logger

### DIFF
--- a/go.work.sum
+++ b/go.work.sum
@@ -1,6 +1,7 @@
 bazil.org/fuse v0.0.0-20160811212531-371fbbdaa898/go.mod h1:Xbm+BRKSBEpa4q4hTSxohYNQpsxXPbPry4JJWOB3LB8=
 bazil.org/fuse v0.0.0-20200407214033-5883e5a4b512 h1:SRsZGA7aFnCZETmov57jwPrWuTmaZK6+4R4v5FUe1/c=
 bazil.org/fuse v0.0.0-20200407214033-5883e5a4b512/go.mod h1:FbcW6z/2VytnFDhZfumh8Ss8zxHE6qpMP5sHTRe0EaM=
+buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.36.4-20250130201111-63bb56e20495.1/go.mod h1:novQBstnxcGpfKf8qGRATqn1anQKwMJIbH5Q581jibU=
 cel.dev/expr v0.15.0/go.mod h1:TRSuuV7DlVCE/uwv5QbAiW/v8l5O8C4eEPHeu7gf7Sg=
 cel.dev/expr v0.16.0/go.mod h1:TRSuuV7DlVCE/uwv5QbAiW/v8l5O8C4eEPHeu7gf7Sg=
 cel.dev/expr v0.16.1/go.mod h1:AsGA5zb3WruAEQeQng1RZdGEXmBj0jvMWh6l5SnNuC8=
@@ -695,6 +696,7 @@ github.com/bsm/ginkgo/v2 v2.7.0/go.mod h1:AiKlXPm7ItEHNc/2+OkrNG4E0ITzojb9/xWzvQ
 github.com/bsm/ginkgo/v2 v2.12.0/go.mod h1:SwYbGRRDovPVboqFv0tPTcG1sN61LM1Z4ARdbAV9g4c=
 github.com/bsm/gomega v1.26.0/go.mod h1:JyEr/xRbxbtgWNi8tIEVPUYZ5Dzef52k01W3YH0H+O0=
 github.com/bsm/gomega v1.27.10/go.mod h1:JyEr/xRbxbtgWNi8tIEVPUYZ5Dzef52k01W3YH0H+O0=
+github.com/bufbuild/protovalidate-go v0.9.1/go.mod h1:5jptBxfvlY51RhX32zR6875JfPBRXUsQjyZjm/NqkLQ=
 github.com/buger/jsonparser v0.0.0-20180808090653-f4dd9f5a6b44/go.mod h1:bbYlZJ7hK1yFx9hf58LP0zeX7UjIGs20ufpu3evjr+s=
 github.com/buger/jsonparser v1.1.1 h1:2PnMjfWD7wBILjqQbt530v576A/cAbQvEW9gGIpYMUs=
 github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
@@ -1953,6 +1955,7 @@ go.etcd.io/etcd/server/v3 v3.5.21/go.mod h1:G1mOzdwuzKT1VRL7SqRchli/qcFrtLBTAQ4l
 go.etcd.io/etcd/server/v3 v3.6.4/go.mod h1:aYCL/h43yiONOv0QIR82kH/2xZ7m+IWYjzRmyQfnCAg=
 go.etcd.io/gofail v0.1.0 h1:XItAMIhOojXFQMgrxjnd2EIIHun/d5qL0Pf7FzVTkFg=
 go.etcd.io/gofail v0.1.0/go.mod h1:VZBCXYGZhHAinaBiiqYvuDynvahNsAyLFwB3kEHKz1M=
+go.etcd.io/gofail v0.2.0/go.mod h1:nL3ILMGfkXTekKI3clMBNazKnjUZjYLKmBHzsVAnC1o=
 go.etcd.io/raft/v3 v3.6.0/go.mod h1:nLvLevg6+xrVtHUmVaTcTz603gQPHfh7kUAwV6YpfGo=
 go.mozilla.org/pkcs7 v0.0.0-20200128120323-432b2356ecb1 h1:A/5uWzF44DlIgdm/PQFwfMkW0JX+cIcQi/SwLAmZP5M=
 go.mozilla.org/pkcs7 v0.0.0-20200128120323-432b2356ecb1/go.mod h1:SNgMg+EgDFwmvSmLRTNKC5fegJjB7v23qTQ0XLGUNHk=
@@ -2985,6 +2988,7 @@ sigs.k8s.io/kustomize/api v0.20.1/go.mod h1:t6hUFxO+Ph0VxIk1sKp1WS0dOjbPCtLJ4p8a
 sigs.k8s.io/kustomize/cmd/config v0.15.0 h1:WkdY8V2+8J+W00YbImXa2ke9oegfrHH79e+kywW7EdU=
 sigs.k8s.io/kustomize/cmd/config v0.15.0/go.mod h1:Jq57b0nPaoYUlOqg//0JtAh6iibboqMcfbtCYoWPM00=
 sigs.k8s.io/kustomize/cmd/config v0.19.0/go.mod h1:29Vvdl26PidPLUDi7nfjYa/I0wHBkwCZp15Nlcc4y98=
+sigs.k8s.io/kustomize/cmd/config v0.20.1/go.mod h1:R7rQ8kxknVlXWVUIbxWtMgu8DCCNVtl8V0KrmeVd/KE=
 sigs.k8s.io/kustomize/kustomize/v5 v5.0.4-0.20230601165947-6ce0bf390ce3/go.mod h1:/d88dHCvoy7d0AKFT0yytezSGZKjsZBVs9YTkBHSGFk=
 sigs.k8s.io/kustomize/kustomize/v5 v5.5.0 h1:o1mtt6vpxsxDYaZKrw3BnEtc+pAjLz7UffnIvHNbvW0=
 sigs.k8s.io/kustomize/kustomize/v5 v5.5.0/go.mod h1:AeFCmgCrXzmvjWWaeZCyBp6XzG1Y0w1svYus8GhJEOE=

--- a/internal/controllers/composition/controller.go
+++ b/internal/controllers/composition/controller.go
@@ -177,14 +177,10 @@ func (c *compositionController) reconcileDeletedComposition(ctx context.Context,
 }
 
 func (c *compositionController) reconcileSimplifiedStatus(ctx context.Context, synth *apiv1.Synthesizer, comp *apiv1.Composition) (bool, error) {
-	logger := logr.FromContextOrDiscard(ctx)
-
 	next := buildSimplifiedStatus(synth, comp)
 	if equality.Semantic.DeepEqual(next, comp.Status.Simplified) {
 		return false, nil
 	}
-
-	logger.V(0).Info("composition status changed", "status", next, "previousStatus", comp.Status.Simplified)
 
 	copy := comp.DeepCopy()
 	copy.Status.Simplified = next

--- a/internal/controllers/composition/statuslogger.go
+++ b/internal/controllers/composition/statuslogger.go
@@ -1,0 +1,92 @@
+package composition
+
+import (
+	"context"
+	"math/rand/v2"
+	"reflect"
+	"time"
+
+	"github.com/go-logr/logr"
+	"golang.org/x/time/rate"
+	"k8s.io/client-go/util/workqueue"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	apiv1 "github.com/Azure/eno/api/v1"
+	"github.com/Azure/eno/internal/manager"
+)
+
+type statusLogger struct {
+	client    client.Client
+	frequency time.Duration
+	logFn     func(ctx context.Context, msg string, args ...any)
+}
+
+func NewStatusLogger(mgr ctrl.Manager, freq time.Duration) error {
+	c := &statusLogger{
+		client:    mgr.GetClient(),
+		frequency: freq,
+		logFn: func(ctx context.Context, msg string, args ...any) {
+			logr.FromContextOrDiscard(ctx).V(0).Info(msg, args...)
+		},
+	}
+	return ctrl.NewControllerManagedBy(mgr).
+		WithOptions(controller.TypedOptions[reconcile.Request]{
+			// Hardcoded safety limit to avoid spewing too many logs
+			RateLimiter: &workqueue.TypedBucketRateLimiter[reconcile.Request]{Limiter: rate.NewLimiter(rate.Every(time.Second), 50)},
+		}).
+		For(&apiv1.Composition{}, builder.WithPredicates(c.newPredicate())).
+		WithLogConstructor(manager.NewLogConstructor(mgr, "compositionStatusLogger")).
+		Complete(c)
+}
+
+func (c *statusLogger) newPredicate() predicate.Predicate {
+	return &predicate.Funcs{
+		CreateFunc:  func(tce event.TypedCreateEvent[client.Object]) bool { return true },
+		DeleteFunc:  func(tde event.TypedDeleteEvent[client.Object]) bool { return true },
+		GenericFunc: func(tge event.TypedGenericEvent[client.Object]) bool { return false },
+		UpdateFunc: func(tue event.TypedUpdateEvent[client.Object]) bool {
+			compA, okA := tue.ObjectNew.(*apiv1.Composition)
+			compB, okB := tue.ObjectOld.(*apiv1.Composition)
+			return okA && okB && !reflect.DeepEqual(compA.Status.Simplified, compB.Status.Simplified)
+		},
+	}
+}
+
+func (c *statusLogger) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	comp := &apiv1.Composition{}
+	err := c.client.Get(ctx, req.NamespacedName, comp)
+	if client.IgnoreNotFound(err) != nil || comp.Status.Simplified == nil {
+		return ctrl.Result{}, err
+	}
+
+	fields := []any{
+		"compositionName", comp.Name,
+		"compositionNamespace", comp.Namespace,
+		"compositionGeneration", comp.Generation,
+		"status", comp.Status.Simplified.Status,
+		"error", comp.Status.Simplified.Error,
+	}
+	if syn := comp.Status.CurrentSynthesis; syn != nil {
+		fields = append(fields,
+			"currentSynthesisUUID", syn.UUID,
+			"currentSynthesizerGeneration", syn.ObservedSynthesizerGeneration,
+		)
+	}
+	if syn := comp.Status.InFlightSynthesis; syn != nil {
+		fields = append(fields,
+			"inflightSynthesisUUID", syn.UUID,
+			"inflightSynthesizerGeneration", syn.ObservedSynthesizerGeneration,
+		)
+	}
+
+	c.logFn(ctx, "current composition status", fields...)
+
+	jitter := time.Duration(float64(c.frequency) * 0.2 * (0.5 - rand.Float64())) // 20% jitter
+	return ctrl.Result{RequeueAfter: c.frequency + jitter}, nil
+}

--- a/internal/controllers/composition/statuslogger_test.go
+++ b/internal/controllers/composition/statuslogger_test.go
@@ -1,0 +1,390 @@
+package composition
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	apiv1 "github.com/Azure/eno/api/v1"
+	"github.com/Azure/eno/internal/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+func TestStatusLoggerPredicate(t *testing.T) {
+	logger := &statusLogger{}
+	predicate := logger.newPredicate()
+
+	t.Run("CreateFunc returns true", func(t *testing.T) {
+		comp := &apiv1.Composition{}
+		event := event.TypedCreateEvent[client.Object]{Object: comp}
+		assert.True(t, predicate.Create(event))
+	})
+
+	t.Run("DeleteFunc returns true", func(t *testing.T) {
+		comp := &apiv1.Composition{}
+		event := event.TypedDeleteEvent[client.Object]{Object: comp}
+		assert.True(t, predicate.Delete(event))
+	})
+
+	t.Run("GenericFunc returns false", func(t *testing.T) {
+		comp := &apiv1.Composition{}
+		event := event.TypedGenericEvent[client.Object]{Object: comp}
+		assert.False(t, predicate.Generic(event))
+	})
+
+	t.Run("UpdateFunc with same simplified status returns false", func(t *testing.T) {
+		simplifiedStatus := &apiv1.SimplifiedStatus{Status: "Ready", Error: ""}
+
+		compA := &apiv1.Composition{
+			Status: apiv1.CompositionStatus{Simplified: simplifiedStatus},
+		}
+		compB := &apiv1.Composition{
+			Status: apiv1.CompositionStatus{Simplified: simplifiedStatus},
+		}
+
+		event := event.TypedUpdateEvent[client.Object]{
+			ObjectNew: compA,
+			ObjectOld: compB,
+		}
+		assert.False(t, predicate.Update(event))
+	})
+
+	t.Run("UpdateFunc with different simplified status returns true", func(t *testing.T) {
+		compA := &apiv1.Composition{
+			Status: apiv1.CompositionStatus{
+				Simplified: &apiv1.SimplifiedStatus{Status: "Ready", Error: ""},
+			},
+		}
+		compB := &apiv1.Composition{
+			Status: apiv1.CompositionStatus{
+				Simplified: &apiv1.SimplifiedStatus{Status: "Synthesizing", Error: ""},
+			},
+		}
+
+		event := event.TypedUpdateEvent[client.Object]{
+			ObjectNew: compA,
+			ObjectOld: compB,
+		}
+		assert.True(t, predicate.Update(event))
+	})
+
+	t.Run("UpdateFunc with nil simplified status returns false", func(t *testing.T) {
+		compA := &apiv1.Composition{}
+		compB := &apiv1.Composition{}
+
+		event := event.TypedUpdateEvent[client.Object]{
+			ObjectNew: compA,
+			ObjectOld: compB,
+		}
+		assert.False(t, predicate.Update(event))
+	})
+
+	t.Run("UpdateFunc with non-Composition objects returns false", func(t *testing.T) {
+		objectA := &corev1.ConfigMap{}
+		objectB := &corev1.ConfigMap{}
+
+		event := event.TypedUpdateEvent[client.Object]{
+			ObjectNew: objectA,
+			ObjectOld: objectB,
+		}
+		assert.False(t, predicate.Update(event))
+	})
+}
+
+func TestStatusLoggerReconcile(t *testing.T) {
+	ctx := testutil.NewContext(t)
+	frequency := 30 * time.Second
+
+	t.Run("successful reconcile with existing composition", func(t *testing.T) {
+		comp := &apiv1.Composition{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:       "test-comp",
+				Namespace:  "default",
+				Generation: 1,
+			},
+			Status: apiv1.CompositionStatus{
+				Simplified: &apiv1.SimplifiedStatus{
+					Status: "Ready",
+					Error:  "",
+				},
+				CurrentSynthesis: &apiv1.Synthesis{
+					UUID:                          "test-uuid-123",
+					ObservedSynthesizerGeneration: 5,
+				},
+			},
+		}
+
+		cli := testutil.NewClient(t, comp)
+
+		var loggedMsg string
+		var loggedArgs []any
+		logger := &statusLogger{
+			client:    cli,
+			frequency: frequency,
+			logFn: func(ctx context.Context, msg string, args ...any) {
+				loggedMsg = msg
+				loggedArgs = args
+			},
+		}
+
+		req := reconcile.Request{
+			NamespacedName: types.NamespacedName{
+				Name:      "test-comp",
+				Namespace: "default",
+			},
+		}
+
+		result, err := logger.Reconcile(ctx, req)
+		require.NoError(t, err)
+
+		assert.Equal(t, "current composition status", loggedMsg)
+		assert.Contains(t, loggedArgs, "compositionName")
+		assert.Contains(t, loggedArgs, "test-comp")
+		assert.Contains(t, loggedArgs, "compositionNamespace")
+		assert.Contains(t, loggedArgs, "default")
+		assert.Contains(t, loggedArgs, "compositionGeneration")
+		assert.Contains(t, loggedArgs, int64(1))
+		assert.Contains(t, loggedArgs, "currentSynthesisUUID")
+		assert.Contains(t, loggedArgs, "test-uuid-123")
+		assert.Contains(t, loggedArgs, "currentSynthesizerGeneration")
+		assert.Contains(t, loggedArgs, int64(5))
+		assert.Contains(t, loggedArgs, "status")
+		assert.Contains(t, loggedArgs, "Ready")
+		assert.Contains(t, loggedArgs, "error")
+		assert.Contains(t, loggedArgs, "")
+
+		assert.True(t, result.RequeueAfter >= frequency*8/10)  // at least 80% of frequency due to jitter
+		assert.True(t, result.RequeueAfter <= frequency*12/10) // at most 120% of frequency due to jitter
+	})
+
+	t.Run("successful reconcile with inflight synthesis", func(t *testing.T) {
+		comp := &apiv1.Composition{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:       "test-comp-inflight",
+				Namespace:  "default",
+				Generation: 2,
+			},
+			Status: apiv1.CompositionStatus{
+				Simplified: &apiv1.SimplifiedStatus{
+					Status: "Synthesizing",
+					Error:  "",
+				},
+				InFlightSynthesis: &apiv1.Synthesis{
+					UUID:                          "inflight-uuid-456",
+					ObservedSynthesizerGeneration: 7,
+				},
+			},
+		}
+
+		cli := testutil.NewClient(t, comp)
+
+		var loggedMsg string
+		var loggedArgs []any
+		logger := &statusLogger{
+			client:    cli,
+			frequency: frequency,
+			logFn: func(ctx context.Context, msg string, args ...any) {
+				loggedMsg = msg
+				loggedArgs = args
+			},
+		}
+
+		req := reconcile.Request{
+			NamespacedName: types.NamespacedName{
+				Name:      "test-comp-inflight",
+				Namespace: "default",
+			},
+		}
+
+		result, err := logger.Reconcile(ctx, req)
+		require.NoError(t, err)
+
+		assert.Equal(t, "current composition status", loggedMsg)
+		assert.Contains(t, loggedArgs, "compositionName")
+		assert.Contains(t, loggedArgs, "test-comp-inflight")
+		assert.Contains(t, loggedArgs, "compositionNamespace")
+		assert.Contains(t, loggedArgs, "default")
+		assert.Contains(t, loggedArgs, "compositionGeneration")
+		assert.Contains(t, loggedArgs, int64(2))
+		assert.Contains(t, loggedArgs, "inflightSynthesisUUID")
+		assert.Contains(t, loggedArgs, "inflight-uuid-456")
+		assert.Contains(t, loggedArgs, "inflightSynthesizerGeneration")
+		assert.Contains(t, loggedArgs, int64(7))
+		assert.Contains(t, loggedArgs, "status")
+		assert.Contains(t, loggedArgs, "Synthesizing")
+		assert.Contains(t, loggedArgs, "error")
+		assert.Contains(t, loggedArgs, "")
+
+		assert.True(t, result.RequeueAfter >= frequency*8/10)  // at least 80% of frequency due to jitter
+		assert.True(t, result.RequeueAfter <= frequency*12/10) // at most 120% of frequency due to jitter
+	})
+
+	t.Run("successful reconcile with both current and inflight synthesis", func(t *testing.T) {
+		comp := &apiv1.Composition{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:       "test-comp-both",
+				Namespace:  "default",
+				Generation: 3,
+			},
+			Status: apiv1.CompositionStatus{
+				Simplified: &apiv1.SimplifiedStatus{
+					Status: "Synthesizing",
+					Error:  "",
+				},
+				CurrentSynthesis: &apiv1.Synthesis{
+					UUID:                          "current-uuid-789",
+					ObservedSynthesizerGeneration: 8,
+				},
+				InFlightSynthesis: &apiv1.Synthesis{
+					UUID:                          "inflight-uuid-012",
+					ObservedSynthesizerGeneration: 9,
+				},
+			},
+		}
+
+		cli := testutil.NewClient(t, comp)
+
+		var loggedArgs []any
+		logger := &statusLogger{
+			client:    cli,
+			frequency: frequency,
+			logFn: func(ctx context.Context, msg string, args ...any) {
+				loggedArgs = args
+			},
+		}
+
+		req := reconcile.Request{
+			NamespacedName: types.NamespacedName{
+				Name:      "test-comp-both",
+				Namespace: "default",
+			},
+		}
+
+		result, err := logger.Reconcile(ctx, req)
+		require.NoError(t, err)
+
+		// Check current synthesis fields
+		assert.Contains(t, loggedArgs, "currentSynthesisUUID")
+		assert.Contains(t, loggedArgs, "current-uuid-789")
+		assert.Contains(t, loggedArgs, "currentSynthesizerGeneration")
+		assert.Contains(t, loggedArgs, int64(8))
+
+		// Check inflight synthesis fields
+		assert.Contains(t, loggedArgs, "inflightSynthesisUUID")
+		assert.Contains(t, loggedArgs, "inflight-uuid-012")
+		assert.Contains(t, loggedArgs, "inflightSynthesizerGeneration")
+		assert.Contains(t, loggedArgs, int64(9))
+
+		assert.True(t, result.RequeueAfter > 0)
+	})
+
+	t.Run("reconcile with composition not found", func(t *testing.T) {
+		cli := testutil.NewClient(t)
+
+		var logCalled bool
+		logger := &statusLogger{
+			client:    cli,
+			frequency: frequency,
+			logFn: func(ctx context.Context, msg string, args ...any) {
+				logCalled = true
+			},
+		}
+
+		req := reconcile.Request{
+			NamespacedName: types.NamespacedName{
+				Name:      "non-existent-comp",
+				Namespace: "default",
+			},
+		}
+
+		result, err := logger.Reconcile(ctx, req)
+		require.Error(t, err)
+		assert.False(t, logCalled)
+		assert.Equal(t, reconcile.Result{}, result)
+	})
+
+	t.Run("reconcile with nil simplified status", func(t *testing.T) {
+		comp := &apiv1.Composition{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-comp",
+				Namespace: "default",
+			},
+			Status: apiv1.CompositionStatus{
+				Simplified: nil,
+			},
+		}
+
+		cli := testutil.NewClient(t, comp)
+
+		var logCalled bool
+		logger := &statusLogger{
+			client:    cli,
+			frequency: frequency,
+			logFn: func(ctx context.Context, msg string, args ...any) {
+				logCalled = true
+			},
+		}
+
+		req := reconcile.Request{
+			NamespacedName: types.NamespacedName{
+				Name:      "test-comp",
+				Namespace: "default",
+			},
+		}
+
+		result, err := logger.Reconcile(ctx, req)
+		require.NoError(t, err)
+		assert.False(t, logCalled)
+		assert.Equal(t, reconcile.Result{}, result)
+	})
+
+	t.Run("reconcile with error status", func(t *testing.T) {
+		comp := &apiv1.Composition{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:       "test-comp",
+				Namespace:  "default",
+				Generation: 2,
+			},
+			Status: apiv1.CompositionStatus{
+				Simplified: &apiv1.SimplifiedStatus{
+					Status: "NotReady",
+					Error:  "synthesis failed",
+				},
+			},
+		}
+
+		cli := testutil.NewClient(t, comp)
+
+		var loggedArgs []any
+		logger := &statusLogger{
+			client:    cli,
+			frequency: frequency,
+			logFn: func(ctx context.Context, msg string, args ...any) {
+				loggedArgs = args
+			},
+		}
+
+		req := reconcile.Request{
+			NamespacedName: types.NamespacedName{
+				Name:      "test-comp",
+				Namespace: "default",
+			},
+		}
+
+		result, err := logger.Reconcile(ctx, req)
+		require.NoError(t, err)
+
+		assert.Contains(t, loggedArgs, "status")
+		assert.Contains(t, loggedArgs, "NotReady")
+		assert.Contains(t, loggedArgs, "error")
+		assert.Contains(t, loggedArgs, "synthesis failed")
+		assert.True(t, result.RequeueAfter > 0)
+	})
+}

--- a/internal/controllers/reconciliation/helpers_test.go
+++ b/internal/controllers/reconciliation/helpers_test.go
@@ -32,6 +32,7 @@ func registerControllers(t *testing.T, mgr *testutil.Manager) {
 	require.NoError(t, resourceslice.NewController(mgr.Manager))
 	require.NoError(t, resourceslice.NewCleanupController(mgr.Manager))
 	require.NoError(t, composition.NewController(mgr.Manager, time.Second))
+	require.NoError(t, composition.NewStatusLogger(mgr.Manager, time.Second*10))
 	require.NoError(t, symphony.NewController(mgr.Manager))
 }
 


### PR DESCRIPTION
Moves the current status transition logs to a separate controller loop that is capable of periodically logging composition status when nothing has changed.

The idea is to keep a fresh representation of each composition's status in indexed log storage.