### PR TITLE
[eno] Adding more Eno metrics

### DIFF
--- a/internal/controllers/reconciliation/controller.go
+++ b/internal/controllers/reconciliation/controller.go
@@ -92,6 +92,8 @@ func New(mgr ctrl.Manager, opts Options) error {
 		maxConcurrentReconciles: opts.MaxConcurrentReconciles,
 	}
 
+	reconciliationMaxConcurrent.Set(float64(opts.MaxConcurrentReconciles))
+
 	return builder.TypedControllerManagedBy[resource.Request](mgr).
 		Named("reconciliationController").
 		WithLogConstructor(manager.NewTypedLogConstructor[*resource.Request](mgr, "reconciliationController")).
@@ -119,6 +121,9 @@ func New(mgr ctrl.Manager, opts Options) error {
 }
 
 func (c *Controller) Reconcile(ctx context.Context, req resource.Request) (ctrl.Result, error) {
+	reconciliationsInFlight.Inc()
+	defer reconciliationsInFlight.Dec()
+
 	logger := logr.FromContextOrDiscard(ctx)
 	logger.Info("reconciling resource", "compositionName", req.Composition.Name, "compositionNamespace", req.Composition.Namespace, "resourceRef", req.Resource.String())
 

--- a/internal/controllers/reconciliation/controller.go
+++ b/internal/controllers/reconciliation/controller.go
@@ -103,6 +103,16 @@ func New(mgr ctrl.Manager, opts Options) error {
 			// the additional shared/global/non-item-scoped limiter.
 			RateLimiter:             workqueue.NewTypedItemExponentialFailureRateLimiter[resource.Request](5*time.Millisecond, 1000*time.Second),
 			MaxConcurrentReconciles: c.maxConcurrentReconciles,
+			// Build the workqueue ourselves so we can capture a reference to it for metrics relateing to reconciliation
+			// The constructor below is what controller-runtime would have called by default.
+			NewQueue: func(name string, rl workqueue.TypedRateLimiter[resource.Request]) workqueue.TypedRateLimitingInterface[resource.Request] {
+				q := workqueue.NewTypedRateLimitingQueueWithConfig(
+					rl,
+					workqueue.TypedRateLimitingQueueConfig[resource.Request]{Name: name},
+				)
+				setWorkqueueLenSource(q.Len)
+				return q
+			},
 		}).
 		WatchesRawSource(src).
 		Complete(c)
