### PR TITLE
Fix resource orphaning edge case

### DIFF
--- a/internal/controllers/reconciliation/controller.go
+++ b/internal/controllers/reconciliation/controller.go
@@ -209,7 +209,7 @@ func (c *Controller) reconcileSnapshot(ctx context.Context, comp *apiv1.Composit
 	}()
 
 	if res.Deleted() {
-		if current == nil || current.GetDeletionTimestamp() != nil || res.Orphan || (comp.Labels != nil && comp.Labels["eno.azure.io/symphony-deleting"] == "true") {
+		if current == nil || current.GetDeletionTimestamp() != nil || (res.Orphan && comp.DeletionTimestamp != nil) || (comp.Labels != nil && comp.Labels["eno.azure.io/symphony-deleting"] == "true") {
 			return false, nil // already deleted - nothing to do
 		}
 


### PR DESCRIPTION
Resources that use `eno.azure.io/deletion-strategy: Orphan` should still be deleted when they're removed from a non-deleting composition. Orphaning only affects composition deletion behavior.

This was a regression from some recent changes to the deletion logic.