### PR TITLE
feat: add optional refs support for synth inputs

### DIFF
--- a/internal/execution/executor_test.go
+++ b/internal/execution/executor_test.go
@@ -920,6 +920,13 @@ func TestWithOptionalInputs(t *testing.T) {
 				assert.Equal(t, "ConfigMap", rl.Items[0].GetKind())
 				assert.Equal(t, "required-input", rl.Items[0].GetName())
 
+				// Verify FunctionConfig contains the missing optional ref
+				require.NotNil(t, rl.FunctionConfig)
+				optRefs, found, err := unstructured.NestedStringSlice(rl.FunctionConfig.Object, "optionalRefs")
+				require.NoError(t, err)
+				require.True(t, found)
+				assert.Contains(t, optRefs, "optional")
+
 				out := &unstructured.Unstructured{
 					Object: map[string]any{
 						"apiVersion": "v1",
@@ -1017,6 +1024,13 @@ func TestWithOptionalInputs(t *testing.T) {
 				names := []string{rl.Items[0].GetName(), rl.Items[1].GetName()}
 				assert.Contains(t, names, "required-input")
 				assert.Contains(t, names, "optional-input")
+
+				// Verify FunctionConfig contains the optional ref
+				require.NotNil(t, rl.FunctionConfig)
+				optRefs, found, err := unstructured.NestedStringSlice(rl.FunctionConfig.Object, "optionalRefs")
+				require.NoError(t, err)
+				require.True(t, found)
+				assert.Contains(t, optRefs, "optional")
 
 				out := &unstructured.Unstructured{
 					Object: map[string]any{

--- a/pkg/function/main_test.go
+++ b/pkg/function/main_test.go
@@ -157,7 +157,7 @@ func TestMainInputMissing(t *testing.T) {
 	}
 
 	require.NoError(t, main(fn, &mainConfig{}, ir, ow))
-	assert.Equal(t, "{\"apiVersion\":\"config.kubernetes.io/v1\",\"kind\":\"ResourceList\",\"items\":[],\"results\":[{\"message\":\"error while reading input with key \\\"test-cm\\\": input \\\"test-cm\\\" was not found\",\"severity\":\"error\"}]}\n", outBuf.String())
+	assert.Equal(t, "{\"apiVersion\":\"config.kubernetes.io/v1\",\"kind\":\"ResourceList\",\"items\":[],\"results\":[{\"message\":\"error while reading input with key \\\"test-cm\\\": input \\\"test-cm\\\": input not found\",\"severity\":\"error\"}]}\n", outBuf.String())
 }
 
 func TestMainError(t *testing.T) {


### PR DESCRIPTION
Continuation of optional refs pr part 2:
- Add Optional field to Ref type in Synthesizer CRD
- Executor skips missing optional inputs without error
- Pass optional metadata via FunctionConfig.optionalRefs  
- Function framework checks FunctionConfig for optional status
- Watch controller handles optional ref deletion correctly
- Add comprehensive tests for optional refs functionality

We have previously added this field in the CRD and controller/watcher. These parts function as expected, but eno has the Executor and Synthesizer/Function which was missing the optional refs.

## Testing Done:
- [x] unit tests
- [x] standalone testing 

## Manual Testing Steps
* Build eno controller/reconciler
* Deploy onto a standalone environment
* Deploy synthesizer with optional input that does not exist - confirm no errors
* Update so input exists - confirm synthesizer reads optional input
* Delete optional input - confirm synthesizer still synthesizes without the input 