### PR TITLE
Consider purposefully orphaned resources to be deleted

### DIFF
--- a/internal/controllers/reconciliation/controller.go
+++ b/internal/controllers/reconciliation/controller.go
@@ -208,7 +208,7 @@ func (c *Controller) reconcileSnapshot(ctx context.Context, comp *apiv1.Composit
 	}()
 
 	if res.Deleted() {
-		if current == nil || current.GetDeletionTimestamp() != nil || (comp.Labels != nil && comp.Labels["eno.azure.io/symphony-deleting"] == "true") {
+		if current == nil || current.GetDeletionTimestamp() != nil || res.Orphan || (comp.Labels != nil && comp.Labels["eno.azure.io/symphony-deleting"] == "true") {
 			return false, nil // already deleted - nothing to do
 		}
 

--- a/internal/resource/resource.go
+++ b/internal/resource/resource.go
@@ -262,6 +262,7 @@ func (r *Resource) SnapshotWithOverrides(ctx context.Context, comp *apiv1.Compos
 
 	const deletionStratKey = "eno.azure.io/deletion-strategy"
 	snap.Orphan = strings.EqualFold(cascadeAnnotation(comp, copy, deletionStratKey), "orphan")
+	snap.Orphan = !r.isPatch && strings.EqualFold(cascadeAnnotation(comp, copy, deletionStratKey), "orphan")
 	snap.ForegroundDeletion = strings.EqualFold(cascadeAnnotation(comp, copy, deletionStratKey), "foreground")
 
 	const reconcileIntervalKey = "eno.azure.io/reconcile-interval"
@@ -304,7 +305,7 @@ func (r *Snapshot) Unstructured() *unstructured.Unstructured {
 }
 
 func (r *Snapshot) Deleted() bool {
-	return (r.compositionDeleted && !r.Orphan) || r.manifestDeleted || r.Disable || (r.isPatch && r.patchSetsDeletionTimestamp())
+	return r.compositionDeleted || r.manifestDeleted || r.Disable || (r.isPatch && r.patchSetsDeletionTimestamp())
 }
 
 func (r *Snapshot) Patch() ([]byte, bool, error) {

--- a/internal/resource/resource_test.go
+++ b/internal/resource/resource_test.go
@@ -139,6 +139,30 @@ var newResourceTests = []struct {
 		},
 	},
 	{
+		Name: "orphan-patch",
+		Manifest: `{
+			"apiVersion": "eno.azure.io/v1",
+			"kind": "Patch",
+			"metadata": {
+				"name": "foo",
+				"namespace": "bar",
+				"annotations": {
+				  "eno.azure.io/deletion-strategy": "orphan"
+				}
+			},
+			"patch": {
+				"apiVersion": "v1",
+				"kind": "ConfigMap",
+				"ops": [
+					{ "op": "add", "path": "/metadata/deletionTimestamp", "value": "foo" }
+				]
+			}
+		}`,
+		Assert: func(t *testing.T, r *Snapshot) {
+			assert.False(t, r.Orphan) // patches are never orphaned
+		},
+	},
+	{
 		Name: "composition-precedence-positive",
 		Manifest: `{
 			"apiVersion": "v1",


### PR DESCRIPTION
Orphaned resources don't block composition deletion because of special logic in the resource slice controller. This makes sense for cases where the reconciler may be unavailable, but is unintuitive from the reconciliation controller's perspective.

This change is important for deletion groups since without it orphaned resources will cause deadlocks.