@@ -236,7 +246,7 @@ func (c *Controller) reconcileSnapshot(ctx context.Context, comp *apiv1.Composit
 	logger := logr.FromContextOrDiscard(ctx)
 	start := time.Now()
 	defer func() {
-		reconciliationLatency.Observe(float64(time.Since(start).Milliseconds()))
+		reconciliationLatency.Observe(time.Since(start).Seconds())
 	}()
 
 	if res.Deleted() {

--- a/internal/controllers/reconciliation/controller.go
+++ b/internal/controllers/reconciliation/controller.go
@@ -105,7 +105,7 @@ func New(mgr ctrl.Manager, opts Options) error {
 			// the additional shared/global/non-item-scoped limiter.
 			RateLimiter:             workqueue.NewTypedItemExponentialFailureRateLimiter[resource.Request](5*time.Millisecond, 1000*time.Second),
 			MaxConcurrentReconciles: c.maxConcurrentReconciles,
-			// Build the workqueue ourselves so we can capture a reference to it for metrics relateing to reconciliation
+			// Build the workqueue ourselves so we can capture a reference to it for metrics relating to reconciliation
 			// The constructor below is what controller-runtime would have called by default.
 			NewQueue: func(name string, rl workqueue.TypedRateLimiter[resource.Request]) workqueue.TypedRateLimitingInterface[resource.Request] {
 				q := workqueue.NewTypedRateLimitingQueueWithConfig(

--- a/internal/controllers/reconciliation/metrics.go
+++ b/internal/controllers/reconciliation/metrics.go
@@ -1,6 +1,8 @@
 package reconciliation
 
 import (
+	"sync/atomic"
+
 	"github.com/prometheus/client_golang/prometheus"
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
 )
@@ -9,8 +11,8 @@ var (
 	reconciliationLatency = prometheus.NewHistogram(
 		prometheus.HistogramOpts{
 			Name:    "eno_reconciliation_duration_seconds",
-			Help:    "Samples latency of the entire reconciliation process",
-			Buckets: []float64{0.1, 0.5, 0.75, 1.0, 3.0, 6.0, 11.0, 20.0, 30.0, 40.0},
+			Help:    "Latency of the entire reconciliation process, in seconds",
+			Buckets: []float64{0.05, 0.1, 0.25, 0.5, 1, 2, 5, 10, 30, 60, 120, 300},
 		},
 	)
 
@@ -20,8 +22,32 @@ var (
 			Help: "Attempts to reconcile managed resources into the desired state, partitioned by action i.e. create, patch, delete",
 		}, []string{"action"},
 	)
+
+	reconciliationWorkqueueDepth = prometheus.NewGaugeFunc(
+		prometheus.GaugeOpts{
+			Name: "eno_reconciliation_workqueue_depth",
+			Help: "Current depth of the reconciliation controller workqueue",
+		},
+		func() float64 {
+			fn := workqueueLenFn.Load()
+			if fn == nil {
+				return 0
+			}
+			return float64((*fn)())
+		},
+	)
+	// Closure that returns the current reconciler workqueue depth. Installed by
+	// the Controller's NewQueue hook (see controller.go); nil before the queue is
+	// constructed. atomic.Pointer makes the swap safe against the scrape goroutine.
+	workqueueLenFn atomic.Pointer[func() int]
 )
 
 func init() {
-	metrics.Registry.MustRegister(reconciliationLatency, reconciliationActions)
+	metrics.Registry.MustRegister(reconciliationLatency, reconciliationActions, reconciliationWorkqueueDepth)
+}
+
+// setWorkqueueLenSource installs the queue.Len reader used by the gauge above.
+// this is called once during Controller construction
+func setWorkqueueLenSource(fn func() int) {
+	workqueueLenFn.Store(&fn)
 }

--- a/internal/controllers/reconciliation/metrics.go
+++ b/internal/controllers/reconciliation/metrics.go
@@ -23,9 +23,23 @@ var (
 		}, []string{"action"},
 	)
 
+	reconciliationsInFlight = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "eno_reconciliations_in_flight",
+			Help: "Number of resource reconciliations currently being processed. Bounded by MaxConcurrentReconciles.",
+		},
+	)
+
+	reconciliationMaxConcurrent = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "eno_reconciliation_controller_max_concurrent_reconciles",
+			Help: "Configured maximum number of concurrent reconciliations for the reconciliation controller.",
+		},
+	)
+
 	reconciliationWorkqueueDepth = prometheus.NewGaugeFunc(
 		prometheus.GaugeOpts{
-			Name: "eno_reconciliation_workqueue_depth",
+			Name: "eno_reconciliation_controller_workqueue_depth",
 			Help: "Current depth of the reconciliation controller workqueue",
 		},
 		func() float64 {
@@ -43,7 +57,7 @@ var (
 )
 
 func init() {
-	metrics.Registry.MustRegister(reconciliationLatency, reconciliationActions, reconciliationWorkqueueDepth)
+	metrics.Registry.MustRegister(reconciliationLatency, reconciliationActions, reconciliationsInFlight, reconciliationMaxConcurrent, reconciliationWorkqueueDepth)
 }
 
 // setWorkqueueLenSource installs the queue.Len reader used by the gauge above.

--- a/internal/controllers/reconciliation/metrics_test.go
+++ b/internal/controllers/reconciliation/metrics_test.go
@@ -1,0 +1,63 @@
+package reconciliation
+
+import (
+	"testing"
+
+	prometheustestutil "github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestReconciliationsInFlightGauge(t *testing.T) {
+	reconciliationsInFlight.Set(0)
+
+	reconciliationsInFlight.Inc()
+	reconciliationsInFlight.Inc()
+	assert.Equal(t, 2.0, prometheustestutil.ToFloat64(reconciliationsInFlight))
+
+	reconciliationsInFlight.Dec()
+	assert.Equal(t, 1.0, prometheustestutil.ToFloat64(reconciliationsInFlight))
+
+	reconciliationsInFlight.Dec()
+	assert.Equal(t, 0.0, prometheustestutil.ToFloat64(reconciliationsInFlight))
+}
+
+func TestReconciliationMaxConcurrentGauge(t *testing.T) {
+	reconciliationMaxConcurrent.Set(0)
+
+	reconciliationMaxConcurrent.Set(42)
+	assert.Equal(t, 42.0, prometheustestutil.ToFloat64(reconciliationMaxConcurrent))
+
+	// Subsequent Set replaces, not accumulates.
+	reconciliationMaxConcurrent.Set(7)
+	assert.Equal(t, 7.0, prometheustestutil.ToFloat64(reconciliationMaxConcurrent))
+}
+
+func TestReconciliationWorkqueueDepthGauge(t *testing.T) {
+	// Restore any previously installed source after the test.
+	prev := workqueueLenFn.Load()
+	t.Cleanup(func() {
+		if prev == nil {
+			workqueueLenFn.Store(nil)
+		} else {
+			workqueueLenFn.Store(prev)
+		}
+	})
+
+	// Before any source is installed the gauge reports 0.
+	workqueueLenFn.Store(nil)
+	assert.Equal(t, 0.0, prometheustestutil.ToFloat64(reconciliationWorkqueueDepth))
+
+	// After installation the gauge reflects the closure's return value live.
+	depth := 0
+	setWorkqueueLenSource(func() int { return depth })
+
+	depth = 5
+	assert.Equal(t, 5.0, prometheustestutil.ToFloat64(reconciliationWorkqueueDepth))
+
+	depth = 0
+	assert.Equal(t, 0.0, prometheustestutil.ToFloat64(reconciliationWorkqueueDepth))
+
+	// A second call replaces the source (last-writer-wins).
+	setWorkqueueLenSource(func() int { return 99 })
+	assert.Equal(t, 99.0, prometheustestutil.ToFloat64(reconciliationWorkqueueDepth))
+}

--- a/internal/controllers/reconciliation/overrides_test.go
+++ b/internal/controllers/reconciliation/overrides_test.go
@@ -1218,7 +1218,9 @@ func TestOverrideVPAMinMax(t *testing.T) {
 
 	// === Case 1: Annotation OFF, no changes — defaults preserved ===
 	testutil.Eventually(t, func() bool {
-		mgr.DownstreamClient.Get(ctx, client.ObjectKeyFromObject(cm), cm)
+		if err := mgr.DownstreamClient.Get(ctx, client.ObjectKeyFromObject(cm), cm); err != nil {
+			return false
+		}
 		return cm.Data["min-cpu"] == "100m" && cm.Data["min-memory"] == "128Mi" &&
 			cm.Data["max-cpu"] == "2" && cm.Data["max-memory"] == "4Gi"
 	})
@@ -1237,7 +1239,9 @@ func TestOverrideVPAMinMax(t *testing.T) {
 	require.NoError(t, err)
 
 	testutil.Eventually(t, func() bool {
-		mgr.DownstreamClient.Get(ctx, client.ObjectKeyFromObject(cm), cm)
+		if err := mgr.DownstreamClient.Get(ctx, client.ObjectKeyFromObject(cm), cm); err != nil {
+			return false
+		}
 		return cm.Data["min-cpu"] == "100m" && cm.Data["min-memory"] == "128Mi" &&
 			cm.Data["max-cpu"] == "2" && cm.Data["max-memory"] == "4Gi"
 	})
@@ -1258,7 +1262,9 @@ func TestOverrideVPAMinMax(t *testing.T) {
 	// valueExpression reads self.data['min-cpu'] from live = "100m" (same as default), so no visible change
 	time.Sleep(100 * time.Millisecond)
 	testutil.Eventually(t, func() bool {
-		mgr.DownstreamClient.Get(ctx, client.ObjectKeyFromObject(cm), cm)
+		if err := mgr.DownstreamClient.Get(ctx, client.ObjectKeyFromObject(cm), cm); err != nil {
+			return false
+		}
 		return cm.Data["min-cpu"] == "100m" && cm.Data["min-memory"] == "128Mi" &&
 			cm.Data["max-cpu"] == "2" && cm.Data["max-memory"] == "4Gi"
 	})
@@ -1277,7 +1283,9 @@ func TestOverrideVPAMinMax(t *testing.T) {
 
 	time.Sleep(100 * time.Millisecond)
 	testutil.Eventually(t, func() bool {
-		mgr.DownstreamClient.Get(ctx, client.ObjectKeyFromObject(cm), cm)
+		if err := mgr.DownstreamClient.Get(ctx, client.ObjectKeyFromObject(cm), cm); err != nil {
+			return false
+		}
 		return cm.Data["min-cpu"] == "500m" && cm.Data["min-memory"] == "1Gi" &&
 			cm.Data["max-cpu"] == "2" && cm.Data["max-memory"] == "4Gi"
 	})
@@ -1296,7 +1304,9 @@ func TestOverrideVPAMinMax(t *testing.T) {
 
 	time.Sleep(100 * time.Millisecond)
 	testutil.Eventually(t, func() bool {
-		mgr.DownstreamClient.Get(ctx, client.ObjectKeyFromObject(cm), cm)
+		if err := mgr.DownstreamClient.Get(ctx, client.ObjectKeyFromObject(cm), cm); err != nil {
+			return false
+		}
 		return cm.Data["min-cpu"] == "500m" && cm.Data["min-memory"] == "1Gi" &&
 			cm.Data["max-cpu"] == "16" && cm.Data["max-memory"] == "32Gi"
 	})

--- a/internal/controllers/scheduling/metrics.go
+++ b/internal/controllers/scheduling/metrics.go
@@ -37,10 +37,25 @@ var (
 			Help: "Health status of each composition (0 = healthy, 1 = stuck/unhealthy)",
 		}, []string{"composition_name", "composition_namespace", "synthesizer_name"},
 	)
+
+	// Per-composition wait between Synthesis.Initialized (the moment the controller
+	// decided this composition should be synthesized) and successful creation of
+	// the synthesizer pod. Captures customer-visible queueing latency that is
+	// independent of synthesizer pod runtime. Anomaly example: p95 jumps from
+	// sub-second into the 60-300s bucket while `eno_free_synthesis_slots` is
+	// occasionally non-zero — points at a dispatch-loop stall or apiserver
+	// contention rather than raw capacity exhaustion.
+	synthesisDispatchWait = prometheus.NewHistogram(
+		prometheus.HistogramOpts{
+			Name:    "eno_composition_synthesis_wait_seconds",
+			Help:    "Time from Synthesis.Initialized to successful pod creation",
+			Buckets: []float64{0.1, 0.5, 1, 5, 15, 60, 300, 900},
+		},
+	)
 )
 
 func init() {
-	metrics.Registry.MustRegister(freeSynthesisSlots, schedulingLatency, stuckReconciling, compositionHealth)
+	metrics.Registry.MustRegister(freeSynthesisSlots, schedulingLatency, stuckReconciling, compositionHealth, synthesisDispatchWait)
 }
 
 func missedReconciliation(comp *apiv1.Composition, threshold time.Duration) bool {
@@ -55,4 +70,8 @@ func missedReconciliation(comp *apiv1.Composition, threshold time.Duration) bool
 		return true // stuck waiting for synthesis dispatch
 	}
 	return syn != nil && syn.Initialized != nil && time.Since(syn.Initialized.Time) > threshold // stuck waiting for reconciliation
+}
+
+func ObserveSynthesisDispatchWait(seconds float64) {
+	synthesisDispatchWait.Observe(seconds)
 }

--- a/internal/controllers/synthesis/gc.go
+++ b/internal/controllers/synthesis/gc.go
@@ -189,5 +189,8 @@ func synthesisAge(comp *apiv1.Composition) *int64 {
 }
 
 func getSynthesizerName(pod *corev1.Pod) string {
-	return pod.GetLabels()[synthesizerNameLabelKey]
+	if name := pod.GetLabels()[synthesizerNameLabelKey]; name != "" {
+		return name
+	}
+	return "unknown"
 }

--- a/internal/controllers/synthesis/gc.go
+++ b/internal/controllers/synthesis/gc.go
@@ -20,6 +20,18 @@ type podGarbageCollector struct {
 	client          client.Client
 	creationTimeout time.Duration
 }
+type terminalReason string
+
+const (
+	reasonSuccess            terminalReason = "success"
+	reasonTimeout            terminalReason = "timeout"
+	reasonSuperseded         terminalReason = "superseded"
+	reasonOrphaned           terminalReason = "orphaned"
+	reasonImageChanged       terminalReason = "image_changed"
+	reasonCompositionDeleted terminalReason = "composition_deleted"
+	reasonSynthesizerDeleted terminalReason = "synthesizer_deleted"
+	reasonKubeletTimeout     terminalReason = "kubelet_timeout"
+)
 
 func NewPodGC(mgr ctrl.Manager, creationTimeout time.Duration) error {
 	c := &podGarbageCollector{
@@ -61,7 +73,7 @@ func (p *podGarbageCollector) Reconcile(ctx context.Context, req ctrl.Request) (
 			return ctrl.Result{RequeueAfter: p.creationTimeout - delta}, nil
 		}
 		logger = logger.WithValues("reason", "ContainerCreationTimeout")
-		return ctrl.Result{}, p.deletePod(ctx, pod, logger)
+		return ctrl.Result{}, p.deletePod(ctx, pod, getSynthesizerName(pod), reasonKubeletTimeout, logger)
 	}
 
 	// GC pods from deleted compositions
@@ -73,7 +85,7 @@ func (p *podGarbageCollector) Reconcile(ctx context.Context, req ctrl.Request) (
 		"operationID", comp.GetAzureOperationID(), "operationOrigin", comp.GetAzureOperationOrigin())
 	if errors.IsNotFound(err) || comp.DeletionTimestamp != nil {
 		logger = logger.WithValues("reason", "CompositionDeleted")
-		return ctrl.Result{}, p.deletePod(ctx, pod, logger)
+		return ctrl.Result{}, p.deletePod(ctx, pod, getSynthesizerName(pod), reasonCompositionDeleted, logger)
 	}
 	if err != nil {
 		logger.Error(err, "failed to get composition resource")
@@ -87,7 +99,7 @@ func (p *podGarbageCollector) Reconcile(ctx context.Context, req ctrl.Request) (
 	logger = logger.WithValues("synthesizerName", syn.Name, "synthesizerGeneration", syn.Generation)
 	if errors.IsNotFound(err) {
 		logger = logger.WithValues("reason", "SynthesizerDeleted")
-		return ctrl.Result{}, p.deletePod(ctx, pod, logger)
+		return ctrl.Result{}, p.deletePod(ctx, pod, getSynthesizerName(pod), reasonSynthesizerDeleted, logger)
 	}
 	if err != nil {
 		logger.Error(err, "failed to get synthesizer")
@@ -104,19 +116,19 @@ func (p *podGarbageCollector) Reconcile(ctx context.Context, req ctrl.Request) (
 	// The image tag must match the current synthesizer, otherwise other properties (e.g. refs) may be incorrect
 	if img := findContainerImage(pod); img != "" && img != syn.Spec.Image {
 		logger = logger.WithValues("reason", "ImageChanged")
-		return ctrl.Result{}, p.deletePod(ctx, pod, logger)
+		return ctrl.Result{}, p.deletePod(ctx, pod, getSynthesizerName(pod), reasonImageChanged, logger)
 	}
 
 	if syn := comp.Status.InFlightSynthesis; syn != nil {
 		if syn.Canceled != nil {
 			logger = logger.WithValues("reason", "Timeout")
-			return ctrl.Result{}, p.deletePod(ctx, pod, logger)
+			return ctrl.Result{}, p.deletePod(ctx, pod, getSynthesizerName(pod), reasonTimeout, logger)
 		}
 
 		// A new synthesis has replaced the previous
 		if syn.UUID != pod.Labels[synthesisIDLabelKey] {
 			logger = logger.WithValues("reason", "Superseded")
-			return ctrl.Result{}, p.deletePod(ctx, pod, logger)
+			return ctrl.Result{}, p.deletePod(ctx, pod, getSynthesizerName(pod), reasonSuperseded, logger)
 		}
 
 		return ctrl.Result{RequeueAfter: time.Second}, nil // still active
@@ -125,15 +137,15 @@ func (p *podGarbageCollector) Reconcile(ctx context.Context, req ctrl.Request) (
 	// In-flight synthesis being swapped to current == synthesis completed
 	if syn := comp.Status.CurrentSynthesis; syn != nil && syn.UUID == pod.Labels[synthesisIDLabelKey] {
 		logger = logger.WithValues("reason", "Success")
-		return ctrl.Result{}, p.deletePod(ctx, pod, logger)
+		return ctrl.Result{}, p.deletePod(ctx, pod, getSynthesizerName(pod), reasonSuccess, logger)
 	}
 
 	// This condition should only be able to happen when the composition has been deleted
 	logger = logger.WithValues("reason", "Orphaned")
-	return ctrl.Result{}, p.deletePod(ctx, pod, logger)
+	return ctrl.Result{}, p.deletePod(ctx, pod, getSynthesizerName(pod), reasonOrphaned, logger)
 }
 
-func (p *podGarbageCollector) deletePod(ctx context.Context, pod *corev1.Pod, logger logr.Logger) error {
+func (p *podGarbageCollector) deletePod(ctx context.Context, pod *corev1.Pod, synthesizerName string, reason terminalReason, logger logr.Logger) error {
 	logger = logger.WithValues("podPhase", string(pod.Status.Phase), "podNodeName", pod.Spec.NodeName)
 	if cs := pod.Status.ContainerStatuses; len(cs) > 0 {
 		logger = logger.WithValues("restarts", cs[0].RestartCount, "containerStarted", cs[0].Started, "containerImage", cs[0].Image)
@@ -142,6 +154,11 @@ func (p *podGarbageCollector) deletePod(ctx context.Context, pod *corev1.Pod, lo
 	if err != nil {
 		return fmt.Errorf("deleting pod: %w", err)
 	}
+	latency := time.Since(pod.CreationTimestamp.Time)
+
+	synthesisResults.WithLabelValues(synthesizerName, string(reason)).Inc()
+	synthesisDuration.WithLabelValues(synthesizerName, string(reason)).Observe(latency.Seconds())
+
 	logger.Info("deleted synthesizer pod", "latency", time.Since(pod.CreationTimestamp.Time).Milliseconds())
 	return nil
 }
@@ -169,4 +186,8 @@ func synthesisAge(comp *apiv1.Composition) *int64 {
 		return nil
 	}
 	return ptr.To(time.Since(syn.Initialized.Time).Milliseconds())
+}
+
+func getSynthesizerName(pod *corev1.Pod) string {
+	return pod.GetLabels()[synthesizerNameLabelKey]
 }

--- a/internal/controllers/synthesis/lifecycle.go
+++ b/internal/controllers/synthesis/lifecycle.go
@@ -3,6 +3,7 @@ package synthesis
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
@@ -18,6 +19,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	apiv1 "github.com/Azure/eno/api/v1"
+	"github.com/Azure/eno/internal/controllers/scheduling"
 	"github.com/Azure/eno/internal/manager"
 )
 
@@ -145,6 +147,9 @@ func (c *podLifecycleController) Reconcile(ctx context.Context, req ctrl.Request
 	}
 	logger.Info("created synthesizer pod", "podName", pod.Name)
 	sytheses.Inc()
+	if init := comp.Status.InFlightSynthesis.Initialized; init != nil {
+		scheduling.ObserveSynthesisDispatchWait(time.Since(init.Time).Seconds())
+	}
 
 	return ctrl.Result{}, nil
 }

--- a/internal/controllers/synthesis/lifecycle.go
+++ b/internal/controllers/synthesis/lifecycle.go
@@ -148,6 +148,10 @@ func (c *podLifecycleController) Reconcile(ctx context.Context, req ctrl.Request
 	logger.Info("created synthesizer pod", "podName", pod.Name)
 	sytheses.Inc()
 	if init := comp.Status.InFlightSynthesis.Initialized; init != nil {
+		// TODO: This introduces a synthesis -> scheduling import dependency. If
+		// more cross-package metric observations come up, extract shared metrics
+		// into a common package (e.g. internal/metrics) so neither controller
+		// imports the other.
 		scheduling.ObserveSynthesisDispatchWait(time.Since(init.Time).Seconds())
 	}
 

--- a/internal/controllers/synthesis/metrics.go
+++ b/internal/controllers/synthesis/metrics.go
@@ -12,8 +12,34 @@ var (
 			Help: "Initiated synthesis operations",
 		},
 	)
+	// Tracks the outcome of every synthesis attempt, broken down per synthesizer.
+	// Used to compute success rate and to alert when a specific synthesizer starts
+	// failing. Anomaly example: a sudden spike in `result="timeout"` or
+	// `result="kubeletTimeout"` for one synthesizer indicates the synth pod is
+	// hanging or the node is unhealthy, while the rest of the fleet looks fine.
+	synthesisResults = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "eno_synthesis_result_total",
+			Help: "Synthesis operations partitioned by synthesizer and result",
+		},
+		[]string{"synthesizer", "result"},
+	)
+
+	// Wall-clock latency from pod creation to terminal state, per synthesizer and
+	// result. Used to track p95/p99 synthesis latency and detect regressions in
+	// synthesizer performance or scheduling. Anomaly example: p95 for a given
+	// synthesizer jumps from ~5s into the 60-120s bucket after a release, pointing
+	// at a slow synthesizer image or kubelet pull/start delays.
+	synthesisDuration = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "eno_synthesis_duration_seconds",
+			Help:    "Wall-clock duration for synthesizer pod creation to terminal state",
+			Buckets: []float64{0.5, 1, 2, 5, 10, 30, 60, 120, 300, 600},
+		},
+		[]string{"synthesizer", "result"},
+	)
 )
 
 func init() {
-	metrics.Registry.MustRegister(sytheses)
+	metrics.Registry.MustRegister(sytheses, synthesisResults, synthesisDuration)
 }

--- a/internal/controllers/synthesis/metrics_test.go
+++ b/internal/controllers/synthesis/metrics_test.go
@@ -1,0 +1,89 @@
+package synthesis
+
+import (
+	"context"
+	"testing"
+
+	apiv1 "github.com/Azure/eno/api/v1"
+	"github.com/go-logr/logr"
+	prometheustestutil "github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestGetSynthesizerName(t *testing.T) {
+	cases := []struct {
+		name   string
+		labels map[string]string
+		want   string
+	}{
+		{"present", map[string]string{synthesizerNameLabelKey: "my-syn"}, "my-syn"},
+		{"empty-value", map[string]string{synthesizerNameLabelKey: ""}, "unknown"},
+		{"missing-key", map[string]string{"other": "x"}, "unknown"},
+		{"nil-labels", nil, "unknown"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			pod := &corev1.Pod{}
+			pod.Labels = tc.labels
+			assert.Equal(t, tc.want, getSynthesizerName(pod))
+		})
+	}
+}
+
+func TestDeletePodEmitsMetrics(t *testing.T) {
+	synthesisResults.Reset()
+	synthesisDuration.Reset()
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, apiv1.SchemeBuilder.AddToScheme(scheme))
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "test-pod",
+			Namespace:         "default",
+			Labels:            map[string]string{synthesizerNameLabelKey: "my-syn"},
+			CreationTimestamp: metav1.Now(),
+		},
+	}
+	cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(pod).Build()
+	gc := &podGarbageCollector{client: cli}
+
+	require.NoError(t, gc.deletePod(context.Background(), pod, getSynthesizerName(pod), reasonSuccess, logr.Discard()))
+
+	got := prometheustestutil.ToFloat64(synthesisResults.WithLabelValues("my-syn", string(reasonSuccess)))
+	assert.Equal(t, 1.0, got)
+
+	// Histogram observation recorded (one series, one sample).
+	assert.Equal(t, 1, prometheustestutil.CollectAndCount(synthesisDuration))
+}
+
+func TestDeletePodUnknownSynthesizer(t *testing.T) {
+	synthesisResults.Reset()
+	synthesisDuration.Reset()
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "test-pod",
+			Namespace:         "default",
+			CreationTimestamp: metav1.Now(),
+			// No synthesizer-name label.
+		},
+	}
+	cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(pod).Build()
+	gc := &podGarbageCollector{client: cli}
+
+	require.NoError(t, gc.deletePod(context.Background(), pod, getSynthesizerName(pod), reasonOrphaned, logr.Discard()))
+
+	// "unknown" fallback fires; empty-string label is never emitted.
+	assert.Equal(t, 1.0, prometheustestutil.ToFloat64(synthesisResults.WithLabelValues("unknown", string(reasonOrphaned))))
+	assert.Equal(t, 0.0, prometheustestutil.ToFloat64(synthesisResults.WithLabelValues("", string(reasonOrphaned))))
+}

