### PR TITLE
Handle 404s correctly in the status logger

### DIFF
--- a/internal/controllers/composition/statuslogger.go
+++ b/internal/controllers/composition/statuslogger.go
@@ -61,8 +61,8 @@ func (c *statusLogger) newPredicate() predicate.Predicate {
 func (c *statusLogger) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	comp := &apiv1.Composition{}
 	err := c.client.Get(ctx, req.NamespacedName, comp)
-	if client.IgnoreNotFound(err) != nil || comp.Status.Simplified == nil {
-		return ctrl.Result{}, err
+	if err != nil || comp.Status.Simplified == nil {
+		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
 	fields := []any{

--- a/internal/controllers/composition/statuslogger_test.go
+++ b/internal/controllers/composition/statuslogger_test.go
@@ -305,7 +305,7 @@ func TestStatusLoggerReconcile(t *testing.T) {
 		}
 
 		result, err := logger.Reconcile(ctx, req)
-		require.Error(t, err)
+		require.NoError(t, err)
 		assert.False(t, logCalled)
 		assert.Equal(t, reconcile.Result{}, result)
 	})


### PR DESCRIPTION
We don't currently drop workqueue items when the composition disappears 🚒 