### PR TITLE
[eno] Fast track cancellation for out of step synthesis pods

### DIFF
--- a/cmd/eno-controller/main.go
+++ b/cmd/eno-controller/main.go
@@ -150,7 +150,7 @@ func runController() error {
 		return fmt.Errorf("constructing synthesis scheduling controller: %w", err)
 	}
 
-	err = composition.NewController(mgr, podTimeout)
+	err = composition.NewController(mgr, podTimeout, synconf.PodNamespace)
 	if err != nil {
 		return fmt.Errorf("constructing composition controller: %w", err)
 	}

--- a/internal/controllers/composition/controller.go
+++ b/internal/controllers/composition/controller.go
@@ -191,7 +191,7 @@ func (c *compositionController) Reconcile(ctx context.Context, req ctrl.Request)
 		}
 
 		if terminal {
-			if grace := time.Until(pod.CreationTimestamp.Time.Add(podCompletionGracePeriod)); grace > 0 {
+			if grace := time.Until(podTerminationTime(pod).Add(podCompletionGracePeriod)); grace > 0 {
 				return ctrl.Result{RequeueAfter: grace}, nil
 			}
 
@@ -640,4 +640,22 @@ func (c *compositionController) terminalInFlightPod(ctx context.Context, comp *a
 		}
 	}
 	return nil, false, nil
+}
+
+// podTerminationTime returns the time the pod actually finished running: the
+// latest container termination timestamp. This is the correct anchor for the
+// completion grace period ("how long after the pod finished do we wait"). It
+// falls back to CreationTimestamp when no terminated state is recorded, which
+// shouldn't happen for a pod already observed in a terminal phase.
+func podTerminationTime(pod *corev1.Pod) time.Time {
+	var latest time.Time
+	for _, cs := range pod.Status.ContainerStatuses {
+		if term := cs.State.Terminated; term != nil && term.FinishedAt.Time.After(latest) {
+			latest = term.FinishedAt.Time
+		}
+	}
+	if latest.IsZero() {
+		return pod.CreationTimestamp.Time
+	}
+	return latest
 }