--- a/internal/controllers/synthesis/pod.go
+++ b/internal/controllers/synthesis/pod.go
@@ -16,6 +16,7 @@ const (
 	compositionNameLabelKey      = "eno.azure.io/composition-name"
 	compositionNamespaceLabelKey = "eno.azure.io/composition-namespace"
 	synthesisIDLabelKey          = "eno.azure.io/synthesis-uuid"
+	synthesizerNameLabelKey      = "eno.azure.io/synthesizer-name"
 )
 
 func newPod(cfg *Config, comp *apiv1.Composition, syn *apiv1.Synthesizer) *corev1.Pod {
@@ -26,6 +27,7 @@ func newPod(cfg *Config, comp *apiv1.Composition, syn *apiv1.Synthesizer) *corev
 		compositionNameLabelKey:      comp.Name,
 		compositionNamespaceLabelKey: comp.Namespace,
 		synthesisIDLabelKey:          comp.Status.InFlightSynthesis.UUID,
+		synthesizerNameLabelKey:      comp.Spec.Synthesizer.Name,
 		manager.ManagerLabelKey:      manager.ManagerLabelValue,
 	}
 	// Apply controller flag overrides first.

--- a/internal/flowcontrol/metrics.go
+++ b/internal/flowcontrol/metrics.go
@@ -1,6 +1,8 @@
 package flowcontrol
 
 import (
+	"sync/atomic"
+
 	"github.com/prometheus/client_golang/prometheus"
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
 )
