### PR TITLE
Add support for --migrating-field-managers

### DIFF
--- a/cmd/eno-reconciler/main.go
+++ b/cmd/eno-reconciler/main.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	"go.uber.org/zap"
@@ -41,6 +42,7 @@ func run() error {
 		namespaceCreationGracePeriod time.Duration
 		namespaceCleanup             bool
 		enoBuildVersion              string
+		migratingFieldManagers       string
 
 		mgrOpts = &manager.Options{
 			Rest: ctrl.GetConfigOrDie(),
@@ -61,6 +63,7 @@ func run() error {
 	flag.DurationVar(&namespaceCreationGracePeriod, "ns-creation-grace-period", time.Second, "A namespace is assumed to be missing if it doesn't exist once one of its resources has existed for this long")
 	flag.BoolVar(&namespaceCleanup, "namespace-cleanup", true, "Clean up orphaned resources caused by namespace force-deletions")
 	flag.BoolVar(&recOpts.FailOpen, "fail-open", false, "Report that resources are reconciled once they've been seen, even if reconciliation failed. Overridden by individual resources with 'eno.azure.io/fail-open: true|false'")
+	flag.StringVar(&migratingFieldManagers, "migrating-field-managers", "", "Comma-separated list of Kubernetes SSA field manager names to take ownership from during migrations")
 	mgrOpts.Bind(flag.CommandLine)
 	flag.Parse()
 
@@ -124,6 +127,12 @@ func run() error {
 	recOpts.Manager = mgr
 	recOpts.WriteBuffer = writeBuffer
 	recOpts.Downstream = remoteConfig
+	if migratingFieldManagers != "" {
+		recOpts.MigratingFieldManagers = strings.Split(migratingFieldManagers, ",")
+		for i := range recOpts.MigratingFieldManagers {
+			recOpts.MigratingFieldManagers[i] = strings.TrimSpace(recOpts.MigratingFieldManagers[i])
+		}
+	}
 
 	err = reconciliation.New(mgr, recOpts)
 	if err != nil {

--- a/internal/controllers/reconciliation/overrides_test.go
+++ b/internal/controllers/reconciliation/overrides_test.go
@@ -903,7 +903,10 @@ func TestMigratingFieldManagers(t *testing.T) {
 		if err != nil {
 			return err
 		}
+		cm.ManagedFields = nil
 		cm.Data["bar"] = "legacy-value"
+		cm.APIVersion = "v1"
+		cm.Kind = "ConfigMap"
 		return mgr.DownstreamClient.Patch(ctx, cm, client.Apply, client.ForceOwnership, client.FieldOwner("legacy-tool"))
 	})
 	require.NoError(t, err)
@@ -1011,7 +1014,10 @@ func TestMigratingFieldManagersFieldRemoval(t *testing.T) {
 		if err != nil {
 			return err
 		}
+		cm.ManagedFields = nil
 		cm.Data["bar"] = "legacy-bar-value"
+		cm.APIVersion = "v1"
+		cm.Kind = "ConfigMap"
 		return mgr.DownstreamClient.Patch(ctx, cm, client.Apply, client.ForceOwnership, client.FieldOwner("legacy-tool"))
 	})
 	require.NoError(t, err)

--- a/internal/controllers/reconciliation/overrides_test.go
+++ b/internal/controllers/reconciliation/overrides_test.go
@@ -847,3 +847,207 @@ func TestOverrideTransferResource(t *testing.T) {
 		return syn1.Name == cm.Annotations["synthName"]
 	})
 }
+
+func TestMigratingFieldManagers(t *testing.T) {
+	ctx := testutil.NewContext(t)
+	mgr := testutil.NewManager(t)
+	upstream := mgr.GetClient()
+
+	requireSSA(t, mgr)
+	registerControllers(t, mgr)
+	testutil.WithFakeExecutor(t, mgr, func(ctx context.Context, s *apiv1.Synthesizer, input *krmv1.ResourceList) (*krmv1.ResourceList, error) {
+		output := &krmv1.ResourceList{}
+		output.Items = []*unstructured.Unstructured{{
+			Object: map[string]any{
+				"apiVersion": "v1",
+				"kind":       "ConfigMap",
+				"metadata": map[string]any{
+					"name":      "test-obj",
+					"namespace": "default",
+				},
+				"data": map[string]any{"foo": "eno-value"},
+			},
+		}}
+		return output, nil
+	})
+
+	// Setup with migrating field managers
+	setupTestSubjectForOptions(t, mgr, Options{
+		Manager:                mgr.Manager,
+		Timeout:                time.Minute,
+		ReadinessPollInterval:  time.Hour,
+		DisableServerSideApply: mgr.NoSsaSupport,
+		MigratingFieldManagers: []string{"legacy-tool"},
+	})
+	mgr.Start(t)
+	_, comp := writeGenericComposition(t, upstream)
+
+	// Wait for initial reconciliation
+	testutil.Eventually(t, func() bool {
+		return upstream.Get(ctx, client.ObjectKeyFromObject(comp), comp) == nil && comp.Status.CurrentSynthesis != nil && comp.Status.CurrentSynthesis.Ready != nil
+	})
+
+	// Resource should be created with Eno as the field manager
+	cm := &corev1.ConfigMap{}
+	cm.Name = "test-obj"
+	cm.Namespace = "default"
+	testutil.Eventually(t, func() bool {
+		err := mgr.DownstreamClient.Get(ctx, client.ObjectKeyFromObject(cm), cm)
+		return err == nil && cm.Data["foo"] == "eno-value"
+	})
+
+	// Simulate a legacy tool taking ownership of a field by updating managed fields
+	// This simulates the scenario where a field was previously managed by another tool
+	err := retry.RetryOnConflict(testutil.Backoff, func() error {
+		err := mgr.DownstreamClient.Get(ctx, client.ObjectKeyFromObject(cm), cm)
+		if err != nil {
+			return err
+		}
+		cm.Data["bar"] = "legacy-value"
+		return mgr.DownstreamClient.Patch(ctx, cm, client.Apply, client.ForceOwnership, client.FieldOwner("legacy-tool"))
+	})
+	require.NoError(t, err)
+
+	// Verify the field is owned by legacy-tool
+	testutil.Eventually(t, func() bool {
+		mgr.DownstreamClient.Get(ctx, client.ObjectKeyFromObject(cm), cm)
+		for _, entry := range cm.GetManagedFields() {
+			if entry.Manager == "legacy-tool" {
+				return true
+			}
+		}
+		return false
+	})
+
+	// Force a resynthesis to trigger field manager migration
+	err = retry.RetryOnConflict(testutil.Backoff, func() error {
+		upstream.Get(ctx, client.ObjectKeyFromObject(comp), comp)
+		comp.Spec.SynthesisEnv = []apiv1.EnvVar{{Name: "TRIGGER", Value: "resynthesis"}}
+		return upstream.Update(ctx, comp)
+	})
+	require.NoError(t, err)
+
+	// Wait for reconciliation
+	testutil.Eventually(t, func() bool {
+		return upstream.Get(ctx, client.ObjectKeyFromObject(comp), comp) == nil && comp.Status.CurrentSynthesis != nil && comp.Status.CurrentSynthesis.Ready != nil
+	})
+
+	// Verify that Eno has taken ownership from legacy-tool
+	testutil.Eventually(t, func() bool {
+		mgr.DownstreamClient.Get(ctx, client.ObjectKeyFromObject(cm), cm)
+		hasEno := false
+		hasLegacy := false
+		for _, entry := range cm.GetManagedFields() {
+			if entry.Manager == "eno" {
+				hasEno = true
+			}
+			if entry.Manager == "legacy-tool" {
+				hasLegacy = true
+			}
+		}
+		// Eno should have taken ownership, and legacy-tool should no longer own fields
+		// (or should own an empty set of fields)
+		return hasEno && !hasLegacy
+	})
+}
+
+func TestMigratingFieldManagersFieldRemoval(t *testing.T) {
+	ctx := testutil.NewContext(t)
+	mgr := testutil.NewManager(t)
+	upstream := mgr.GetClient()
+
+	requireSSA(t, mgr)
+	registerControllers(t, mgr)
+
+	// Start with synthesizer that includes a field
+	includeField := true
+	testutil.WithFakeExecutor(t, mgr, func(ctx context.Context, s *apiv1.Synthesizer, input *krmv1.ResourceList) (*krmv1.ResourceList, error) {
+		output := &krmv1.ResourceList{}
+		data := map[string]any{"foo": "eno-value"}
+		if includeField {
+			data["bar"] = "eno-bar-value"
+		}
+		output.Items = []*unstructured.Unstructured{{
+			Object: map[string]any{
+				"apiVersion": "v1",
+				"kind":       "ConfigMap",
+				"metadata": map[string]any{
+					"name":      "test-obj",
+					"namespace": "default",
+				},
+				"data": data,
+			},
+		}}
+		return output, nil
+	})
+
+	// Setup with migrating field managers
+	setupTestSubjectForOptions(t, mgr, Options{
+		Manager:                mgr.Manager,
+		Timeout:                time.Minute,
+		ReadinessPollInterval:  time.Hour,
+		DisableServerSideApply: mgr.NoSsaSupport,
+		MigratingFieldManagers: []string{"legacy-tool"},
+	})
+	mgr.Start(t)
+	_, comp := writeGenericComposition(t, upstream)
+
+	// Wait for initial reconciliation
+	testutil.Eventually(t, func() bool {
+		return upstream.Get(ctx, client.ObjectKeyFromObject(comp), comp) == nil && comp.Status.CurrentSynthesis != nil && comp.Status.CurrentSynthesis.Ready != nil
+	})
+
+	cm := &corev1.ConfigMap{}
+	cm.Name = "test-obj"
+	cm.Namespace = "default"
+	testutil.Eventually(t, func() bool {
+		err := mgr.DownstreamClient.Get(ctx, client.ObjectKeyFromObject(cm), cm)
+		return err == nil && cm.Data["bar"] == "eno-bar-value"
+	})
+
+	// Simulate legacy tool taking ownership of the "bar" field
+	err := retry.RetryOnConflict(testutil.Backoff, func() error {
+		err := mgr.DownstreamClient.Get(ctx, client.ObjectKeyFromObject(cm), cm)
+		if err != nil {
+			return err
+		}
+		cm.Data["bar"] = "legacy-bar-value"
+		return mgr.DownstreamClient.Patch(ctx, cm, client.Apply, client.ForceOwnership, client.FieldOwner("legacy-tool"))
+	})
+	require.NoError(t, err)
+
+	// Verify legacy-tool owns the field
+	testutil.Eventually(t, func() bool {
+		mgr.DownstreamClient.Get(ctx, client.ObjectKeyFromObject(cm), cm)
+		return cm.Data["bar"] == "legacy-bar-value"
+	})
+
+	// Now remove the field from Eno's desired state
+	includeField = false
+
+	// Force resynthesis
+	err = retry.RetryOnConflict(testutil.Backoff, func() error {
+		upstream.Get(ctx, client.ObjectKeyFromObject(comp), comp)
+		comp.Spec.SynthesisEnv = []apiv1.EnvVar{{Name: "REMOVE_FIELD", Value: "true"}}
+		return upstream.Update(ctx, comp)
+	})
+	require.NoError(t, err)
+
+	// Wait for reconciliation
+	testutil.Eventually(t, func() bool {
+		return upstream.Get(ctx, client.ObjectKeyFromObject(comp), comp) == nil && comp.Status.CurrentSynthesis != nil && comp.Status.CurrentSynthesis.Ready != nil
+	})
+
+	// The critical test: since Eno took ownership from legacy-tool,
+	// it should be able to remove the field even though it was originally owned by legacy-tool.
+	// This is the whole point of the migration feature - to allow safe field removal during migrations.
+	testutil.Eventually(t, func() bool {
+		mgr.DownstreamClient.Get(ctx, client.ObjectKeyFromObject(cm), cm)
+		_, exists := cm.Data["bar"]
+		return !exists // Field should be removed
+	})
+
+	// Verify foo is still present
+	require.NoError(t, mgr.DownstreamClient.Get(ctx, client.ObjectKeyFromObject(cm), cm))
+	assert.Equal(t, "eno-value", cm.Data["foo"])
+}

--- a/internal/resource/fieldmanager.go
+++ b/internal/resource/fieldmanager.go
@@ -28,13 +28,9 @@ func MergeEnoManagedFields(prev, current, next []metav1.ManagedFieldsEntry, migr
 	if !prevEnoSet.Empty() {
 		if !nextEnoSet.Empty() && currentEnoSet.Empty() {
 			expectedFields = prevEnoSet
-		} else {
-			driftFields := prevEnoSet.Difference(nextEnoSet)
-			if !driftFields.Empty() {
-				driftFields = driftFields.Intersection(parseAllFields(current))
-				if !driftFields.Empty() {
-					expectedFields = driftFields
-				}
+		} else if driftFields := prevEnoSet.Difference(nextEnoSet); !driftFields.Empty() {
+			if driftFields = driftFields.Intersection(parseAllFields(current)); !driftFields.Empty() {
+				expectedFields = driftFields
 			}
 		}
 	}
@@ -55,11 +51,12 @@ func MergeEnoManagedFields(prev, current, next []metav1.ManagedFieldsEntry, migr
 
 	// When there's no previous Eno fields but we have migrating fields,
 	// we need to build the managed fields from current state
+	base := prev
 	if prevEnoSet.Empty() && !migratingFields.Empty() {
-		return adjustManagedFields(current, expectedFields), expectedFields.String(), true
+		base = current
 	}
 
-	return adjustManagedFields(prev, expectedFields), expectedFields.String(), true
+	return adjustManagedFields(base, expectedFields), expectedFields.String(), true
 }
 
 func adjustManagedFields(entries []metav1.ManagedFieldsEntry, expected *fieldpath.Set) []metav1.ManagedFieldsEntry {

--- a/internal/resource/fieldmanager_test.go
+++ b/internal/resource/fieldmanager_test.go
@@ -252,7 +252,7 @@ func TestManagedFields(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.Name, func(t *testing.T) {
-			merged, _, modified := MergeEnoManagedFields(tc.Previous, tc.Current, tc.Next)
+			merged, _, modified := MergeEnoManagedFields(tc.Previous, tc.Current, tc.Next, nil)
 			assert.Equal(t, tc.ExpectModified, modified)
 			assert.Equal(t, parseFieldEntries(tc.Expected), parseFieldEntries(merged))
 
@@ -295,4 +295,125 @@ func parseFieldEntries(entries []metav1.ManagedFieldsEntry) []*fieldpath.Set {
 		sets[i] = set
 	}
 	return sets
+}
+
+func TestMigratingFieldManagers(t *testing.T) {
+	tests := []struct {
+		Name                    string
+		ExpectModified          bool
+		Previous, Current, Next []metav1.ManagedFieldsEntry
+		MigratingManagers       []string
+		Expected                []metav1.ManagedFieldsEntry
+	}{
+		{
+			Name:           "take ownership from single migrating manager",
+			ExpectModified: true,
+			Previous: []metav1.ManagedFieldsEntry{
+				makeFields(t, "eno", []string{"foo"}),
+			},
+			Current: []metav1.ManagedFieldsEntry{
+				makeFields(t, "eno", []string{"foo"}),
+				makeFields(t, "legacy-tool", []string{"bar"}),
+			},
+			Next: []metav1.ManagedFieldsEntry{
+				makeFields(t, "eno", []string{"foo"}),
+			},
+			MigratingManagers: []string{"legacy-tool"},
+			Expected: []metav1.ManagedFieldsEntry{
+				makeFields(t, "eno", []string{"foo", "bar"}),
+			},
+		},
+		{
+			Name:           "take ownership from multiple migrating managers",
+			ExpectModified: true,
+			Previous: []metav1.ManagedFieldsEntry{
+				makeFields(t, "eno", []string{"foo"}),
+			},
+			Current: []metav1.ManagedFieldsEntry{
+				makeFields(t, "eno", []string{"foo"}),
+				makeFields(t, "legacy-tool-1", []string{"bar"}),
+				makeFields(t, "legacy-tool-2", []string{"baz"}),
+			},
+			Next: []metav1.ManagedFieldsEntry{
+				makeFields(t, "eno", []string{"foo"}),
+			},
+			MigratingManagers: []string{"legacy-tool-1", "legacy-tool-2"},
+			Expected: []metav1.ManagedFieldsEntry{
+				makeFields(t, "eno", []string{"foo", "bar", "baz"}),
+			},
+		},
+		{
+			Name:           "no migrating managers configured",
+			ExpectModified: false,
+			Previous: []metav1.ManagedFieldsEntry{
+				makeFields(t, "eno", []string{"foo"}),
+			},
+			Current: []metav1.ManagedFieldsEntry{
+				makeFields(t, "eno", []string{"foo"}),
+				makeFields(t, "other-tool", []string{"bar"}),
+			},
+			Next: []metav1.ManagedFieldsEntry{
+				makeFields(t, "eno", []string{"foo"}),
+			},
+			MigratingManagers: nil,
+		},
+		{
+			Name:           "migrating manager not present in current",
+			ExpectModified: false,
+			Previous: []metav1.ManagedFieldsEntry{
+				makeFields(t, "eno", []string{"foo"}),
+			},
+			Current: []metav1.ManagedFieldsEntry{
+				makeFields(t, "eno", []string{"foo"}),
+			},
+			Next: []metav1.ManagedFieldsEntry{
+				makeFields(t, "eno", []string{"foo"}),
+			},
+			MigratingManagers: []string{"legacy-tool"},
+		},
+		{
+			Name:           "take ownership from migrating manager and handle drift",
+			ExpectModified: true,
+			Previous: []metav1.ManagedFieldsEntry{
+				makeFields(t, "eno", []string{"foo", "removed"}),
+			},
+			Current: []metav1.ManagedFieldsEntry{
+				makeFields(t, "eno", []string{"foo"}),
+				makeFields(t, "drift-tool", []string{"removed"}),
+				makeFields(t, "legacy-tool", []string{"bar"}),
+			},
+			Next: []metav1.ManagedFieldsEntry{
+				makeFields(t, "eno", []string{"foo"}),
+			},
+			MigratingManagers: []string{"legacy-tool"},
+			Expected: []metav1.ManagedFieldsEntry{
+				makeFields(t, "eno", []string{"foo", "removed", "bar"}),
+			},
+		},
+		{
+			Name:           "empty previous eno fields with migrating manager",
+			ExpectModified: false,
+			Previous:       []metav1.ManagedFieldsEntry{},
+			Current: []metav1.ManagedFieldsEntry{
+				makeFields(t, "legacy-tool", []string{"bar"}),
+			},
+			Next:              []metav1.ManagedFieldsEntry{},
+			MigratingManagers: []string{"legacy-tool"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.Name, func(t *testing.T) {
+			merged, _, modified := MergeEnoManagedFields(tc.Previous, tc.Current, tc.Next, tc.MigratingManagers)
+			assert.Equal(t, tc.ExpectModified, modified)
+			if tc.Expected != nil {
+				assert.Equal(t, parseFieldEntries(tc.Expected), parseFieldEntries(merged))
+			}
+
+			// Prove that the current slice wasn't mutated
+			if tc.ExpectModified {
+				assert.NotEqual(t, tc.Current, merged)
+			}
+		})
+	}
 }

--- a/internal/resource/fieldmanager_test.go
+++ b/internal/resource/fieldmanager_test.go
@@ -391,14 +391,18 @@ func TestMigratingFieldManagers(t *testing.T) {
 			},
 		},
 		{
-			Name:           "empty previous eno fields with migrating manager",
-			ExpectModified: false,
+			Name:           "empty previous eno fields with migrating manager - first reconciliation",
+			ExpectModified: true,
 			Previous:       []metav1.ManagedFieldsEntry{},
 			Current: []metav1.ManagedFieldsEntry{
 				makeFields(t, "legacy-tool", []string{"bar"}),
 			},
 			Next:              []metav1.ManagedFieldsEntry{},
 			MigratingManagers: []string{"legacy-tool"},
+			Expected: []metav1.ManagedFieldsEntry{
+				makeFields(t, "legacy-tool", []string{}), // Fields removed from legacy-tool
+				makeFields(t, "eno", []string{"bar"}),    // Fields added to eno
+			},
 		},
 	}
 


### PR DESCRIPTION
Allows users to specify one or more SSE field managers that Eno should take ownership from before making any changes to a resource.

This is useful for migration scenarios where a field is removed from an object during Eno's first update (to that object). Without first taking ownership of the previous manager's fields, apiserver will just ignore the empty field sent by Eno instead of pruning it.