--- a/internal/controllers/composition/controller.go
+++ b/internal/controllers/composition/controller.go
@@ -183,7 +183,7 @@ func (c *compositionController) Reconcile(ctx context.Context, req ctrl.Request)
 	if syn := comp.Status.InFlightSynthesis; syn != nil && syn.Canceled == nil && syn.Initialized != nil {
 		// If the synthesizer pod already terminated because of various reasons in skipSynthesis, we
 		// don't want to wait for the full cancellation, we want to fail fast and cancel early
-		pod, terminal, err := c.terminalInFlightPod(ctx, comp)
+		pod, terminal, err := c.succeededInFlightPod(ctx, comp)
 		if err != nil {
 			logger.Error(err, "failed to check synthesis pod phase")
 			return ctrl.Result{}, err
@@ -615,7 +615,7 @@ func (c *compositionController) clearDependencyStatus(ctx context.Context, comp 
 	return ctrl.Result{}, nil
 }
 
-func (c *compositionController) terminalInFlightPod(ctx context.Context, comp *apiv1.Composition) (*corev1.Pod, bool, error) {
+func (c *compositionController) succeededInFlightPod(ctx context.Context, comp *apiv1.Composition) (*corev1.Pod, bool, error) {
 	syn := comp.Status.InFlightSynthesis
 	if syn == nil || syn.UUID == "" {
 		return nil, false, nil

--- a/internal/controllers/composition/controller.go
+++ b/internal/controllers/composition/controller.go
@@ -40,7 +40,6 @@ const (
 	NotReadyStatus                      = "NotReady"
 	ReconcilingStatus                   = "Reconciling"
 	LogSampleCap                        = 50
-	synthesisIDLabelKey                 = "eno.azure.io/synthesis-uuid"
 )
 
 // podCompletionGracePeriod is how long after a synthesizer pod is observed
@@ -625,7 +624,7 @@ func (c *compositionController) terminalInFlightPod(ctx context.Context, comp *a
 	var pods corev1.PodList
 	err := c.client.List(ctx, &pods,
 		client.InNamespace(c.synthesisPodNamespace),
-		client.MatchingLabels{synthesisIDLabelKey: syn.UUID})
+		client.MatchingLabels{manager.SynthesisIDLabelKey: syn.UUID})
 	if err != nil {
 		return nil, false, fmt.Errorf("error listing synthesizer pods: %w", err)
 	}
@@ -635,7 +634,7 @@ func (c *compositionController) terminalInFlightPod(ctx context.Context, comp *a
 		if pod.DeletionTimestamp != nil {
 			continue
 		}
-		if pod.Status.Phase == corev1.PodSucceeded || pod.Status.Phase == corev1.PodFailed {
+		if pod.Status.Phase == corev1.PodSucceeded {
 			return pod, true, nil
 		}
 	}

--- a/internal/controllers/composition/controller.go
+++ b/internal/controllers/composition/controller.go
@@ -10,6 +10,7 @@ import (
 	krmv1 "github.com/Azure/eno/pkg/krm/functions/api/v1"
 	"github.com/go-logr/logr"
 	"github.com/google/uuid"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -39,17 +40,32 @@ const (
 	NotReadyStatus                      = "NotReady"
 	ReconcilingStatus                   = "Reconciling"
 	LogSampleCap                        = 50
+	synthesisIDLabelKey                 = "eno.azure.io/synthesis-uuid"
 )
 
+// podCompletionGracePeriod is how long after a synthesizer pod is observed
+// terminal we wait before treating its in-flight synthesis as abandoned, giving
+// a late-but-successful executor status write time to propagate. It is a var so
+// tests can shorten it.
+var podCompletionGracePeriod = 5 * time.Second
+
+// inFlightPollInterval bounds how often the composition controller re-checks an
+// in-flight synthesis's pod phase. It lets the fast-cancel path observe a
+// terminal pod promptly without watching Pods, while podTimeout remains the
+// upper bound for genuinely hung pods. It is a var so tests can shorten it.
+var inFlightPollInterval = 5 * time.Second
+
 type compositionController struct {
-	client     client.Client
-	podTimeout time.Duration
+	client                client.Client
+	podTimeout            time.Duration
+	synthesisPodNamespace string
 }
 
-func NewController(mgr ctrl.Manager, podTimeout time.Duration) error {
+func NewController(mgr ctrl.Manager, podTimeout time.Duration, synthesisPodNamespace string) error {
 	c := &compositionController{
-		client:     mgr.GetClient(),
-		podTimeout: podTimeout,
+		client:                mgr.GetClient(),
+		podTimeout:            podTimeout,
+		synthesisPodNamespace: synthesisPodNamespace,
 	}
 	depPredicate := predicate.TypedFuncs[*apiv1.Composition]{
 		CreateFunc: func(e event.TypedCreateEvent[*apiv1.Composition]) bool { return false },
@@ -166,9 +182,52 @@ func (c *compositionController) Reconcile(ctx context.Context, req ctrl.Request)
 
 	// Enforce the synthesis timeout period
 	if syn := comp.Status.InFlightSynthesis; syn != nil && syn.Canceled == nil && syn.Initialized != nil {
+		// If the synthesizer pod already terminated because of various reasons in skipSynthesis, we
+		// don't want to wait for the full cancellation, we want to fail fast and cancel early
+		pod, terminal, err := c.terminalInFlightPod(ctx, comp)
+		if err != nil {
+			logger.Error(err, "failed to check synthesis pod phase")
+			return ctrl.Result{}, err
+		}
+
+		if terminal {
+			if grace := time.Until(pod.CreationTimestamp.Time.Add(podCompletionGracePeriod)); grace > 0 {
+				return ctrl.Result{RequeueAfter: grace}, nil
+			}
+
+			// A successful executor write bumps resourceVersion, so Status.Update() will conflict and we requeue. If the synthesis already advanced/cancelled do nothing
+			if comp.Status.InFlightSynthesis == nil || comp.Status.InFlightSynthesis.UUID != syn.UUID ||
+				comp.Status.InFlightSynthesis.Canceled != nil {
+				return ctrl.Result{}, nil
+			}
+
+			comp.Status.InFlightSynthesis.Canceled = ptr.To(metav1.Now())
+			if err := c.client.Status().Update(ctx, comp); err != nil {
+				if errors.IsConflict(err) {
+					return ctrl.Result{Requeue: true}, nil
+				}
+				logger.Error(err, "failed to cancel synthesis after pod terminated without advancing status")
+				return ctrl.Result{}, err
+			}
+			logger.Info("synthesis pod terminated without advancing status - cancelling for retry",
+				"podPhase", string(pod.Status.Phase),
+				"podName", pod.Name,
+				"synthesisUUID", syn.UUID,
+				"compositionGeneration", comp.Generation,
+			)
+			return ctrl.Result{}, nil
+		}
+
+		// No terminal pod yet. Poll on a short interval (capped by the remaining
+		// timeout) so a terminal pod is noticed promptly without watching Pods,
+		// while podTimeout remains the backstop for genuinely hung pods.
 		delta := time.Until(syn.Initialized.Time.Add(c.podTimeout))
 		if delta > 0 {
-			return ctrl.Result{RequeueAfter: delta}, nil
+			next := inFlightPollInterval
+			if delta < next {
+				next = delta
+			}
+			return ctrl.Result{RequeueAfter: next}, nil
 		}
 		syn.Canceled = ptr.To(metav1.Now())
 		if err := c.client.Status().Update(ctx, comp); err != nil {
@@ -555,4 +614,30 @@ func (c *compositionController) clearDependencyStatus(ctx context.Context, comp 
 		return ctrl.Result{}, fmt.Errorf("clearing dependency failed: %w", err)
 	}
 	return ctrl.Result{}, nil
+}
+
+func (c *compositionController) terminalInFlightPod(ctx context.Context, comp *apiv1.Composition) (*corev1.Pod, bool, error) {
+	syn := comp.Status.InFlightSynthesis
+	if syn == nil || syn.UUID == "" {
+		return nil, false, nil
+	}
+
+	var pods corev1.PodList
+	err := c.client.List(ctx, &pods,
+		client.InNamespace(c.synthesisPodNamespace),
+		client.MatchingLabels{synthesisIDLabelKey: syn.UUID})
+	if err != nil {
+		return nil, false, fmt.Errorf("error listing synthesizer pods: %w", err)
+	}
+
+	for i := range pods.Items {
+		pod := &pods.Items[i]
+		if pod.DeletionTimestamp != nil {
+			continue
+		}
+		if pod.Status.Phase == corev1.PodSucceeded || pod.Status.Phase == corev1.PodFailed {
+			return pod, true, nil
+		}
+	}
+	return nil, false, nil
 }

--- a/internal/controllers/composition/fast_cancel_integration_test.go
+++ b/internal/controllers/composition/fast_cancel_integration_test.go
@@ -18,7 +18,7 @@ import (
 // newSynthPodForCache builds a synthesizer pod the way the pod lifecycle
 // controller does, including the manager label. That label is required for the
 // pod to be admitted into the controller's namespace-and-label-scoped cache, so
-// terminalInFlightPod (a cached List) can see it.
+// succeededInFlightPod (a cached List) can see it.
 func newSynthPodForCache(name, uuid string) *corev1.Pod {
 	pod := &corev1.Pod{}
 	pod.Name = name

--- a/internal/controllers/composition/fast_cancel_integration_test.go
+++ b/internal/controllers/composition/fast_cancel_integration_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	apiv1 "github.com/Azure/eno/api/v1"
+	"github.com/Azure/eno/internal/manager"
 	"github.com/Azure/eno/internal/testutil"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
@@ -13,6 +14,22 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
+
+// newSynthPodForCache builds a synthesizer pod the way the pod lifecycle
+// controller does, including the manager label. That label is required for the
+// pod to be admitted into the controller's namespace-and-label-scoped cache, so
+// terminalInFlightPod (a cached List) can see it.
+func newSynthPodForCache(name, uuid string) *corev1.Pod {
+	pod := &corev1.Pod{}
+	pod.Name = name
+	pod.Namespace = "default"
+	pod.Labels = map[string]string{
+		synthesisIDLabelKey:     uuid,
+		manager.ManagerLabelKey: manager.ManagerLabelValue,
+	}
+	pod.Spec.Containers = []corev1.Container{{Name: "synth", Image: "test-image"}}
+	return pod
+}
 
 // TestIntegrationFastCancelAbandonedSynthesis proves, against a real manager and
 // informer cache, that an in-flight synthesis whose pod has terminated without
@@ -37,6 +54,7 @@ func TestIntegrationFastCancelAbandonedSynthesis(t *testing.T) {
 	ctx := testutil.NewContext(t)
 	mgr := testutil.NewManager(t, testutil.WithPodNamespace("default"))
 	cli := mgr.GetClient()
+	apiReader := mgr.GetAPIReader() // uncached: avoids read-after-write cache lag
 
 	require.NoError(t, NewController(mgr.Manager, time.Hour, "default"))
 	mgr.Start(t)
@@ -57,7 +75,7 @@ func TestIntegrationFastCancelAbandonedSynthesis(t *testing.T) {
 
 	// Drive the composition into the dangling in-flight state.
 	require.NoError(t, retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		if err := cli.Get(ctx, client.ObjectKeyFromObject(comp), comp); err != nil {
+		if err := apiReader.Get(ctx, client.ObjectKeyFromObject(comp), comp); err != nil {
 			return err
 		}
 		comp.Status.InFlightSynthesis = &apiv1.Synthesis{
@@ -69,14 +87,10 @@ func TestIntegrationFastCancelAbandonedSynthesis(t *testing.T) {
 
 	// Create a terminal pod that never advanced the status (simulates the
 	// executor's skipSynthesis early return: exit 0, no status write).
-	pod := &corev1.Pod{}
-	pod.Name = "synthesis-abandoned"
-	pod.Namespace = "default"
-	pod.Labels = map[string]string{synthesisIDLabelKey: uuid}
-	pod.Spec.Containers = []corev1.Container{{Name: "synth", Image: "test-image"}}
+	pod := newSynthPodForCache("synthesis-abandoned", uuid)
 	require.NoError(t, cli.Create(ctx, pod))
 	require.NoError(t, retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		if err := cli.Get(ctx, client.ObjectKeyFromObject(pod), pod); err != nil {
+		if err := apiReader.Get(ctx, client.ObjectKeyFromObject(pod), pod); err != nil {
 			return err
 		}
 		pod.Status.Phase = corev1.PodSucceeded
@@ -86,7 +100,7 @@ func TestIntegrationFastCancelAbandonedSynthesis(t *testing.T) {
 	// The fast path must cancel the abandoned synthesis far sooner than the 1h
 	// podTimeout.
 	testutil.Eventually(t, func() bool {
-		if err := cli.Get(ctx, client.ObjectKeyFromObject(comp), comp); err != nil {
+		if err := apiReader.Get(ctx, client.ObjectKeyFromObject(comp), comp); err != nil {
 			return false
 		}
 		return comp.Status.InFlightSynthesis != nil && comp.Status.InFlightSynthesis.Canceled != nil
@@ -108,6 +122,7 @@ func TestIntegrationFastCancelLeavesSuccessAlone(t *testing.T) {
 	ctx := testutil.NewContext(t)
 	mgr := testutil.NewManager(t, testutil.WithPodNamespace("default"))
 	cli := mgr.GetClient()
+	apiReader := mgr.GetAPIReader()
 
 	require.NoError(t, NewController(mgr.Manager, time.Hour, "default"))
 	mgr.Start(t)
@@ -129,7 +144,7 @@ func TestIntegrationFastCancelLeavesSuccessAlone(t *testing.T) {
 	// Advanced/successful state: no in-flight synthesis, current synthesis matches
 	// the pod's UUID.
 	require.NoError(t, retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		if err := cli.Get(ctx, client.ObjectKeyFromObject(comp), comp); err != nil {
+		if err := apiReader.Get(ctx, client.ObjectKeyFromObject(comp), comp); err != nil {
 			return err
 		}
 		comp.Status.CurrentSynthesis = &apiv1.Synthesis{
@@ -141,14 +156,10 @@ func TestIntegrationFastCancelLeavesSuccessAlone(t *testing.T) {
 		return cli.Status().Update(ctx, comp)
 	}))
 
-	pod := &corev1.Pod{}
-	pod.Name = "synthesis-succeeded"
-	pod.Namespace = "default"
-	pod.Labels = map[string]string{synthesisIDLabelKey: uuid}
-	pod.Spec.Containers = []corev1.Container{{Name: "synth", Image: "test-image"}}
+	pod := newSynthPodForCache("synthesis-succeeded", uuid)
 	require.NoError(t, cli.Create(ctx, pod))
 	require.NoError(t, retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		if err := cli.Get(ctx, client.ObjectKeyFromObject(pod), pod); err != nil {
+		if err := apiReader.Get(ctx, client.ObjectKeyFromObject(pod), pod); err != nil {
 			return err
 		}
 		pod.Status.Phase = corev1.PodSucceeded
@@ -158,7 +169,7 @@ func TestIntegrationFastCancelLeavesSuccessAlone(t *testing.T) {
 	// Give the controller time to reconcile a few poll intervals, then assert the
 	// completed synthesis was never disturbed.
 	time.Sleep(time.Second)
-	require.NoError(t, cli.Get(ctx, client.ObjectKeyFromObject(comp), comp))
+	require.NoError(t, apiReader.Get(ctx, client.ObjectKeyFromObject(comp), comp))
 	require.Nil(t, comp.Status.InFlightSynthesis, "no in-flight synthesis should be created")
 	require.NotNil(t, comp.Status.CurrentSynthesis)
 	require.Equal(t, uuid, comp.Status.CurrentSynthesis.UUID)

--- a/internal/controllers/composition/fast_cancel_integration_test.go
+++ b/internal/controllers/composition/fast_cancel_integration_test.go
@@ -24,8 +24,8 @@ func newSynthPodForCache(name, uuid string) *corev1.Pod {
 	pod.Name = name
 	pod.Namespace = "default"
 	pod.Labels = map[string]string{
-		synthesisIDLabelKey:     uuid,
-		manager.ManagerLabelKey: manager.ManagerLabelValue,
+		manager.SynthesisIDLabelKey: uuid,
+		manager.ManagerLabelKey:     manager.ManagerLabelValue,
 	}
 	pod.Spec.Containers = []corev1.Container{{Name: "synth", Image: "test-image"}}
 	return pod

--- a/internal/controllers/composition/fast_cancel_integration_test.go
+++ b/internal/controllers/composition/fast_cancel_integration_test.go
@@ -1,0 +1,166 @@
+package composition
+
+import (
+	"testing"
+	"time"
+
+	apiv1 "github.com/Azure/eno/api/v1"
+	"github.com/Azure/eno/internal/testutil"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/util/retry"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// TestIntegrationFastCancelAbandonedSynthesis proves, against a real manager and
+// informer cache, that an in-flight synthesis whose pod has terminated without
+// advancing the status (the skipSynthesis early-return case) is cancelled
+// promptly by the fast path rather than waiting for podTimeout.
+//
+// It wires only the composition controller and drives the "terminal pod, status
+// never advanced" state directly, so the assertion isolates the fast-cancel
+// behavior. podTimeout is set to an hour, so the only thing that can set Canceled
+// within the test window is the fast path.
+func TestIntegrationFastCancelAbandonedSynthesis(t *testing.T) {
+	// Shrink the fast-path timers so the cancel is observable well within
+	// testutil.Eventually's window. Production defaults are unchanged.
+	origGrace, origPoll := podCompletionGracePeriod, inFlightPollInterval
+	podCompletionGracePeriod = 100 * time.Millisecond
+	inFlightPollInterval = 100 * time.Millisecond
+	t.Cleanup(func() {
+		podCompletionGracePeriod = origGrace
+		inFlightPollInterval = origPoll
+	})
+
+	ctx := testutil.NewContext(t)
+	mgr := testutil.NewManager(t, testutil.WithPodNamespace("default"))
+	cli := mgr.GetClient()
+
+	require.NoError(t, NewController(mgr.Manager, time.Hour, "default"))
+	mgr.Start(t)
+
+	syn := &apiv1.Synthesizer{}
+	syn.Name = "test-syn"
+	syn.Spec.Image = "test-image"
+	require.NoError(t, cli.Create(ctx, syn))
+
+	comp := &apiv1.Composition{}
+	comp.Name = "test-comp"
+	comp.Namespace = "default"
+	comp.Finalizers = []string{EnoCleanupFinalizer}
+	comp.Spec.Synthesizer.Name = syn.Name
+	require.NoError(t, cli.Create(ctx, comp))
+
+	const uuid = "abandoned-uuid"
+
+	// Drive the composition into the dangling in-flight state.
+	require.NoError(t, retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		if err := cli.Get(ctx, client.ObjectKeyFromObject(comp), comp); err != nil {
+			return err
+		}
+		comp.Status.InFlightSynthesis = &apiv1.Synthesis{
+			UUID:        uuid,
+			Initialized: ptr.To(metav1.Now()),
+		}
+		return cli.Status().Update(ctx, comp)
+	}))
+
+	// Create a terminal pod that never advanced the status (simulates the
+	// executor's skipSynthesis early return: exit 0, no status write).
+	pod := &corev1.Pod{}
+	pod.Name = "synthesis-abandoned"
+	pod.Namespace = "default"
+	pod.Labels = map[string]string{synthesisIDLabelKey: uuid}
+	pod.Spec.Containers = []corev1.Container{{Name: "synth", Image: "test-image"}}
+	require.NoError(t, cli.Create(ctx, pod))
+	require.NoError(t, retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		if err := cli.Get(ctx, client.ObjectKeyFromObject(pod), pod); err != nil {
+			return err
+		}
+		pod.Status.Phase = corev1.PodSucceeded
+		return cli.Status().Update(ctx, pod)
+	}))
+
+	// The fast path must cancel the abandoned synthesis far sooner than the 1h
+	// podTimeout.
+	testutil.Eventually(t, func() bool {
+		if err := cli.Get(ctx, client.ObjectKeyFromObject(comp), comp); err != nil {
+			return false
+		}
+		return comp.Status.InFlightSynthesis != nil && comp.Status.InFlightSynthesis.Canceled != nil
+	})
+}
+
+// TestIntegrationFastCancelLeavesSuccessAlone proves the inverse: when the
+// executor advanced the status (success swap to CurrentSynthesis) the fast path
+// must not cancel anything, even though the pod is terminal.
+func TestIntegrationFastCancelLeavesSuccessAlone(t *testing.T) {
+	origGrace, origPoll := podCompletionGracePeriod, inFlightPollInterval
+	podCompletionGracePeriod = 100 * time.Millisecond
+	inFlightPollInterval = 100 * time.Millisecond
+	t.Cleanup(func() {
+		podCompletionGracePeriod = origGrace
+		inFlightPollInterval = origPoll
+	})
+
+	ctx := testutil.NewContext(t)
+	mgr := testutil.NewManager(t, testutil.WithPodNamespace("default"))
+	cli := mgr.GetClient()
+
+	require.NoError(t, NewController(mgr.Manager, time.Hour, "default"))
+	mgr.Start(t)
+
+	syn := &apiv1.Synthesizer{}
+	syn.Name = "test-syn"
+	syn.Spec.Image = "test-image"
+	require.NoError(t, cli.Create(ctx, syn))
+
+	comp := &apiv1.Composition{}
+	comp.Name = "test-comp"
+	comp.Namespace = "default"
+	comp.Finalizers = []string{EnoCleanupFinalizer}
+	comp.Spec.Synthesizer.Name = syn.Name
+	require.NoError(t, cli.Create(ctx, comp))
+
+	const uuid = "succeeded-uuid"
+
+	// Advanced/successful state: no in-flight synthesis, current synthesis matches
+	// the pod's UUID.
+	require.NoError(t, retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		if err := cli.Get(ctx, client.ObjectKeyFromObject(comp), comp); err != nil {
+			return err
+		}
+		comp.Status.CurrentSynthesis = &apiv1.Synthesis{
+			UUID:        uuid,
+			Initialized: ptr.To(metav1.Now()),
+			Synthesized: ptr.To(metav1.Now()),
+		}
+		comp.Status.InFlightSynthesis = nil
+		return cli.Status().Update(ctx, comp)
+	}))
+
+	pod := &corev1.Pod{}
+	pod.Name = "synthesis-succeeded"
+	pod.Namespace = "default"
+	pod.Labels = map[string]string{synthesisIDLabelKey: uuid}
+	pod.Spec.Containers = []corev1.Container{{Name: "synth", Image: "test-image"}}
+	require.NoError(t, cli.Create(ctx, pod))
+	require.NoError(t, retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		if err := cli.Get(ctx, client.ObjectKeyFromObject(pod), pod); err != nil {
+			return err
+		}
+		pod.Status.Phase = corev1.PodSucceeded
+		return cli.Status().Update(ctx, pod)
+	}))
+
+	// Give the controller time to reconcile a few poll intervals, then assert the
+	// completed synthesis was never disturbed.
+	time.Sleep(time.Second)
+	require.NoError(t, cli.Get(ctx, client.ObjectKeyFromObject(comp), comp))
+	require.Nil(t, comp.Status.InFlightSynthesis, "no in-flight synthesis should be created")
+	require.NotNil(t, comp.Status.CurrentSynthesis)
+	require.Equal(t, uuid, comp.Status.CurrentSynthesis.UUID)
+	require.Nil(t, comp.Status.CurrentSynthesis.Canceled)
+}

--- a/internal/controllers/composition/fast_cancel_test.go
+++ b/internal/controllers/composition/fast_cancel_test.go
@@ -99,7 +99,7 @@ func pinFastCancelTimers(t *testing.T, grace, poll time.Duration) {
 	})
 }
 
-// --- terminalInFlightPod unit matrix ---
+// --- succeededInFlightPod unit matrix ---
 
 func TestTerminalInFlightPod(t *testing.T) {
 	const uuid = "uuid-1"
@@ -187,7 +187,7 @@ func TestTerminalInFlightPod(t *testing.T) {
 			comp := &apiv1.Composition{}
 			comp.Status.InFlightSynthesis = tc.inFlight
 
-			pod, terminal, err := c.terminalInFlightPod(ctx, comp)
+			pod, terminal, err := c.succeededInFlightPod(ctx, comp)
 			require.NoError(t, err)
 			assert.Equal(t, tc.wantTerminal, terminal)
 			if tc.wantTerminal {

--- a/internal/controllers/composition/fast_cancel_test.go
+++ b/internal/controllers/composition/fast_cancel_test.go
@@ -69,6 +69,19 @@ func newFastCancelController(cli client.Client) *compositionController {
 	}
 }
 
+// pinFastCancelTimers sets the package-level fast-path timers for the duration of
+// a test and restores them afterwards. Tests that assert grace/poll behavior use
+// this so they don't depend on the ambient (possibly integration-mutated) value.
+func pinFastCancelTimers(t *testing.T, grace, poll time.Duration) {
+	origGrace, origPoll := podCompletionGracePeriod, inFlightPollInterval
+	podCompletionGracePeriod = grace
+	inFlightPollInterval = poll
+	t.Cleanup(func() {
+		podCompletionGracePeriod = origGrace
+		inFlightPollInterval = origPoll
+	})
+}
+
 // --- terminalInFlightPod unit matrix ---
 
 func TestTerminalInFlightPod(t *testing.T) {
@@ -190,6 +203,7 @@ func TestFastCancelAbandonedSynthesis(t *testing.T) {
 // Case 2: a terminal pod still within the grace period requeues instead of
 // cancelling, giving a late successful status write time to propagate.
 func TestFastCancelWithinGraceRequeues(t *testing.T) {
+	pinFastCancelTimers(t, time.Minute, inFlightPollInterval) // grace must be long enough that a now-created pod is within it
 	ctx := testutil.NewContext(t)
 	comp := newInFlightComp("uuid-1", time.Now())
 	pod := newSynthPod("synthesis-1", "uuid-1", corev1.PodSucceeded, time.Now()) // created now -> within grace
@@ -322,6 +336,7 @@ func TestFastCancelConflictRequeues(t *testing.T) {
 // --- Functional progression: grace gate releases into a cancel ---
 
 func TestFastCancelGraceThenCancel(t *testing.T) {
+	pinFastCancelTimers(t, time.Minute, inFlightPollInterval) // grace must be long enough that a now-created pod is within it
 	ctx := testutil.NewContext(t)
 	comp := newInFlightComp("uuid-1", time.Now())
 	pod := newSynthPod("synthesis-1", "uuid-1", corev1.PodSucceeded, time.Now()) // within grace

--- a/internal/controllers/composition/fast_cancel_test.go
+++ b/internal/controllers/composition/fast_cancel_test.go
@@ -139,10 +139,14 @@ func TestTerminalInFlightPod(t *testing.T) {
 			wantTerminal: true,
 		},
 		{
+			// Under RestartPolicy: OnFailure a failed executor is restarted (pod stays
+			// Running); a Failed phase only happens on eviction/deadline, which the
+			// podTimeout backstop handles. Only a Succeeded pod (the skipSynthesis
+			// early-return) triggers fast-cancel.
 			name:         "pod failed",
 			inFlight:     &apiv1.Synthesis{UUID: uuid},
 			pods:         []client.Object{newSynthPod("p", uuid, corev1.PodFailed, time.Time{})},
-			wantTerminal: true,
+			wantTerminal: false,
 		},
 		{
 			name:     "terminal but being deleted",

--- a/internal/controllers/composition/fast_cancel_test.go
+++ b/internal/controllers/composition/fast_cancel_test.go
@@ -61,6 +61,22 @@ func newSynthPod(name, uuid string, phase corev1.PodPhase, created time.Time) *c
 	return pod
 }
 
+// newTerminatedSynthPod builds a Succeeded synthesizer pod whose container
+// terminated at finishedAt, so tests can exercise the termination-time grace
+// anchor independently of CreationTimestamp.
+func newTerminatedSynthPod(name, uuid string, created, finishedAt time.Time) *corev1.Pod {
+	pod := newSynthPod(name, uuid, corev1.PodSucceeded, created)
+	pod.Status.ContainerStatuses = []corev1.ContainerStatus{{
+		Name: "synth",
+		State: corev1.ContainerState{
+			Terminated: &corev1.ContainerStateTerminated{
+				FinishedAt: metav1.NewTime(finishedAt),
+			},
+		},
+	}}
+	return pod
+}
+
 func newFastCancelController(cli client.Client) *compositionController {
 	return &compositionController{
 		client:                cli,
@@ -218,6 +234,50 @@ func TestFastCancelWithinGraceRequeues(t *testing.T) {
 
 	require.NoError(t, cli.Get(ctx, client.ObjectKeyFromObject(comp), comp))
 	assert.Nil(t, comp.Status.InFlightSynthesis.Canceled, "should not cancel while within grace period")
+}
+
+// Case 2b: the grace window is measured from when the pod *terminated*, not when
+// it was created. A pod created long ago but finished just now must still be
+// within grace (the old creation-time anchor would have cancelled immediately).
+func TestFastCancelGraceUsesTerminationTime(t *testing.T) {
+	pinFastCancelTimers(t, time.Minute, inFlightPollInterval)
+	ctx := testutil.NewContext(t)
+	comp := newInFlightComp("uuid-1", time.Now())
+	pod := newTerminatedSynthPod("synthesis-1", "uuid-1", time.Now().Add(-time.Hour), time.Now()) // created long ago, finished now
+
+	cli := testutil.NewClient(t, comp, newTestSynth(), pod)
+	c := newFastCancelController(cli)
+
+	res, err := c.Reconcile(ctx, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(comp)})
+	require.NoError(t, err)
+	assert.Greater(t, res.RequeueAfter, time.Duration(0), "grace must be measured from termination, not creation")
+
+	require.NoError(t, cli.Get(ctx, client.ObjectKeyFromObject(comp), comp))
+	assert.Nil(t, comp.Status.InFlightSynthesis.Canceled, "should not cancel while within the post-termination grace window")
+}
+
+// TestPodTerminationTime covers the grace anchor helper directly.
+func TestPodTerminationTime(t *testing.T) {
+	created := time.Now().Add(-time.Hour)
+	finished := time.Now().Add(-time.Minute)
+
+	// No terminated state -> falls back to CreationTimestamp.
+	assert.WithinDuration(t, created,
+		podTerminationTime(newSynthPod("p", "u", corev1.PodSucceeded, created)), time.Second)
+
+	// Single terminated container -> uses its FinishedAt.
+	assert.WithinDuration(t, finished,
+		podTerminationTime(newTerminatedSynthPod("p", "u", created, finished)), time.Second)
+
+	// Multiple terminated containers -> uses the latest FinishedAt.
+	multi := newTerminatedSynthPod("p", "u", created, finished)
+	multi.Status.ContainerStatuses = append(multi.Status.ContainerStatuses, corev1.ContainerStatus{
+		Name: "c2",
+		State: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{
+			FinishedAt: metav1.NewTime(finished.Add(30 * time.Second)),
+		}},
+	})
+	assert.WithinDuration(t, finished.Add(30*time.Second), podTerminationTime(multi), time.Second)
 }
 
 // Case 3: when the synthesis has already advanced (InFlightSynthesis cleared by a

--- a/internal/controllers/composition/fast_cancel_test.go
+++ b/internal/controllers/composition/fast_cancel_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	apiv1 "github.com/Azure/eno/api/v1"
+	"github.com/Azure/eno/internal/manager"
 	"github.com/Azure/eno/internal/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -53,7 +54,7 @@ func newSynthPod(name, uuid string, phase corev1.PodPhase, created time.Time) *c
 	pod := &corev1.Pod{}
 	pod.Name = name
 	pod.Namespace = testPodNamespace
-	pod.Labels = map[string]string{synthesisIDLabelKey: uuid}
+	pod.Labels = map[string]string{manager.SynthesisIDLabelKey: uuid}
 	pod.Status.Phase = phase
 	if !created.IsZero() {
 		pod.CreationTimestamp = metav1.NewTime(created)

--- a/internal/controllers/composition/fast_cancel_test.go
+++ b/internal/controllers/composition/fast_cancel_test.go
@@ -1,0 +1,349 @@
+package composition
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	apiv1 "github.com/Azure/eno/api/v1"
+	"github.com/Azure/eno/internal/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+const testPodNamespace = "eno-system"
+
+// newInFlightComp builds a composition that is mid-synthesis: it has the cleanup
+// finalizer, a synthesizer reference, an in-flight synthesis with the given UUID
+// and Initialized time, and a pre-seeded "Synthesizing" simplified status so that
+// reconcileSimplifiedStatus is a no-op and Reconcile reaches the timeout block.
+func newInFlightComp(uuid string, initialized time.Time) *apiv1.Composition {
+	comp := &apiv1.Composition{}
+	comp.Name = "test-comp"
+	comp.Namespace = "default"
+	comp.Finalizers = []string{EnoCleanupFinalizer}
+	comp.Spec.Synthesizer.Name = "test-syn"
+	comp.Status.Simplified = &apiv1.SimplifiedStatus{Status: "Synthesizing"}
+	comp.Status.InFlightSynthesis = &apiv1.Synthesis{
+		UUID:        uuid,
+		Initialized: ptr.To(metav1.NewTime(initialized)),
+	}
+	return comp
+}
+
+func newTestSynth() *apiv1.Synthesizer {
+	syn := &apiv1.Synthesizer{}
+	syn.Name = "test-syn"
+	return syn
+}
+
+// newSynthPod builds a synthesizer pod labeled with the synthesis UUID. A zero
+// "created" time leaves CreationTimestamp unset (which reads as far in the past,
+// i.e. the grace period has elapsed).
+func newSynthPod(name, uuid string, phase corev1.PodPhase, created time.Time) *corev1.Pod {
+	pod := &corev1.Pod{}
+	pod.Name = name
+	pod.Namespace = testPodNamespace
+	pod.Labels = map[string]string{synthesisIDLabelKey: uuid}
+	pod.Status.Phase = phase
+	if !created.IsZero() {
+		pod.CreationTimestamp = metav1.NewTime(created)
+	}
+	return pod
+}
+
+func newFastCancelController(cli client.Client) *compositionController {
+	return &compositionController{
+		client:                cli,
+		podTimeout:            time.Minute,
+		synthesisPodNamespace: testPodNamespace,
+	}
+}
+
+// --- terminalInFlightPod unit matrix ---
+
+func TestTerminalInFlightPod(t *testing.T) {
+	const uuid = "uuid-1"
+
+	tests := []struct {
+		name         string
+		inFlight     *apiv1.Synthesis
+		pods         []client.Object
+		wantTerminal bool
+	}{
+		{
+			name:         "no in-flight synthesis",
+			inFlight:     nil,
+			wantTerminal: false,
+		},
+		{
+			name:         "empty uuid",
+			inFlight:     &apiv1.Synthesis{UUID: ""},
+			wantTerminal: false,
+		},
+		{
+			name:         "pod pending",
+			inFlight:     &apiv1.Synthesis{UUID: uuid},
+			pods:         []client.Object{newSynthPod("p", uuid, corev1.PodPending, time.Time{})},
+			wantTerminal: false,
+		},
+		{
+			name:         "pod running",
+			inFlight:     &apiv1.Synthesis{UUID: uuid},
+			pods:         []client.Object{newSynthPod("p", uuid, corev1.PodRunning, time.Time{})},
+			wantTerminal: false,
+		},
+		{
+			name:         "pod succeeded",
+			inFlight:     &apiv1.Synthesis{UUID: uuid},
+			pods:         []client.Object{newSynthPod("p", uuid, corev1.PodSucceeded, time.Time{})},
+			wantTerminal: true,
+		},
+		{
+			name:         "pod failed",
+			inFlight:     &apiv1.Synthesis{UUID: uuid},
+			pods:         []client.Object{newSynthPod("p", uuid, corev1.PodFailed, time.Time{})},
+			wantTerminal: true,
+		},
+		{
+			name:     "terminal but being deleted",
+			inFlight: &apiv1.Synthesis{UUID: uuid},
+			pods: []client.Object{func() client.Object {
+				p := newSynthPod("p", uuid, corev1.PodSucceeded, time.Time{})
+				now := metav1.Now()
+				p.DeletionTimestamp = &now
+				p.Finalizers = []string{"kubernetes"} // fake client requires a finalizer to retain a deleting object
+				return p
+			}()},
+			wantTerminal: false,
+		},
+		{
+			name:         "uuid mismatch",
+			inFlight:     &apiv1.Synthesis{UUID: uuid},
+			pods:         []client.Object{newSynthPod("p", "other-uuid", corev1.PodSucceeded, time.Time{})},
+			wantTerminal: false,
+		},
+		{
+			name:     "wrong namespace",
+			inFlight: &apiv1.Synthesis{UUID: uuid},
+			pods: []client.Object{func() client.Object {
+				p := newSynthPod("p", uuid, corev1.PodSucceeded, time.Time{})
+				p.Namespace = "somewhere-else"
+				return p
+			}()},
+			wantTerminal: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := testutil.NewContext(t)
+			cli := testutil.NewClient(t, tc.pods...)
+			c := newFastCancelController(cli)
+
+			comp := &apiv1.Composition{}
+			comp.Status.InFlightSynthesis = tc.inFlight
+
+			pod, terminal, err := c.terminalInFlightPod(ctx, comp)
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantTerminal, terminal)
+			if tc.wantTerminal {
+				assert.NotNil(t, pod)
+			} else {
+				assert.Nil(t, pod)
+			}
+		})
+	}
+}
+
+// --- Reconcile fast-cancel decision matrix ---
+
+// Case 1: abandoned synthesis (terminal pod, status never advanced, grace elapsed)
+// is cancelled immediately rather than waiting for podTimeout.
+func TestFastCancelAbandonedSynthesis(t *testing.T) {
+	ctx := testutil.NewContext(t)
+	comp := newInFlightComp("uuid-1", time.Now()) // initialized just now: well within podTimeout
+	pod := newSynthPod("synthesis-1", "uuid-1", corev1.PodSucceeded, time.Time{})
+
+	cli := testutil.NewClient(t, comp, newTestSynth(), pod)
+	c := newFastCancelController(cli)
+
+	res, err := c.Reconcile(ctx, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(comp)})
+	require.NoError(t, err)
+	assert.Zero(t, res.RequeueAfter)
+	assert.False(t, res.Requeue)
+
+	require.NoError(t, cli.Get(ctx, client.ObjectKeyFromObject(comp), comp))
+	require.NotNil(t, comp.Status.InFlightSynthesis)
+	assert.NotNil(t, comp.Status.InFlightSynthesis.Canceled, "abandoned synthesis should be cancelled immediately")
+}
+
+// Case 2: a terminal pod still within the grace period requeues instead of
+// cancelling, giving a late successful status write time to propagate.
+func TestFastCancelWithinGraceRequeues(t *testing.T) {
+	ctx := testutil.NewContext(t)
+	comp := newInFlightComp("uuid-1", time.Now())
+	pod := newSynthPod("synthesis-1", "uuid-1", corev1.PodSucceeded, time.Now()) // created now -> within grace
+
+	cli := testutil.NewClient(t, comp, newTestSynth(), pod)
+	c := newFastCancelController(cli)
+
+	res, err := c.Reconcile(ctx, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(comp)})
+	require.NoError(t, err)
+	assert.Greater(t, res.RequeueAfter, time.Duration(0))
+	assert.LessOrEqual(t, res.RequeueAfter, podCompletionGracePeriod)
+
+	require.NoError(t, cli.Get(ctx, client.ObjectKeyFromObject(comp), comp))
+	assert.Nil(t, comp.Status.InFlightSynthesis.Canceled, "should not cancel while within grace period")
+}
+
+// Case 3: when the synthesis has already advanced (InFlightSynthesis cleared by a
+// successful executor swap), Reconcile must not cancel anything even though the
+// pod is terminal.
+func TestFastCancelSkippedWhenAdvanced(t *testing.T) {
+	ctx := testutil.NewContext(t)
+
+	comp := &apiv1.Composition{}
+	comp.Name = "test-comp"
+	comp.Namespace = "default"
+	comp.Finalizers = []string{EnoCleanupFinalizer}
+	comp.Spec.Synthesizer.Name = "test-syn"
+	comp.Status.CurrentSynthesis = &apiv1.Synthesis{
+		UUID:       "uuid-1",
+		Reconciled: ptr.To(metav1.Now()),
+		Ready:      ptr.To(metav1.Now()),
+	}
+	pod := newSynthPod("synthesis-1", "uuid-1", corev1.PodSucceeded, time.Time{})
+
+	cli := testutil.NewClient(t, comp, newTestSynth(), pod)
+	c := newFastCancelController(cli)
+
+	res, err := c.Reconcile(ctx, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(comp)})
+	require.NoError(t, err)
+	assert.False(t, res.Requeue)
+
+	require.NoError(t, cli.Get(ctx, client.ObjectKeyFromObject(comp), comp))
+	assert.Nil(t, comp.Status.InFlightSynthesis, "no in-flight synthesis should be created")
+	require.NotNil(t, comp.Status.CurrentSynthesis)
+	assert.Equal(t, "uuid-1", comp.Status.CurrentSynthesis.UUID, "completed synthesis must be untouched")
+	assert.Nil(t, comp.Status.CurrentSynthesis.Canceled)
+}
+
+// Case 4: a genuinely hung pod (never terminal) is still cancelled by the existing
+// time-based timeout once podTimeout elapses.
+func TestSynthesisTimeoutStillFires(t *testing.T) {
+	ctx := testutil.NewContext(t)
+	comp := newInFlightComp("uuid-1", time.Now().Add(-2*time.Minute)) // older than podTimeout (1m)
+	pod := newSynthPod("synthesis-1", "uuid-1", corev1.PodRunning, time.Now().Add(-2*time.Minute))
+
+	cli := testutil.NewClient(t, comp, newTestSynth(), pod)
+	c := newFastCancelController(cli)
+
+	res, err := c.Reconcile(ctx, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(comp)})
+	require.NoError(t, err)
+	assert.Zero(t, res.RequeueAfter)
+
+	require.NoError(t, cli.Get(ctx, client.ObjectKeyFromObject(comp), comp))
+	require.NotNil(t, comp.Status.InFlightSynthesis)
+	assert.NotNil(t, comp.Status.InFlightSynthesis.Canceled, "hung pod should still time out")
+}
+
+// Case 5: while the pod is running and within podTimeout, Reconcile polls on the
+// short interval instead of sleeping the full timeout, and does not cancel.
+func TestInFlightPollsWhilePodRunning(t *testing.T) {
+	ctx := testutil.NewContext(t)
+	comp := newInFlightComp("uuid-1", time.Now())
+	pod := newSynthPod("synthesis-1", "uuid-1", corev1.PodRunning, time.Now())
+
+	cli := testutil.NewClient(t, comp, newTestSynth(), pod)
+	c := newFastCancelController(cli)
+
+	res, err := c.Reconcile(ctx, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(comp)})
+	require.NoError(t, err)
+	assert.Equal(t, inFlightPollInterval, res.RequeueAfter)
+
+	require.NoError(t, cli.Get(ctx, client.ObjectKeyFromObject(comp), comp))
+	assert.Nil(t, comp.Status.InFlightSynthesis.Canceled, "running pod within timeout must not be cancelled")
+}
+
+// Case 5b: with no pod at all, behavior is identical to a non-terminal pod: poll,
+// do not cancel (absence is ambiguous and must not be treated as terminal).
+func TestInFlightPollsWhenPodMissing(t *testing.T) {
+	ctx := testutil.NewContext(t)
+	comp := newInFlightComp("uuid-1", time.Now())
+
+	cli := testutil.NewClient(t, comp, newTestSynth())
+	c := newFastCancelController(cli)
+
+	res, err := c.Reconcile(ctx, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(comp)})
+	require.NoError(t, err)
+	assert.Equal(t, inFlightPollInterval, res.RequeueAfter)
+
+	require.NoError(t, cli.Get(ctx, client.ObjectKeyFromObject(comp), comp))
+	assert.Nil(t, comp.Status.InFlightSynthesis.Canceled, "missing pod must not be treated as terminal")
+}
+
+// Case 6: if the cancel write conflicts (a concurrent successful executor write
+// bumped resourceVersion), Reconcile requeues instead of erroring or clobbering.
+func TestFastCancelConflictRequeues(t *testing.T) {
+	ctx := testutil.NewContext(t)
+	comp := newInFlightComp("uuid-1", time.Now())
+	pod := newSynthPod("synthesis-1", "uuid-1", corev1.PodSucceeded, time.Time{}) // grace elapsed
+
+	ict := &interceptor.Funcs{
+		SubResourceUpdate: func(ctx context.Context, cl client.Client, subResourceName string, obj client.Object, opts ...client.SubResourceUpdateOption) error {
+			return apierrors.NewConflict(
+				schema.GroupResource{Group: "eno.azure.io", Resource: "compositions"},
+				obj.GetName(), fmt.Errorf("simulated conflict"))
+		},
+	}
+	cli := testutil.NewClientWithInterceptors(t, ict, comp, newTestSynth(), pod)
+	c := newFastCancelController(cli)
+
+	res, err := c.Reconcile(ctx, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(comp)})
+	require.NoError(t, err, "conflict must not surface as an error")
+	assert.True(t, res.Requeue, "conflict should requeue")
+
+	// The conflicting write must not have landed: the (concurrently successful)
+	// synthesis is left intact rather than clobbered with a cancellation.
+	require.NoError(t, cli.Get(ctx, client.ObjectKeyFromObject(comp), comp))
+	assert.Nil(t, comp.Status.InFlightSynthesis.Canceled, "conflicted cancel must not be persisted")
+}
+
+// --- Functional progression: grace gate releases into a cancel ---
+
+func TestFastCancelGraceThenCancel(t *testing.T) {
+	ctx := testutil.NewContext(t)
+	comp := newInFlightComp("uuid-1", time.Now())
+	pod := newSynthPod("synthesis-1", "uuid-1", corev1.PodSucceeded, time.Now()) // within grace
+
+	cli := testutil.NewClient(t, comp, newTestSynth(), pod)
+	c := newFastCancelController(cli)
+
+	// First reconcile: within grace -> requeue, no cancel.
+	res, err := c.Reconcile(ctx, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(comp)})
+	require.NoError(t, err)
+	assert.Greater(t, res.RequeueAfter, time.Duration(0))
+	require.NoError(t, cli.Get(ctx, client.ObjectKeyFromObject(comp), comp))
+	require.Nil(t, comp.Status.InFlightSynthesis.Canceled)
+
+	// Simulate the grace period elapsing by replacing the pod with a backdated one.
+	require.NoError(t, cli.Delete(ctx, pod))
+	agedPod := newSynthPod("synthesis-1", "uuid-1", corev1.PodSucceeded, time.Now().Add(-time.Hour))
+	require.NoError(t, cli.Create(ctx, agedPod))
+
+	// Second reconcile: grace elapsed -> cancel.
+	_, err = c.Reconcile(ctx, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(comp)})
+	require.NoError(t, err)
+	require.NoError(t, cli.Get(ctx, client.ObjectKeyFromObject(comp), comp))
+	assert.NotNil(t, comp.Status.InFlightSynthesis.Canceled, "should cancel once grace has elapsed")
+}

--- a/internal/controllers/reconciliation/helpers_test.go
+++ b/internal/controllers/reconciliation/helpers_test.go
@@ -31,7 +31,7 @@ func registerControllers(t *testing.T, mgr *testutil.Manager) {
 	require.NoError(t, watch.NewController(mgr.Manager))
 	require.NoError(t, resourceslice.NewController(mgr.Manager))
 	require.NoError(t, resourceslice.NewCleanupController(mgr.Manager))
-	require.NoError(t, composition.NewController(mgr.Manager, time.Second))
+	require.NoError(t, composition.NewController(mgr.Manager, time.Second, "eno-system"))
 	require.NoError(t, logging.NewCompositionStatusLogger(mgr.Manager, time.Second*10))
 	require.NoError(t, symphony.NewController(mgr.Manager))
 }

--- a/internal/controllers/reconciliation/helpers_test.go
+++ b/internal/controllers/reconciliation/helpers_test.go
@@ -31,7 +31,7 @@ func registerControllers(t *testing.T, mgr *testutil.Manager) {
 	require.NoError(t, watch.NewController(mgr.Manager))
 	require.NoError(t, resourceslice.NewController(mgr.Manager))
 	require.NoError(t, resourceslice.NewCleanupController(mgr.Manager))
-	require.NoError(t, composition.NewController(mgr.Manager, time.Second, "eno-system"))
+	require.NoError(t, composition.NewController(mgr.Manager, time.Second, "default"))
 	require.NoError(t, logging.NewCompositionStatusLogger(mgr.Manager, time.Second*10))
 	require.NoError(t, symphony.NewController(mgr.Manager))
 }

--- a/internal/controllers/symphony/controller_test.go
+++ b/internal/controllers/symphony/controller_test.go
@@ -938,7 +938,7 @@ func TestSymphonyNoDependencyVariationsReconcileNormally(t *testing.T) {
 
 	require.NoError(t, NewController(mgr.Manager))
 	require.NoError(t, scheduling.NewController(mgr.Manager, 100, 2*time.Second, 0))
-	require.NoError(t, composition.NewController(mgr.Manager, time.Minute))
+	require.NoError(t, composition.NewController(mgr.Manager, time.Minute, "eno-system"))
 	mgr.Start(t)
 
 	// Create synthesizers
@@ -999,7 +999,7 @@ func TestSymphonyDependencyVariationsReconcileInOrder(t *testing.T) {
 
 	require.NoError(t, NewController(mgr.Manager))
 	require.NoError(t, scheduling.NewController(mgr.Manager, 100, 2*time.Second, 0))
-	require.NoError(t, composition.NewController(mgr.Manager, time.Minute))
+	require.NoError(t, composition.NewController(mgr.Manager, time.Minute, "eno-system"))
 	mgr.Start(t)
 
 	// Create synthesizers

--- a/internal/controllers/symphony/controller_test.go
+++ b/internal/controllers/symphony/controller_test.go
@@ -938,7 +938,7 @@ func TestSymphonyNoDependencyVariationsReconcileNormally(t *testing.T) {
 
 	require.NoError(t, NewController(mgr.Manager))
 	require.NoError(t, scheduling.NewController(mgr.Manager, 100, 2*time.Second, 0))
-	require.NoError(t, composition.NewController(mgr.Manager, time.Minute, "eno-system"))
+	require.NoError(t, composition.NewController(mgr.Manager, time.Minute, "default"))
 	mgr.Start(t)
 
 	// Create synthesizers
@@ -999,7 +999,7 @@ func TestSymphonyDependencyVariationsReconcileInOrder(t *testing.T) {
 
 	require.NoError(t, NewController(mgr.Manager))
 	require.NoError(t, scheduling.NewController(mgr.Manager, 100, 2*time.Second, 0))
-	require.NoError(t, composition.NewController(mgr.Manager, time.Minute, "eno-system"))
+	require.NoError(t, composition.NewController(mgr.Manager, time.Minute, "default"))
 	mgr.Start(t)
 
 	// Create synthesizers

--- a/internal/controllers/synthesis/gc.go
+++ b/internal/controllers/synthesis/gc.go
@@ -126,7 +126,7 @@ func (p *podGarbageCollector) Reconcile(ctx context.Context, req ctrl.Request) (
 		}
 
 		// A new synthesis has replaced the previous
-		if syn.UUID != pod.Labels[synthesisIDLabelKey] {
+		if syn.UUID != pod.Labels[manager.SynthesisIDLabelKey] {
 			logger = logger.WithValues("reason", "Superseded")
 			return ctrl.Result{}, p.deletePod(ctx, pod, getSynthesizerName(pod), reasonSuperseded, logger)
 		}
@@ -135,7 +135,7 @@ func (p *podGarbageCollector) Reconcile(ctx context.Context, req ctrl.Request) (
 	}
 
 	// In-flight synthesis being swapped to current == synthesis completed
-	if syn := comp.Status.CurrentSynthesis; syn != nil && syn.UUID == pod.Labels[synthesisIDLabelKey] {
+	if syn := comp.Status.CurrentSynthesis; syn != nil && syn.UUID == pod.Labels[manager.SynthesisIDLabelKey] {
 		logger = logger.WithValues("reason", "Success")
 		return ctrl.Result{}, p.deletePod(ctx, pod, getSynthesizerName(pod), reasonSuccess, logger)
 	}

--- a/internal/controllers/synthesis/lifecycle.go
+++ b/internal/controllers/synthesis/lifecycle.go
@@ -124,7 +124,7 @@ func (c *podLifecycleController) Reconcile(ctx context.Context, req ctrl.Request
 	// another tick of this loop before the pod write hits the informer.
 	pods := &corev1.PodList{}
 	err = c.noCacheReader.List(ctx, pods, client.InNamespace(c.config.PodNamespace), client.MatchingLabels{
-		synthesisIDLabelKey: comp.Status.InFlightSynthesis.UUID,
+		manager.SynthesisIDLabelKey: comp.Status.InFlightSynthesis.UUID,
 	})
 	if err != nil {
 		logger.Error(err, fmt.Sprintf("Error while listing Pods in Namespace[%s], SynthesisUUID[%s]",

--- a/internal/controllers/synthesis/lifecycle_test.go
+++ b/internal/controllers/synthesis/lifecycle_test.go
@@ -48,7 +48,7 @@ func TestCompositionDeletion(t *testing.T) {
 	require.NoError(t, NewPodLifecycleController(mgr.Manager, minimalTestConfig))
 	require.NoError(t, resourceslice.NewCleanupController(mgr.Manager))
 	require.NoError(t, scheduling.NewController(mgr.Manager, 10, 2*time.Second, time.Second))
-	require.NoError(t, composition.NewController(mgr.Manager, time.Minute, "eno-system"))
+	require.NoError(t, composition.NewController(mgr.Manager, time.Minute, "default"))
 	require.NoError(t, NewPodGC(mgr.Manager, 0))
 	mgr.Start(t)
 

--- a/internal/controllers/synthesis/lifecycle_test.go
+++ b/internal/controllers/synthesis/lifecycle_test.go
@@ -48,7 +48,7 @@ func TestCompositionDeletion(t *testing.T) {
 	require.NoError(t, NewPodLifecycleController(mgr.Manager, minimalTestConfig))
 	require.NoError(t, resourceslice.NewCleanupController(mgr.Manager))
 	require.NoError(t, scheduling.NewController(mgr.Manager, 10, 2*time.Second, time.Second))
-	require.NoError(t, composition.NewController(mgr.Manager, time.Minute))
+	require.NoError(t, composition.NewController(mgr.Manager, time.Minute, "eno-system"))
 	require.NoError(t, NewPodGC(mgr.Manager, 0))
 	mgr.Start(t)
 

--- a/internal/controllers/synthesis/pod.go
+++ b/internal/controllers/synthesis/pod.go
@@ -15,7 +15,6 @@ import (
 const (
 	compositionNameLabelKey      = "eno.azure.io/composition-name"
 	compositionNamespaceLabelKey = "eno.azure.io/composition-namespace"
-	synthesisIDLabelKey          = "eno.azure.io/synthesis-uuid"
 	synthesizerNameLabelKey      = "eno.azure.io/synthesizer-name"
 )
 
@@ -26,7 +25,7 @@ func newPod(cfg *Config, comp *apiv1.Composition, syn *apiv1.Synthesizer) *corev
 	pod.Labels = map[string]string{
 		compositionNameLabelKey:      comp.Name,
 		compositionNamespaceLabelKey: comp.Namespace,
-		synthesisIDLabelKey:          comp.Status.InFlightSynthesis.UUID,
+		manager.SynthesisIDLabelKey:  comp.Status.InFlightSynthesis.UUID,
 		synthesizerNameLabelKey:      comp.Spec.Synthesizer.Name,
 		manager.ManagerLabelKey:      manager.ManagerLabelValue,
 	}

--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -43,8 +43,9 @@ func init() {
 // - The resource slices cached by the informer do not have the configured manifests since they are held by the reconstitution cache anyway
 
 const (
-	ManagerLabelKey   = "app.kubernetes.io/managed-by"
-	ManagerLabelValue = "eno"
+	ManagerLabelKey     = "app.kubernetes.io/managed-by"
+	ManagerLabelValue   = "eno"
+	SynthesisIDLabelKey = "eno.azure.io/synthesis-uuid"
 )
 
 func init() {


### PR DESCRIPTION
Instead of waiting for 2 minutes straight, we want to fast track cancellation for out of lock synthesis pods. 