@@ -12,8 +14,45 @@ var (
 			Help: "Count of batch updates to resource slice status",
 		},
 	)
+
+	// Depth of the write buffer's internal queue. A persistently non-zero value
+	// means status patches are accumulating faster than the buffer can flush them
+	// to apiserver, which directly delays comp.Status.{Reconciled,Ready} updates.
+	writeBufferDepth = prometheus.NewGaugeFunc(
+		prometheus.GaugeOpts{
+			Name: "eno_write_buffer_depth",
+			Help: "Current depth of the resource slice status write buffer queue",
+		},
+		func() float64 {
+			fn := writeBufferLenFn.Load()
+			if fn == nil {
+				return 0
+			}
+			return float64((*fn)())
+		},
+	)
+	// Closure that returns the current write buffer queue depth. Installed by
+	// NewResourceSliceWriteBuffer; nil before the buffer is constructed.
+	// atomic.Pointer makes the swap safe against the scrape goroutine.
+	writeBufferLenFn atomic.Pointer[func() int]
+
+	// Errors hit while flushing status patches. Partitioned by op (get/patch/marshal)
+	// to distinguish "stale cache" (get) from "apiserver rejected the patch" (patch).
+	// All of these silently retry today, so without this counter they're invisible.
+	writeBufferStatusUpdateErrors = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "eno_write_buffer_status_update_errors_total",
+			Help: "Errors encountered while flushing resource slice status updates, partitioned by operation",
+		}, []string{"op"},
+	)
 )
 
 func init() {
-	metrics.Registry.MustRegister(sliceStatusUpdates)
+	metrics.Registry.MustRegister(sliceStatusUpdates, writeBufferDepth, writeBufferStatusUpdateErrors)
+}
+
+// setWriteBufferLenSource installs the queue.Len reader used by the depth gauge.
+// Called once during NewResourceSliceWriteBuffer.
+func setWriteBufferLenSource(fn func() int) {
+	writeBufferLenFn.Store(&fn)
 }

