### PR TITLE
Support recreation for immutable resources

### DIFF
--- a/internal/controllers/reconciliation/controller.go
+++ b/internal/controllers/reconciliation/controller.go
@@ -208,7 +208,7 @@ func (c *Controller) reconcileSnapshot(ctx context.Context, comp *apiv1.Composit
 		reconciliationLatency.Observe(float64(time.Since(start).Milliseconds()))
 	}()
 
-	if res.Deleted() {
+	if res.Deleted() || (res.Recreate && prev != nil && res.CompareManifest(prev) != 0) {
 		if current == nil || current.GetDeletionTimestamp() != nil || res.Orphan || (comp.Labels != nil && comp.Labels["eno.azure.io/symphony-deleting"] == "true") {
 			return false, nil // already deleted - nothing to do
 		}

--- a/internal/resource/resource_test.go
+++ b/internal/resource/resource_test.go
@@ -501,7 +501,7 @@ func TestResourceOrdering(t *testing.T) {
 		{manifestHash: []byte("c")},
 	}
 	sort.Slice(resources, func(i, j int) bool {
-		return resources[i].Less(resources[j])
+		return resources[i].CompareManifest(resources[j]) < 0
 	})
 
 	assert.Equal(t, []*Resource{

--- a/internal/resource/tree.go
+++ b/internal/resource/tree.go
@@ -58,7 +58,7 @@ func (b *treeBuilder) Add(resource *Resource) {
 	b.init()
 
 	// Handle conflicting refs deterministically
-	if existing, ok := b.byRef[resource.Ref]; ok && resource.Less(existing.Resource) {
+	if existing, ok := b.byRef[resource.Ref]; ok && resource.CompareManifest(existing.Resource) < 0 {
 		return
 	}
 


### PR DESCRIPTION
Adds the `eno.azure.io/recreate: "true"` annotation to handle cases where updates (even full updates, not patches) will never succeed.

The most obvious example would be immutable configmaps. Synthesizers can always generate their own unique names for immutable configmaps, but in most cases it's easier to just recreate the configmap - it will only be missing for a few ms.