### PR TITLE
[eno] Bump Go toolchain to 1.25.11 to fix stdlib CVEs (#613)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/Azure/eno
 
 go 1.25.0
 
-toolchain go1.25.9
+toolchain go1.25.11
 
 require (
 	github.com/Azure/go-workflow v0.1.13


### PR DESCRIPTION
Rebuilds eno-reconciler and eno-controller against Go 1.25.11, clearing 11 stdlib CVEs (8 HIGH, 3 MEDIUM) flagged by Trivy.

HIGH: CVE-2026-33811, CVE-2026-33814, CVE-2026-39820, CVE-2026-39823, CVE-2026-39825, CVE-2026-39836, CVE-2026-42499, CVE-2026-42504 MEDIUM: CVE-2026-27145, CVE-2026-39826, CVE-2026-42507