--- a/internal/flowcontrol/metrics_test.go
+++ b/internal/flowcontrol/metrics_test.go
@@ -1,0 +1,52 @@
+package flowcontrol
+
+import (
+	"testing"
+
+	prometheustestutil "github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWriteBufferStatusUpdateErrorsLabels(t *testing.T) {
+	writeBufferStatusUpdateErrors.Reset()
+
+	writeBufferStatusUpdateErrors.WithLabelValues("get").Inc()
+	writeBufferStatusUpdateErrors.WithLabelValues("get").Inc()
+	writeBufferStatusUpdateErrors.WithLabelValues("marshal").Inc()
+	writeBufferStatusUpdateErrors.WithLabelValues("patch").Inc()
+
+	assert.Equal(t, 2.0, prometheustestutil.ToFloat64(writeBufferStatusUpdateErrors.WithLabelValues("get")))
+	assert.Equal(t, 1.0, prometheustestutil.ToFloat64(writeBufferStatusUpdateErrors.WithLabelValues("marshal")))
+	assert.Equal(t, 1.0, prometheustestutil.ToFloat64(writeBufferStatusUpdateErrors.WithLabelValues("patch")))
+	// Untouched labels stay at zero.
+	assert.Equal(t, 0.0, prometheustestutil.ToFloat64(writeBufferStatusUpdateErrors.WithLabelValues("other")))
+}
+
+func TestWriteBufferDepthGauge(t *testing.T) {
+	prev := writeBufferLenFn.Load()
+	t.Cleanup(func() {
+		if prev == nil {
+			writeBufferLenFn.Store(nil)
+		} else {
+			writeBufferLenFn.Store(prev)
+		}
+	})
+
+	// Before installation the gauge reports 0.
+	writeBufferLenFn.Store(nil)
+	assert.Equal(t, 0.0, prometheustestutil.ToFloat64(writeBufferDepth))
+
+	// After installation the gauge reflects the closure's return value live.
+	depth := 0
+	setWriteBufferLenSource(func() int { return depth })
+
+	depth = 3
+	assert.Equal(t, 3.0, prometheustestutil.ToFloat64(writeBufferDepth))
+
+	depth = 0
+	assert.Equal(t, 0.0, prometheustestutil.ToFloat64(writeBufferDepth))
+
+	// A second call replaces the source.
+	setWriteBufferLenSource(func() int { return 12 })
+	assert.Equal(t, 12.0, prometheustestutil.ToFloat64(writeBufferDepth))
+}

