### PR TITLE
Use resource filter expression instead of a label selector.

### DIFF
--- a/docs/reconciliation.md
+++ b/docs/reconciliation.md
@@ -122,6 +122,24 @@ metadata:
 - **Ordering**: Lower numbers reconcile first: `-2` → `-1` → `0` → `1` → `2`
 - **Dependencies**: Group `N+1` waits for all group `N` resources to be ready
 
+## Sharding
+
+You may reconcile a subset of Compositions and/or resources by optionally passing the following flags to the Eno reconciler:
+- **--composition-namespace**: Only watch compositions in the given namespace.
+  ```
+  --composition-namespace=default
+  ```
+- **--composition-label-selector**: Only watch composition that match the selector.
+  ```
+  --composition-label-selector=some.domain.com/type=some-type
+  ```
+- **--resource-filter**: Only reconcile resources that pass the given cel filter expression. Both the Composition and resource are availalbe in the evaluation context.
+  ```
+  --resource-filter=composition.metadata.annotations.someAnnotation == 'some-value' && self.kind == 'ConfigMap'
+  ```
+  > ⚠️ Changes to composition metadata (without changing the spec) will not trigger a reevaluation of the filter.
+
+The flags stack up and are not mutually excluive i.e. A resource filter will only be evaluated against resources whose Composition match the label selector, which in turn is only evaluated against Compositions in the selected namespace.
 ## Advanced Concepts
 
 - [Overrides](./overrides.md)

--- a/docs/reconciliation.md
+++ b/docs/reconciliation.md
@@ -137,7 +137,7 @@ You may reconcile a subset of Compositions and/or resources by optionally passin
   ```
   --resource-filter=composition.metadata.annotations.someAnnotation == 'some-value' && self.kind == 'ConfigMap'
   ```
-  > ⚠️ Changes to composition metadata (without changing the spec) will not trigger a reevaluation of the filter.
+  > ⚠️ Changes to composition metadata (without changing the spec) will not trigger a re-evaluation of the filter.
 
 The flags stack up and are not mutually excluive i.e. A resource filter will only be evaluated against resources whose Composition match the label selector, which in turn is only evaluated against Compositions in the selected namespace.
 ## Advanced Concepts

--- a/docs/reconciliation.md
+++ b/docs/reconciliation.md
@@ -139,7 +139,7 @@ You may reconcile a subset of Compositions and/or resources by optionally passin
   ```
   > ⚠️ Changes to composition metadata (without changing the spec) will not trigger a re-evaluation of the filter.
 
-The flags stack up and are not mutually excluive i.e. A resource filter will only be evaluated against resources whose Composition match the label selector, which in turn is only evaluated against Compositions in the selected namespace.
+The flags stack up and are not mutually exclusive i.e. A resource filter will only be evaluated against resources whose Composition match the label selector, which in turn is only evaluated against Compositions in the selected namespace.
 ## Advanced Concepts
 
 - [Overrides](./overrides.md)

--- a/docs/reconciliation.md
+++ b/docs/reconciliation.md
@@ -133,7 +133,7 @@ You may reconcile a subset of Compositions and/or resources by optionally passin
   ```
   --composition-label-selector=some.domain.com/type=some-type
   ```
-- **--resource-filter**: Only reconcile resources that pass the given cel filter expression. Both the Composition and resource are availalbe in the evaluation context.
+- **--resource-filter**: Only reconcile resources that pass the given cel filter expression. Both the Composition and resource are available in the evaluation context.
   ```
   --resource-filter=composition.metadata.annotations.someAnnotation == 'some-value' && self.kind == 'ConfigMap'
   ```

--- a/internal/resource/cache.go
+++ b/internal/resource/cache.go
@@ -5,10 +5,10 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/google/cel-go/cel"
 	apiv1 "github.com/Azure/eno/api/v1"
 	enocel "github.com/Azure/eno/internal/cel"
 	"github.com/go-logr/logr"
+	"github.com/google/cel-go/cel"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/workqueue"
 )
@@ -113,6 +113,7 @@ func (c *Cache) Fill(ctx context.Context, comp *apiv1.Composition, synUUID strin
 				matches, err := c.evaluateResourceFilter(ctx, comp, res)
 				if err != nil {
 					logger.Error(err, "failed to evaluate resource filter", "resourceKind", res.Ref.Kind, "resourceName", res.Ref.Name)
+					resourceFilterErrors.Inc()
 					continue
 				}
 				if !matches {

--- a/internal/resource/metrics.go
+++ b/internal/resource/metrics.go
@@ -1,0 +1,19 @@
+package resource
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+var (
+	resourceFilterErrors = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Name: "eno_resource_filter_eval_errors_total",
+			Help: "Errors while evaluating resource filter expressions",
+		},
+	)
+)
+
+func init() {
+	metrics.Registry.MustRegister(resourceFilterErrors)
+}


### PR DESCRIPTION
This allows matching on both resource and composition labels. Also move the filter check to the cache so we can avoid keeping unwanted resources in memory.