### PR TITLE
Add readiness logic for resource deletion path

### DIFF
--- a/internal/controllers/reconciliation/controller.go
+++ b/internal/controllers/reconciliation/controller.go
@@ -190,9 +190,13 @@ func (c *Controller) checkReadiness(ctx context.Context, resource *resource.Reso
 		return state.Ready
 	}
 
-	// Deleting resources aren't ready until deletion is complete
-	if current != nil && snap != nil && snap.Deleted() && !snap.Orphan && !snap.Disable {
-		return nil
+	if snap != nil && snap.Deleted() && !snap.Orphan && !snap.Disable {
+		if current != nil {
+			// Deleting resources aren't ready until deletion is complete
+			return nil
+		}
+		// Readiness checks shouldn't apply to deleting resources
+		return ptr.To(metav1.Now())
 	}
 
 	// Process the readiness checks

--- a/internal/controllers/reconciliation/crud_test.go
+++ b/internal/controllers/reconciliation/crud_test.go
@@ -733,10 +733,7 @@ func TestDisableReconciliation(t *testing.T) {
 	_, comp := writeGenericComposition(t, upstream)
 
 	// Wait for readiness
-	testutil.Eventually(t, func() bool {
-		err := upstream.Get(ctx, client.ObjectKeyFromObject(comp), comp)
-		return err == nil && comp.Status.CurrentSynthesis != nil && comp.Status.CurrentSynthesis.Ready != nil
-	})
+	waitForReadiness(t, mgr, comp, nil, nil)
 
 	// The resource should not have been created
 	obj := &corev1.ConfigMap{}
@@ -789,10 +786,7 @@ func TestUpdateReplace(t *testing.T) {
 	_, comp := writeGenericComposition(t, upstream)
 
 	// Wait for resource to be created
-	testutil.Eventually(t, func() bool {
-		err := upstream.Get(ctx, client.ObjectKeyFromObject(comp), comp)
-		return err == nil && comp.Status.CurrentSynthesis != nil && comp.Status.CurrentSynthesis.Reconciled != nil
-	})
+	waitForReadiness(t, mgr, comp, nil, nil)
 
 	initial := &corev1.ConfigMap{}
 	initial.SetName("test-obj")
@@ -816,10 +810,7 @@ func TestUpdateReplace(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	testutil.Eventually(t, func() bool {
-		err := upstream.Get(ctx, client.ObjectKeyFromObject(comp), comp)
-		return err == nil && comp.Status.CurrentSynthesis != nil && comp.Status.CurrentSynthesis.Reconciled != nil && comp.Status.CurrentSynthesis.ObservedCompositionGeneration == comp.Generation
-	})
+	waitForReadiness(t, mgr, comp, nil, nil)
 
 	// The external change should be removed AND the UID should not change
 	testutil.Eventually(t, func() bool {
@@ -844,10 +835,7 @@ func TestUpdateReplace(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	testutil.Eventually(t, func() bool {
-		err := upstream.Get(ctx, client.ObjectKeyFromObject(comp), comp)
-		return err == nil && comp.Status.CurrentSynthesis != nil && comp.Status.CurrentSynthesis.Reconciled != nil && comp.Status.CurrentSynthesis.ObservedCompositionGeneration == comp.Generation
-	})
+	waitForReadiness(t, mgr, comp, nil, nil)
 
 	// The external change should be removed AND the UID should not change
 	testutil.Eventually(t, func() bool {
@@ -928,7 +916,6 @@ func TestResourceDefaulting(t *testing.T) {
 	corev1.SchemeBuilder.AddToScheme(scheme)
 	testv1.SchemeBuilder.AddToScheme(scheme)
 
-	ctx := testutil.NewContext(t)
 	mgr := testutil.NewManager(t)
 	upstream := mgr.GetClient()
 
@@ -982,10 +969,7 @@ func TestResourceDefaulting(t *testing.T) {
 	_, comp := writeGenericComposition(t, upstream)
 
 	// It should be able to become ready
-	testutil.Eventually(t, func() bool {
-		err := upstream.Get(ctx, client.ObjectKeyFromObject(comp), comp)
-		return err == nil && comp.Status.CurrentSynthesis != nil && comp.Status.CurrentSynthesis.Ready != nil && comp.Status.CurrentSynthesis.ObservedCompositionGeneration == comp.Generation
-	})
+	waitForReadiness(t, mgr, comp, nil, nil)
 }
 
 func TestImplicitBindings(t *testing.T) {

--- a/internal/controllers/reconciliation/errors_test.go
+++ b/internal/controllers/reconciliation/errors_test.go
@@ -59,12 +59,7 @@ func TestErrorReporting(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	testutil.Eventually(t, func() bool {
-		err := upstream.Get(ctx, client.ObjectKeyFromObject(comp), comp)
-		return err == nil &&
-			comp.Status.Simplified != nil && comp.Status.Simplified.Error == "" &&
-			comp.Status.CurrentSynthesis != nil && comp.Status.CurrentSynthesis.Ready != nil
-	})
+	waitForReadiness(t, mgr, comp, syn, nil)
 }
 
 func TestSummarizeErrorIntegration(t *testing.T) {

--- a/internal/controllers/reconciliation/status_test.go
+++ b/internal/controllers/reconciliation/status_test.go
@@ -90,10 +90,7 @@ func TestResourceReadiness(t *testing.T) {
 	require.NoError(t, err)
 
 	// The composition should also be updated
-	testutil.Eventually(t, func() bool {
-		err = upstream.Get(ctx, client.ObjectKeyFromObject(comp), comp)
-		return err == nil && comp.Status.CurrentSynthesis != nil && comp.Status.CurrentSynthesis.Ready != nil
-	})
+	waitForReadiness(t, mgr, comp, syn, nil)
 
 	// Update resource to not meet readiness criteria
 	err = retry.RetryOnConflict(testutil.Backoff, func() error {


### PR DESCRIPTION
The resource readiness signal isn't currently used when deleting resources since readiness expressions shouldn't apply to deleting resources.

But in order to implement ordered deletion we need some knowledge of when the resource is fully deleted e.g. returns 404 vs a 200 response with `deletionTimestamp !=nil`. We can easily reuse the concept of readiness to track the deletion state for this purpose.

This PR also refactors the tests to better for the readiness path - some only wait on reconciliation. All of the logic in `checkReadiness` that is important to current behaviors has test coverage and the new branches will be covered more directly in the upcoming deletion order integration tests.