--- a/internal/flowcontrol/writebuffer.go
+++ b/internal/flowcontrol/writebuffer.go
@@ -35,7 +35,7 @@ type ResourceSliceWriteBuffer struct {
 	mut           sync.Mutex
 	state         map[types.NamespacedName][]*resourceSliceStatusUpdate
 	insertionTime map[types.NamespacedName]time.Time
-	queue         workqueue.RateLimitingInterface
+	queue         workqueue.TypedRateLimitingInterface[types.NamespacedName]
 }
 
 func NewResourceSliceWriteBufferForManager(mgr ctrl.Manager) *ResourceSliceWriteBuffer {
@@ -45,15 +45,17 @@ func NewResourceSliceWriteBufferForManager(mgr ctrl.Manager) *ResourceSliceWrite
 }
 
 func NewResourceSliceWriteBuffer(cli client.Client) *ResourceSliceWriteBuffer {
+	q := workqueue.NewTypedRateLimitingQueueWithConfig(
+		workqueue.NewTypedItemExponentialFailureRateLimiter[types.NamespacedName](time.Millisecond*100, 8*time.Second),
+		workqueue.TypedRateLimitingQueueConfig[types.NamespacedName]{
+			Name: "writeBuffer",
+		})
+	setWriteBufferLenSource(q.Len)
 	return &ResourceSliceWriteBuffer{
 		client:        cli,
 		state:         make(map[types.NamespacedName][]*resourceSliceStatusUpdate),
 		insertionTime: make(map[types.NamespacedName]time.Time),
-		queue: workqueue.NewRateLimitingQueueWithConfig(
-			workqueue.NewItemExponentialFailureRateLimiter(time.Millisecond*100, 8*time.Second),
-			workqueue.RateLimitingQueueConfig{
-				Name: "writeBuffer",
-			}),
+		queue:         q,
 	}
 }
 
