### PR TITLE
Support foreground deletion strategy

### DIFF
--- a/internal/controllers/reconciliation/controller.go
+++ b/internal/controllers/reconciliation/controller.go
@@ -402,7 +402,7 @@ func (c *Controller) requeue(logger logr.Logger, resource *resource.Snapshot, re
 		return ctrl.Result{RequeueAfter: wait.Jitter(c.readinessPollInterval, 0.1)}, nil
 	}
 
-	if resource == nil || (resource.Deleted() && resource.Disable) || resource.ReconcileInterval == nil {
+	if resource == nil || resource.ReconcileInterval == nil {
 		return ctrl.Result{}, nil
 	}
 

--- a/internal/controllers/reconciliation/controller.go
+++ b/internal/controllers/reconciliation/controller.go
@@ -398,11 +398,13 @@ func (c *Controller) getCurrent(ctx context.Context, resource *resource.Resource
 }
 
 func (c *Controller) requeue(logger logr.Logger, resource *resource.Snapshot, ready *metav1.Time) (ctrl.Result, error) {
-	if ready == nil {
+	pendingForegroundDeletion := (resource.Deleted() && !resource.Disable && resource.ForegroundDeletion)
+
+	if ready == nil || pendingForegroundDeletion {
 		return ctrl.Result{RequeueAfter: wait.Jitter(c.readinessPollInterval, 0.1)}, nil
 	}
 
-	if resource == nil || resource.ReconcileInterval == nil {
+	if resource == nil || (resource.Deleted() && !resource.Disable) || resource.ReconcileInterval == nil {
 		return ctrl.Result{}, nil
 	}
 

--- a/internal/controllers/reconciliation/controller.go
+++ b/internal/controllers/reconciliation/controller.go
@@ -145,7 +145,7 @@ func (c *Controller) Reconcile(ctx context.Context, req resource.Request) (ctrl.
 	}
 
 	deleted := current == nil ||
-		current.GetDeletionTimestamp() != nil ||
+		(current.GetDeletionTimestamp() != nil && !snap.ForegroundDeletion) ||
 		(snap.Deleted() && (snap.Orphan || snap.Disable)) // orphaning should be reflected on the status.
 	ready := c.checkReadiness(ctx, resource, snap, current)
 	c.writeBuffer.PatchStatusAsync(ctx, &resource.ManifestRef, patchResourceState(deleted, ready))
@@ -402,7 +402,7 @@ func (c *Controller) requeue(logger logr.Logger, resource *resource.Snapshot, re
 		return ctrl.Result{RequeueAfter: wait.Jitter(c.readinessPollInterval, 0.1)}, nil
 	}
 
-	if resource == nil || (resource.Deleted() && !resource.Disable) || resource.ReconcileInterval == nil {
+	if resource == nil || (resource.Deleted() && resource.Disable) || resource.ReconcileInterval == nil {
 		return ctrl.Result{}, nil
 	}
 

--- a/internal/controllers/reconciliation/ordering_test.go
+++ b/internal/controllers/reconciliation/ordering_test.go
@@ -476,3 +476,57 @@ func TestInputCompositionGenerationOrdering(t *testing.T) {
 	})
 	assert.Equal(t, input.ResourceVersion, comp.Status.InputRevisions[0].ResourceVersion)
 }
+
+func TestForegroundDeletion(t *testing.T) {
+	ctx := testutil.NewContext(t)
+	mgr := testutil.NewManager(t)
+	upstream := mgr.GetClient()
+
+	testutil.WithFakeExecutor(t, mgr, func(ctx context.Context, s *apiv1.Synthesizer, input *krmv1.ResourceList) (*krmv1.ResourceList, error) {
+		output := &krmv1.ResourceList{}
+		output.Items = []*unstructured.Unstructured{{
+			Object: map[string]any{
+				"apiVersion": "v1",
+				"kind":       "ConfigMap",
+				"metadata": map[string]any{
+					"name":       "test-obj",
+					"namespace":  "default",
+					"finalizers": []any{"eno.azure.io/test"},
+					"annotations": map[string]any{
+						"eno.azure.io/deletion-strategy":  "foreground",
+						"eno.azure.io/reconcile-interval": "100ms",
+					},
+				},
+			},
+		}}
+		return output, nil
+	})
+
+	registerControllers(t, mgr)
+	setupTestSubject(t, mgr)
+	mgr.Start(t)
+	_, comp := writeGenericComposition(t, upstream)
+	waitForReadiness(t, mgr, comp, nil, nil)
+	require.NoError(t, upstream.Delete(ctx, comp))
+
+	// The composition should still exist while the configmap is deleting
+	cm := &corev1.ConfigMap{}
+	cm.Name = "test-obj"
+	cm.Namespace = "default"
+	testutil.Eventually(t, func() bool {
+		err := mgr.DownstreamClient.Get(ctx, client.ObjectKeyFromObject(cm), cm)
+		return err == nil && cm.DeletionTimestamp != nil
+	})
+	require.NoError(t, upstream.Get(ctx, client.ObjectKeyFromObject(comp), comp))
+
+	// Unblocking the configmap deletion should also unblock composition deletion
+	err := retry.RetryOnConflict(testutil.Backoff, func() error {
+		upstream.Get(ctx, client.ObjectKeyFromObject(cm), cm)
+		cm.Finalizers = []string{}
+		return upstream.Update(ctx, cm)
+	})
+	require.NoError(t, err)
+	testutil.Eventually(t, func() bool {
+		return errors.IsNotFound(upstream.Get(ctx, client.ObjectKeyFromObject(comp), comp))
+	})
+}

--- a/internal/controllers/reconciliation/ordering_test.go
+++ b/internal/controllers/reconciliation/ordering_test.go
@@ -493,8 +493,7 @@ func TestForegroundDeletion(t *testing.T) {
 					"namespace":  "default",
 					"finalizers": []any{"eno.azure.io/test"},
 					"annotations": map[string]any{
-						"eno.azure.io/deletion-strategy":  "foreground",
-						"eno.azure.io/reconcile-interval": "100ms",
+						"eno.azure.io/deletion-strategy": "foreground",
 					},
 				},
 			},

--- a/internal/controllers/reconciliation/ordering_test.go
+++ b/internal/controllers/reconciliation/ordering_test.go
@@ -523,7 +523,7 @@ func TestForegroundDeletion(t *testing.T) {
 	err := retry.RetryOnConflict(testutil.Backoff, func() error {
 		mgr.DownstreamClient.Get(ctx, client.ObjectKeyFromObject(cm), cm)
 		cm.Finalizers = []string{}
-		return upstream.Update(ctx, cm)
+		return mgr.DownstreamClient.Update(ctx, cm)
 	})
 	require.NoError(t, err)
 	testutil.Eventually(t, func() bool {

--- a/internal/controllers/reconciliation/ordering_test.go
+++ b/internal/controllers/reconciliation/ordering_test.go
@@ -521,7 +521,7 @@ func TestForegroundDeletion(t *testing.T) {
 
 	// Unblocking the configmap deletion should also unblock composition deletion
 	err := retry.RetryOnConflict(testutil.Backoff, func() error {
-		upstream.Get(ctx, client.ObjectKeyFromObject(cm), cm)
+		mgr.DownstreamClient.Get(ctx, client.ObjectKeyFromObject(cm), cm)
 		cm.Finalizers = []string{}
 		return upstream.Update(ctx, cm)
 	})

--- a/internal/controllers/reconciliation/ordering_test.go
+++ b/internal/controllers/reconciliation/ordering_test.go
@@ -503,7 +503,12 @@ func TestForegroundDeletion(t *testing.T) {
 	})
 
 	registerControllers(t, mgr)
-	setupTestSubject(t, mgr)
+	setupTestSubjectForOptions(t, mgr, Options{
+		Manager:                mgr.Manager,
+		Timeout:                time.Minute,
+		ReadinessPollInterval:  time.Millisecond * 10,
+		DisableServerSideApply: mgr.NoSsaSupport,
+	})
 	mgr.Start(t)
 	_, comp := writeGenericComposition(t, upstream)
 	waitForReadiness(t, mgr, comp, nil, nil)

--- a/internal/resource/resource.go
+++ b/internal/resource/resource.go
@@ -261,7 +261,8 @@ func (r *Resource) SnapshotWithOverrides(ctx context.Context, comp *apiv1.Compos
 	snap.Replace = cascadeAnnotation(comp, copy, replaceKey) == "true"
 
 	const deletionStratKey = "eno.azure.io/deletion-strategy"
-	snap.Orphan = cascadeAnnotation(comp, copy, deletionStratKey) == "orphan"
+	snap.Orphan = strings.EqualFold(cascadeAnnotation(comp, copy, deletionStratKey), "orphan")
+	snap.ForegroundDeletion = strings.EqualFold(cascadeAnnotation(comp, copy, deletionStratKey), "foreground")
 
 	const reconcileIntervalKey = "eno.azure.io/reconcile-interval"
 	if str := cascadeAnnotation(comp, copy, reconcileIntervalKey); str != "" {
@@ -284,11 +285,12 @@ func (r *Resource) SnapshotWithOverrides(ctx context.Context, comp *apiv1.Compos
 type Snapshot struct {
 	*Resource
 
-	ReconcileInterval *metav1.Duration
-	Disable           bool
-	DisableUpdates    bool
-	Replace           bool
-	Orphan            bool
+	ReconcileInterval  *metav1.Duration
+	Disable            bool
+	DisableUpdates     bool
+	Replace            bool
+	Orphan             bool
+	ForegroundDeletion bool
 
 	parsed         *unstructured.Unstructured
 	overrideStatus string

--- a/internal/resource/resource_test.go
+++ b/internal/resource/resource_test.go
@@ -62,6 +62,7 @@ var newResourceTests = []struct {
 			assert.True(t, r.DisableUpdates)
 			assert.True(t, r.Replace)
 			assert.True(t, r.Orphan)
+			assert.False(t, r.ForegroundDeletion)
 			assert.True(t, *r.FailOpen)
 			assert.Equal(t, int(250), r.readinessGroup)
 			assert.Len(t, r.overrides, 2)
@@ -119,6 +120,22 @@ var newResourceTests = []struct {
 			assert.Equal(t, int(0), r.readinessGroup)
 			assert.False(t, r.DisableUpdates)
 			assert.False(t, r.Replace)
+		},
+	},
+	{
+		Name: "foreground-deletion",
+		Manifest: `{
+			"apiVersion": "v1",
+			"kind": "ConfigMap",
+			"metadata": {
+				"name": "foo",
+				"annotations": {
+					"eno.azure.io/deletion-strategy": "Foreground"
+				}
+			}
+		}`,
+		Assert: func(t *testing.T, r *Snapshot) {
+			assert.True(t, r.ForegroundDeletion)
 		},
 	},
 	{


### PR DESCRIPTION
Setting `eno.azure.io/deletion-strategy: Foreground` will cause eno-reconciler to wait until the resource is done deleting before marking its status as `Deleted==true`.

This is useful for blocking composition deletion until some resources are completely gone.