### PR TITLE
Fix: Update AnnotateOverrides to Append New Overrides on Existing Overrides

### DIFF
--- a/pkg/function/overrides/override.go
+++ b/pkg/function/overrides/override.go
@@ -104,7 +104,7 @@ func AnnotateOverrides(obj client.Object, overrides []Override) error {
 	if existingStr, exists := annotations["eno.azure.io/overrides"]; exists {
 		var existing []Override
 		json.Unmarshal([]byte(existingStr), &existing)
-		merged = append(merged, overrides...)
+		merged = append(existing, overrides...)
 	}
 
 	// intentionally not validating so custom overrides can work eno-reconciler rather than be bound to cel


### PR DESCRIPTION
Fixes a bug in the the `AnnotateOverrides` function where if the "eno.azure.io/overrides" annotation existed, the function call would append a duplicate override to the list of overrides instead of appending new overrides to existing overrides.