### PR TITLE
[eno] Force Eno Ownership Transfer

### DIFF
--- a/internal/controllers/reconciliation/controller.go
+++ b/internal/controllers/reconciliation/controller.go
@@ -2,6 +2,7 @@ package reconciliation
 
 import (
 	"context"
+	"encoding/json"
 	goerrors "errors"
 	"fmt"
 	"strings"
@@ -315,29 +316,44 @@ func (c *Controller) reconcileSnapshot(ctx context.Context, comp *apiv1.Composit
 
 	// Dry-run the update to see if it's needed
 	if !c.disableSSA {
-		// Before the dry-run, normalize conflicting field managers to "eno" to prevent SSA validation errors
-		// caused by multiple managers owning overlapping fields. When managers are renamed to "eno", the
-		// subsequent SSA Apply will treat eno as the sole owner and automatically merge the managedFields
-		// entries into a single consolidated entry for eno.
-		if current != nil && len(c.migratingFieldManagers) > 0 {
-			wasModified, err := resource.NormalizeConflictingManagers(ctx, current, c.migratingFieldManagers, c.migratingFields)
+		// One-shot migration of managedFields ownership from configured legacy
+		// managers into eno's Apply entry, scoped to the configured field
+		// prefixes. NormalizeConflictingManagers returns modified=true only
+		// while a legacy manager still owns an allowed field, so subsequent
+		// reconciles short-circuit once ownership is transferred.
+		if current != nil && len(c.migratingFieldManagers) > 0 && len(c.migratingFields) > 0 {
+			normalized := current.DeepCopy()
+			modified, err := resource.NormalizeConflictingManagers(ctx, normalized, c.migratingFieldManagers, c.migratingFields)
 			if err != nil {
-				return false, fmt.Errorf("normalize conflicting manager failed: %w", err)
+				return false, fmt.Errorf("computing managedFields migration: %w", err)
 			}
-			if wasModified {
-				logger.Info("Normalized conflicting managers to eno")
-				err = c.upstreamClient.Update(ctx, current, client.FieldOwner("eno"))
+			if modified {
+				desiredMF, _ := json.Marshal(normalized.GetManagedFields())
+				beforeMF, _ := json.Marshal(current.GetManagedFields())
+				patch, err := json.Marshal([]map[string]any{
+					{"op": "replace", "path": "/metadata/managedFields", "value": normalized.GetManagedFields()},
+					// Optimistic lock: rejected with 409 if another writer raced us.
+					{"op": "replace", "path": "/metadata/resourceVersion", "value": current.GetResourceVersion()},
+				})
 				if err != nil {
-					return false, fmt.Errorf("normalizing managedFields failed: %w", err)
+					return false, fmt.Errorf("marshalling managedFields migration patch: %w", err)
 				}
-				// refetch the current before apply dry-run
+				logger.Info("migrating managedFields ownership to eno",
+					"managers", c.migratingFieldManagers,
+					"fields", c.migratingFields,
+					"beforeManagedFields", string(beforeMF),
+					"desiredManagedFields", string(desiredMF))
+				if err := c.upstreamClient.Patch(ctx, current.DeepCopy(), client.RawPatch(types.JSONPatchType, patch)); err != nil {
+					return false, fmt.Errorf("applying managedFields migration patch failed: %w", err)
+				}
 				current, err = c.getCurrent(ctx, res.Resource)
 				if err != nil {
-					logger.Error(err, "failed to get current resource after eno ownership migration")
-					return false, fmt.Errorf("re-fetching after normalizing manager failed: %w", err)
+					logger.Error(err, "failed to get current resource after managedFields migration")
+					return false, fmt.Errorf("re-fetching after managedFields migration failed: %w", err)
 				}
-
-				logger.Info("Successfully normalized field managers to eno")
+				afterMF, _ := json.Marshal(current.GetManagedFields())
+				logger.Info("successfully migrated managedFields ownership to eno",
+					"afterManagedFields", string(afterMF))
 			}
 		}
 		dryRun, err := c.update(ctx, comp, prev, res, current, true)

--- a/internal/controllers/reconciliation/controller.go
+++ b/internal/controllers/reconciliation/controller.go
@@ -328,8 +328,6 @@ func (c *Controller) reconcileSnapshot(ctx context.Context, comp *apiv1.Composit
 				return false, fmt.Errorf("computing managedFields migration: %w", err)
 			}
 			if modified {
-				desiredMF, _ := json.Marshal(normalized.GetManagedFields())
-				beforeMF, _ := json.Marshal(current.GetManagedFields())
 				patch, err := json.Marshal([]map[string]any{
 					{"op": "replace", "path": "/metadata/managedFields", "value": normalized.GetManagedFields()},
 					// Optimistic lock: rejected with 409 if another writer raced us.
@@ -340,9 +338,7 @@ func (c *Controller) reconcileSnapshot(ctx context.Context, comp *apiv1.Composit
 				}
 				logger.Info("migrating managedFields ownership to eno",
 					"managers", c.migratingFieldManagers,
-					"fields", c.migratingFields,
-					"beforeManagedFields", string(beforeMF),
-					"desiredManagedFields", string(desiredMF))
+					"fields", c.migratingFields)
 				if err := c.upstreamClient.Patch(ctx, current.DeepCopy(), client.RawPatch(types.JSONPatchType, patch)); err != nil {
 					return false, fmt.Errorf("applying managedFields migration patch failed: %w", err)
 				}
@@ -351,9 +347,7 @@ func (c *Controller) reconcileSnapshot(ctx context.Context, comp *apiv1.Composit
 					logger.Error(err, "failed to get current resource after managedFields migration")
 					return false, fmt.Errorf("re-fetching after managedFields migration failed: %w", err)
 				}
-				afterMF, _ := json.Marshal(current.GetManagedFields())
-				logger.Info("successfully migrated managedFields ownership to eno",
-					"afterManagedFields", string(afterMF))
+				logger.Info("successfully migrated managedFields ownership to eno")
 			}
 		}
 		dryRun, err := c.update(ctx, comp, prev, res, current, true)

--- a/internal/resource/fieldmanager.go
+++ b/internal/resource/fieldmanager.go
@@ -340,7 +340,7 @@ func createMergedEnoEntry(mergedSet *fieldpath.Set, timestamp *metav1.Time, mana
 	}
 
 	// Find an existing entry to use as a template for apiVersion and fieldsType.
-	// Prefer an existing eno Apply entry. Otherwise borrow from any non-status
+	// Prefer an existing eno Apply entry. Otherwise borrow from any non-subresource
 	// entry (all entries describe the same GVK at the main resource scope).
 	// Without a non-empty apiVersion the apiserver silently drops the entry
 	// during managedFields normalization, so the migration becomes a no-op.
@@ -370,6 +370,9 @@ func createMergedEnoEntry(mergedSet *fieldpath.Set, timestamp *metav1.Time, mana
 				break
 			}
 		}
+	}
+	if apiVersion == "" {
+		return metav1.ManagedFieldsEntry{}, fmt.Errorf("cannot synthesize eno managedFields entry: no source entry with non-empty APIVersion")
 	}
 	if fieldsType == "" {
 		fieldsType = "FieldsV1"

--- a/internal/resource/fieldmanager.go
+++ b/internal/resource/fieldmanager.go
@@ -339,14 +339,36 @@ func createMergedEnoEntry(mergedSet *fieldpath.Set, timestamp *metav1.Time, mana
 		return metav1.ManagedFieldsEntry{}, fmt.Errorf("failed to serialize merged eno fields: %w", err)
 	}
 
-	// Find an existing eno entry to use as a template for apiVersion and fieldsType
+	// Find an existing entry to use as a template for apiVersion and fieldsType.
+	// Prefer an existing eno Apply entry. Otherwise borrow from any non-status
+	// entry (all entries describe the same GVK at the main resource scope).
+	// Without a non-empty apiVersion the apiserver silently drops the entry
+	// during managedFields normalization, so the migration becomes a no-op.
 	var apiVersion string
 	var fieldsType string
 	for i := range managedFields {
-		if managedFields[i].Manager == enoManager {
+		if managedFields[i].Manager == enoManager && managedFields[i].APIVersion != "" {
 			apiVersion = managedFields[i].APIVersion
 			fieldsType = managedFields[i].FieldsType
 			break
+		}
+	}
+	if apiVersion == "" {
+		for i := range managedFields {
+			if managedFields[i].APIVersion != "" && managedFields[i].Subresource == "" {
+				apiVersion = managedFields[i].APIVersion
+				fieldsType = managedFields[i].FieldsType
+				break
+			}
+		}
+	}
+	if apiVersion == "" {
+		for i := range managedFields {
+			if managedFields[i].APIVersion != "" {
+				apiVersion = managedFields[i].APIVersion
+				fieldsType = managedFields[i].FieldsType
+				break
+			}
 		}
 	}
 	if fieldsType == "" {

--- a/internal/resource/fieldmanager_test.go
+++ b/internal/resource/fieldmanager_test.go
@@ -1358,3 +1358,131 @@ func TestNormalizeConflictingManagers_CustomMigratingFields(t *testing.T) {
 		})
 	}
 }
+
+// TestCreateMergedEnoEntry_APIVersionFallback covers the three-tier fallback
+// that prevents the apiserver from silently dropping eno's managedFields entry
+// when no prior eno Apply entry exists (k8s.io/apimachinery's DecodeManagedFields
+// hard-rejects empty APIVersion and falls back to live managedFields, making the
+// migration a no-op).
+func TestCreateMergedEnoEntry_APIVersionFallback(t *testing.T) {
+	mergedSet := &fieldpath.Set{}
+	mergedSet.Insert(fieldpath.MakePathOrDie("spec", "replicas"))
+
+	tests := []struct {
+		name               string
+		entries            []metav1.ManagedFieldsEntry
+		expectedAPIVersion string
+		expectedFieldsType string
+	}{
+		{
+			name: "prefer existing eno Apply entry's apiVersion",
+			entries: []metav1.ManagedFieldsEntry{
+				{Manager: "helm-controller", APIVersion: "apps/v1beta1", FieldsType: "FieldsV1"},
+				{Manager: "eno", Operation: metav1.ManagedFieldsOperationApply, APIVersion: "apps/v1", FieldsType: "FieldsV1"},
+				{Manager: "kubectl", APIVersion: "apps/v1beta2", FieldsType: "FieldsV1"},
+			},
+			expectedAPIVersion: "apps/v1",
+			expectedFieldsType: "FieldsV1",
+		},
+		{
+			name: "fall back to any non-subresource entry when no eno entry exists",
+			entries: []metav1.ManagedFieldsEntry{
+				{Manager: "kube-controller-manager", APIVersion: "apps/v1", Subresource: "status", FieldsType: "FieldsV1"},
+				{Manager: "helm-controller", APIVersion: "apps/v1", FieldsType: "FieldsV1"},
+			},
+			expectedAPIVersion: "apps/v1",
+			expectedFieldsType: "FieldsV1",
+		},
+		{
+			name: "fall back to subresource entry when nothing else is available",
+			entries: []metav1.ManagedFieldsEntry{
+				{Manager: "kube-controller-manager", APIVersion: "apps/v1", Subresource: "status", FieldsType: "FieldsV1"},
+			},
+			expectedAPIVersion: "apps/v1",
+			expectedFieldsType: "FieldsV1",
+		},
+		{
+			name: "default fieldsType to FieldsV1 when blank on source entry",
+			entries: []metav1.ManagedFieldsEntry{
+				{Manager: "helm-controller", APIVersion: "rbac.authorization.k8s.io/v1"},
+			},
+			expectedAPIVersion: "rbac.authorization.k8s.io/v1",
+			expectedFieldsType: "FieldsV1",
+		},
+		{
+			name: "skip entries with empty apiVersion when choosing template",
+			entries: []metav1.ManagedFieldsEntry{
+				{Manager: "broken-manager", APIVersion: "", FieldsType: "FieldsV1"},
+				{Manager: "helm-controller", APIVersion: "v1", FieldsType: "FieldsV1"},
+			},
+			expectedAPIVersion: "v1",
+			expectedFieldsType: "FieldsV1",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			entry, err := createMergedEnoEntry(mergedSet, nil, tc.entries)
+			require.NoError(t, err)
+
+			assert.Equal(t, "eno", entry.Manager)
+			assert.Equal(t, metav1.ManagedFieldsOperationApply, entry.Operation)
+			assert.Equal(t, tc.expectedAPIVersion, entry.APIVersion,
+				"empty APIVersion makes apimachinery silently drop the entry during managedFields normalization")
+			assert.Equal(t, tc.expectedFieldsType, entry.FieldsType)
+			require.NotNil(t, entry.FieldsV1)
+			assert.NotEmpty(t, entry.FieldsV1.Raw)
+		})
+	}
+}
+
+// TestNormalizeConflictingManagers_PreservesAPIVersionFromLegacyManager is the
+// end-to-end regression test for the silent-drop bug. The setup mirrors the
+// hubble-relay/hubble-peer case from a live cluster: helm-controller owned
+// spec on an apps/v1 Deployment, no eno Apply entry existed yet, so the eno
+// entry the controller emitted had to inherit apps/v1 from helm-controller.
+// Previously this produced an entry with APIVersion="" that apimachinery
+// silently dropped, making the migration patch a no-op.
+func TestNormalizeConflictingManagers_PreservesAPIVersionFromLegacyManager(t *testing.T) {
+	obj := &unstructured.Unstructured{}
+	obj.SetManagedFields([]metav1.ManagedFieldsEntry{
+		{
+			Manager:    "helm-controller",
+			Operation:  metav1.ManagedFieldsOperationUpdate,
+			APIVersion: "apps/v1",
+			FieldsType: "FieldsV1",
+			FieldsV1:   &metav1.FieldsV1{Raw: []byte(`{"f:spec":{"f:replicas":{},"f:template":{"f:spec":{"f:containers":{}}}}}`)},
+		},
+		{
+			Manager:    "kube-controller-manager",
+			Operation:  metav1.ManagedFieldsOperationUpdate,
+			APIVersion: "apps/v1",
+			Subresource: "status",
+			FieldsType: "FieldsV1",
+			FieldsV1:   &metav1.FieldsV1{Raw: []byte(`{"f:status":{"f:replicas":{}}}`)},
+		},
+	})
+
+	modified, err := NormalizeConflictingManagers(
+		context.Background(),
+		obj,
+		[]string{"helm-controller"},
+		[]string{"spec", "data", "stringData", "binaryData", "metadata.labels", "metadata.annotations"},
+	)
+	require.NoError(t, err)
+	require.True(t, modified, "expected migration to fire when helm-controller owns f:spec")
+
+	var enoEntry *metav1.ManagedFieldsEntry
+	for i, entry := range obj.GetManagedFields() {
+		if entry.Manager == "eno" && entry.Operation == metav1.ManagedFieldsOperationApply {
+			enoEntry = &obj.GetManagedFields()[i]
+			break
+		}
+	}
+	require.NotNil(t, enoEntry, "expected migration to produce an eno Apply entry")
+	assert.Equal(t, "apps/v1", enoEntry.APIVersion,
+		"empty APIVersion makes apimachinery silently drop the entry during managedFields normalization, turning the migration into a no-op")
+	assert.Equal(t, "FieldsV1", enoEntry.FieldsType)
+	require.NotNil(t, enoEntry.FieldsV1)
+	assert.NotEmpty(t, enoEntry.FieldsV1.Raw)
+}

--- a/internal/resource/fieldmanager_test.go
+++ b/internal/resource/fieldmanager_test.go
@@ -285,6 +285,21 @@ func makeFields(t *testing.T, manager string, fields []string) metav1.ManagedFie
 	return entry
 }
 
+// withDefaultAPIVersion returns a copy of the entries with APIVersion="v1"
+// filled in where missing. Real managedFields entries from the apiserver
+// always have a non-empty APIVersion; defaulting here keeps test fixtures
+// concise without relying on the now-rejected empty-APIVersion fallback.
+func withDefaultAPIVersion(entries []metav1.ManagedFieldsEntry) []metav1.ManagedFieldsEntry {
+	out := make([]metav1.ManagedFieldsEntry, len(entries))
+	copy(out, entries)
+	for i := range out {
+		if out[i].APIVersion == "" {
+			out[i].APIVersion = "v1"
+		}
+	}
+	return out
+}
+
 func parseFieldEntries(entries []metav1.ManagedFieldsEntry) []*fieldpath.Set {
 	sets := make([]*fieldpath.Set, len(entries))
 	for i, entry := range entries {
@@ -610,7 +625,7 @@ func TestNormalizeConflictingManagers(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			obj := &unstructured.Unstructured{}
-			obj.SetManagedFields(tc.managedFields)
+			obj.SetManagedFields(withDefaultAPIVersion(tc.managedFields))
 
 			modified, err := NormalizeConflictingManagers(context.Background(), obj, tc.migratingManagers, []string{"spec", "data", "stringData", "binaryData", "metadata.labels", "metadata.annotations"})
 
@@ -826,7 +841,7 @@ func TestNormalizeConflictingManagers_FieldMerging(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			obj := &unstructured.Unstructured{}
-			obj.SetManagedFields(tc.managedFields)
+			obj.SetManagedFields(withDefaultAPIVersion(tc.managedFields))
 
 			modified, err := NormalizeConflictingManagers(context.Background(), obj, tc.migratingManagers, []string{"spec", "data", "stringData", "binaryData", "metadata.labels", "metadata.annotations"})
 
@@ -946,7 +961,7 @@ func TestNormalizeConflictingManagers_AnnotationGating(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			obj := &unstructured.Unstructured{}
-			obj.SetManagedFields(tc.managedFields)
+			obj.SetManagedFields(withDefaultAPIVersion(tc.managedFields))
 			if tc.annotations != nil {
 				obj.SetAnnotations(tc.annotations)
 			}
@@ -1079,7 +1094,7 @@ func TestNormalizeConflictingManagers_FieldPathFiltering(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			obj := &unstructured.Unstructured{}
-			obj.SetManagedFields(tc.managedFields)
+			obj.SetManagedFields(withDefaultAPIVersion(tc.managedFields))
 
 			modified, err := NormalizeConflictingManagers(context.Background(), obj, tc.migratingManagers, []string{"spec", "data", "stringData", "binaryData", "metadata.labels", "metadata.annotations"})
 
@@ -1280,7 +1295,7 @@ func TestNormalizeConflictingManagers_CustomMigratingFields(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			obj := &unstructured.Unstructured{}
-			obj.SetManagedFields(tc.managedFields)
+			obj.SetManagedFields(withDefaultAPIVersion(tc.managedFields))
 
 			modified, err := NormalizeConflictingManagers(context.Background(), obj, tc.migratingManagers, tc.migratingFields)
 
@@ -1436,6 +1451,39 @@ func TestCreateMergedEnoEntry_APIVersionFallback(t *testing.T) {
 	}
 }
 
+// TestCreateMergedEnoEntry_NoUsableAPIVersion ensures the function refuses to
+// synthesize an eno entry rather than silently producing one with APIVersion=""
+// (which apimachinery would drop during managedFields decode).
+func TestCreateMergedEnoEntry_NoUsableAPIVersion(t *testing.T) {
+	mergedSet := &fieldpath.Set{}
+	mergedSet.Insert(fieldpath.MakePathOrDie("spec", "replicas"))
+
+	tests := []struct {
+		name    string
+		entries []metav1.ManagedFieldsEntry
+	}{
+		{
+			name:    "no entries at all",
+			entries: nil,
+		},
+		{
+			name: "entries present but all have empty APIVersion",
+			entries: []metav1.ManagedFieldsEntry{
+				{Manager: "broken-a", APIVersion: "", FieldsType: "FieldsV1"},
+				{Manager: "broken-b", APIVersion: "", FieldsType: "FieldsV1"},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := createMergedEnoEntry(mergedSet, nil, tc.entries)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "no source entry with non-empty APIVersion")
+		})
+	}
+}
+
 // TestNormalizeConflictingManagers_PreservesAPIVersionFromLegacyManager is the
 // end-to-end regression test for the silent-drop bug. The setup mirrors the
 // hubble-relay/hubble-peer case from a live cluster: helm-controller owned
@@ -1454,12 +1502,12 @@ func TestNormalizeConflictingManagers_PreservesAPIVersionFromLegacyManager(t *te
 			FieldsV1:   &metav1.FieldsV1{Raw: []byte(`{"f:spec":{"f:replicas":{},"f:template":{"f:spec":{"f:containers":{}}}}}`)},
 		},
 		{
-			Manager:    "kube-controller-manager",
-			Operation:  metav1.ManagedFieldsOperationUpdate,
-			APIVersion: "apps/v1",
+			Manager:     "kube-controller-manager",
+			Operation:   metav1.ManagedFieldsOperationUpdate,
+			APIVersion:  "apps/v1",
 			Subresource: "status",
-			FieldsType: "FieldsV1",
-			FieldsV1:   &metav1.FieldsV1{Raw: []byte(`{"f:status":{"f:replicas":{}}}`)},
+			FieldsType:  "FieldsV1",
+			FieldsV1:    &metav1.FieldsV1{Raw: []byte(`{"f:status":{"f:replicas":{}}}`)},
 		},
 	})
 


### PR DESCRIPTION
Implements a one-shot migration that transfers `managedFields` ownership ofconfigured field-path prefixes from legacy field managers (e.g.`helm-controller`, `kubectl`) into a single consolidated eno Apply entry.Once ownership has been transferred, the normal SSA Apply path takes over with eno as the sole owner — no further migration occurs.