### PR TITLE
Support optional symphony variations

### DIFF
--- a/api/v1/config/crd/eno.azure.io_symphonies.yaml
+++ b/api/v1/config/crd/eno.azure.io_symphonies.yaml
@@ -134,6 +134,11 @@ spec:
                         type: string
                       description: Used to populate the composition's metadata.labels.
                       type: object
+                    optional:
+                      description: |-
+                        Optional indicates that this variation should not block the symphony status
+                        when it fails to synthesize, reconcile, or become ready.
+                      type: boolean
                     synthesisEnv:
                       description: |-
                         SynthesisEnv

--- a/api/v1/symphony.go
+++ b/api/v1/symphony.go
@@ -67,4 +67,8 @@ type Variation struct {
 	// It gets merged with the Symhony environment and takes precedence over it.
 	// +kubebuilder:validation:MaxItems:=25
 	SynthesisEnv []EnvVar `json:"synthesisEnv,omitempty"`
+
+	// Optional indicates that this variation should not block the symphony status
+	// when it fails to synthesize, reconcile, or become ready.
+	Optional bool `json:"optional,omitempty"`
 }

--- a/internal/controllers/reconciliation/symphony_test.go
+++ b/internal/controllers/reconciliation/symphony_test.go
@@ -393,5 +393,5 @@ func TestSymphonyOptionalVariation(t *testing.T) {
 	obj := &corev1.ConfigMap{}
 	obj.SetName("test-obj")
 	obj.SetNamespace("default")
-	assert.NoError(t, upstream.Get(ctx, client.ObjectKeyFromObject(obj), obj))
+	assert.NoError(t, mgr.DownstreamClient.Get(ctx, client.ObjectKeyFromObject(obj), obj))
 }


### PR DESCRIPTION
Some compositions that are part of a symphony might not logically contribute to its `Ready` state. (monitoring agents for example)

This change adds an `Optional` bool that excludes particular symphony variations from the status logic.