### PR TITLE
Fix panic in the new "fail open" codepath

### DIFF
--- a/internal/controllers/reconciliation/controller.go
+++ b/internal/controllers/reconciliation/controller.go
@@ -384,7 +384,7 @@ func (c *Controller) getCurrent(ctx context.Context, resource *resource.Resource
 }
 
 func (c *Controller) requeue(logger logr.Logger, resource *resource.Snapshot, ready *metav1.Time) (ctrl.Result, error) {
-	pendingForegroundDeletion := (resource.Deleted() && !resource.Disable && resource.ForegroundDeletion)
+	pendingForegroundDeletion := (resource != nil && resource.Deleted() && !resource.Disable && resource.ForegroundDeletion)
 
 	if ready == nil || pendingForegroundDeletion {
 		return ctrl.Result{RequeueAfter: wait.Jitter(c.readinessPollInterval, 0.1)}, nil


### PR DESCRIPTION
Currently the reconciliation controller will panic when requeueing resources that set `FailOpen` and are currently nil (e.g. already deleted).