### PR TITLE
support map types in synth input

### DIFF
--- a/pkg/function/main.go
+++ b/pkg/function/main.go
@@ -135,9 +135,12 @@ func newInput(ir *InputReader, field reflect.Value) (*input, error) {
 
 	// Allocate values for nil pointers
 	if field.IsNil() {
-		if field.Kind() == reflect.Slice {
+		switch field.Kind() {
+		case reflect.Map:
+			field.Set(reflect.MakeMap(field.Type()))
+		case reflect.Slice:
 			field.Set(reflect.MakeSlice(field.Type(), 0, 0))
-		} else {
+		default:
 			field.Set(reflect.New(field.Type().Elem()))
 		}
 	}


### PR DESCRIPTION
This patch fixes a panic when using a map type in the synthesizer input.

```console
synthesis-x7r79 executor panic: reflect.Set: value of type **toggles.Toggle is not assignable to type toggles.Toggles
synthesis-x7r79 executor 
synthesis-x7r79 executor goroutine 1 [running]:
synthesis-x7r79 executor reflect.Value.assignTo({0xc000546140?, 0xc000234378?, 0xc000055b88?}, {0x1a705fa, 0xb}, 0x18c4fe0, 0x0)
synthesis-x7r79 executor 	/usr/lib/golang/src/reflect/value.go:3072 +0x28b
synthesis-x7r79 executor reflect.Value.Set({0x18c4fe0?, 0xc00013ab80?, 0x1971440?}, {0xc000546140?, 0xc000234378?, 0x1726309?})
synthesis-x7r79 executor 	/usr/lib/golang/src/reflect/value.go:2057 +0xe6
synthesis-x7r79 executor github.com/Azure/eno/pkg/function.newInput(0x1971440?, {0x18c4fe0?, 0xc00013ab80?, 0x7?})
synthesis-x7r79 executor 	/build/top/BUILD/__gomods/github.com/!azure/eno@v0.1.32/pkg/function/main.go:141 +0x1b9
synthesis-x7r79 executor github.com/Azure/eno/pkg/function.main[...](0x1b6a150, 0xc000280940, 0xc0002341d0, 0xc000055e98)
synthesis-x7r79 executor 	/build/top/BUILD/__gomods/github.com/!azure/eno@v0.1.32/pkg/function/main.go:59 +0x228
synthesis-x7r79 executor github.com/Azure/eno/pkg/function.Main[...](0x1b6a150, {0x0, 0x0, 0x0})
synthesis-x7r79 executor 	/build/top/BUILD/__gomods/github.com/!azure/eno@v0.1.32/pkg/function/main.go:41 +0x173
synthesis-x7r79 executor main.main()
synthesis-x7r79 executor 	/build/top/BUILD/cmd/synthesizer/main.go:65 +0x105
```