@@ -95,17 +97,16 @@ func (w *ResourceSliceWriteBuffer) Start(ctx context.Context) error {
 }
 
 func (w *ResourceSliceWriteBuffer) processQueueItem(ctx context.Context) bool {
-	item, shutdown := w.queue.Get()
+	sliceNSN, shutdown := w.queue.Get()
 	if shutdown {
 		return false
 	}
-	defer w.queue.Done(item)
-	sliceNSN := item.(types.NamespacedName)
+	defer w.queue.Done(sliceNSN)
 
 	logger := logr.FromContextOrDiscard(ctx).WithValues("resourceSliceName", sliceNSN.Name, "resourceSliceNamespace", sliceNSN.Namespace, "controller", "writeBuffer")
 	ctx = logr.NewContext(ctx, logger)
 
-	logger.Info("processing write buffer queue item", "requeues", w.queue.NumRequeues(item))
+	logger.Info("processing write buffer queue item", "requeues", w.queue.NumRequeues(sliceNSN))
 	w.mut.Lock()
 	insertionTime := w.insertionTime[sliceNSN]
 	updates := w.state[sliceNSN]
@@ -125,7 +126,7 @@ func (w *ResourceSliceWriteBuffer) processQueueItem(ctx context.Context) bool {
 	// So the first write is fast, but a steady stream of writes will be throttled exponentially.
 	if len(updates) == 0 {
 		logger.Info("no updates to process, forgetting rate limit")
-		w.queue.Forget(item)
+		w.queue.Forget(sliceNSN)
 		w.mut.Lock()
 		delete(w.insertionTime, sliceNSN)
 		w.mut.Unlock()
@@ -134,7 +135,7 @@ func (w *ResourceSliceWriteBuffer) processQueueItem(ctx context.Context) bool {
 
 	if w.updateSlice(ctx, insertionTime, sliceNSN, updates) {
 		logger.Info("successfully updated resource slice, re-queueing to process remaining updates")
-		w.queue.AddRateLimited(item)
+		w.queue.AddRateLimited(sliceNSN)
 		return true
 	}
 
@@ -143,7 +144,7 @@ func (w *ResourceSliceWriteBuffer) processQueueItem(ctx context.Context) bool {
 	w.mut.Lock()
 	w.state[sliceNSN] = append(updates, w.state[sliceNSN]...)
 	w.mut.Unlock()
-	w.queue.AddRateLimited(item)
+	w.queue.AddRateLimited(sliceNSN)
 
 	logger.Info("re-queued resource slice with rate limiting")
 	return true
@@ -159,6 +160,7 @@ func (w *ResourceSliceWriteBuffer) updateSlice(ctx context.Context, insertionTim
 	err := w.client.Get(ctx, client.ObjectKeyFromObject(slice), slice)
 	if client.IgnoreNotFound(err) != nil {
 		logger.Error(err, "unable to get resource slice")
+		writeBufferStatusUpdateErrors.WithLabelValues("get").Inc()
 		return false
 	}
 
@@ -172,6 +174,7 @@ func (w *ResourceSliceWriteBuffer) updateSlice(ctx context.Context, insertionTim
 	patchJson, err := json.Marshal(&patches)
 	if err != nil {
 		logger.Error(err, "unable to encode patch")
+		writeBufferStatusUpdateErrors.WithLabelValues("marshal").Inc()
 		return false
 	}
 	err = w.client.Status().Patch(ctx, slice, client.RawPatch(types.JSONPatchType, patchJson))
@@ -181,6 +184,7 @@ func (w *ResourceSliceWriteBuffer) updateSlice(ctx context.Context, insertionTim
 	}
 	if err != nil {
 		logger.Error(err, "unable to update resource slice")
+		writeBufferStatusUpdateErrors.WithLabelValues("patch").Inc()
 		return false
 	}
 


### PR DESCRIPTION
Add observability metrics for Eno synthesis and reconciliation

Implements the gaps documented in docs/observability-gaps.md.

New metrics:
- eno-controller:
  - eno_synthesis_result_total{synthesizer,result}
  - eno_synthesis_duration_seconds{synthesizer,result}
  - eno_composition_synthesis_wait_seconds
- eno-reconciler:
  - eno_reconciliation_workqueue_depth
  - eno_write_buffer_depth
  - eno_write_buffer_status_update_errors_total{op}

Bug fix:
- eno_reconciliation_duration_seconds was observing milliseconds into
  second-named buckets, sending 100% of samples to +Inf. Fixed in place
  since existing data was already unusable.

Sample Metrics now:
eno_reconciliation_actions_total{action="apply"} 463
eno_reconciliation_actions_total{action="create"} 3
eno_reconciliation_actions_total{action="delete"} 24
eno_reconciliation_duration_seconds_bucket{le="0.05"} 4516
eno_reconciliation_duration_seconds_bucket{le="0.1"} 4762
eno_reconciliation_duration_seconds_bucket{le="0.25"} 4837
eno_reconciliation_duration_seconds_bucket{le="0.5"} 4844
eno_reconciliation_duration_seconds_bucket{le="1"} 4846
eno_reconciliation_duration_seconds_bucket{le="2"} 4846
eno_reconciliation_duration_seconds_bucket{le="5"} 4846
eno_reconciliation_duration_seconds_bucket{le="10"} 4846
eno_reconciliation_duration_seconds_bucket{le="30"} 4846
eno_reconciliation_duration_seconds_bucket{le="60"} 4846
eno_reconciliation_duration_seconds_bucket{le="120"} 4846
eno_reconciliation_duration_seconds_bucket{le="300"} 4846
eno_reconciliation_duration_seconds_bucket{le="+Inf"} 4846
eno_reconciliation_duration_seconds_sum 98.15231790400016
eno_reconciliation_duration_seconds_count 4846
eno_reconciliation_controller_max_concurrent_reconciles 6
eno_reconciliation_controller_workqueue_depth 0
eno_reconciliations_in_flight 0