### PR TITLE
[eno] Add default reconcile interval support

### DIFF
--- a/cmd/eno-reconciler/main.go
+++ b/cmd/eno-reconciler/main.go
@@ -57,7 +57,7 @@ func run() error {
 	flag.DurationVar(&recOpts.Timeout, "timeout", time.Minute, "Per-resource reconciliation timeout. Avoids cases where client retries/timeouts are configured poorly and the loop gets blocked")
 	flag.DurationVar(&recOpts.ReadinessPollInterval, "readiness-poll-interval", time.Second*5, "Interval at which non-ready resources will be checked for readiness")
 	flag.DurationVar(&recOpts.MinReconcileInterval, "min-reconcile-interval", time.Second, "Minimum value of eno.azure.com/reconcile-interval that will be honored by the controller")
-	flag.DurationVar(&recOpts.DefaultReconcileInterval, "default-reconcile-interval", time.Second*15, "Reconcile interval used for resources that set 'eno.azure.io/use-default-reconcile-interval: true' but don't specify an explicit 'eno.azure.io/reconcile-interval'")
+	flag.DurationVar(&recOpts.DefaultReconcileInterval, "default-reconcile-interval", time.Minute*5, "Reconcile interval used for resources that set 'eno.azure.io/use-default-reconcile-interval: true' but don't specify an explicit 'eno.azure.io/reconcile-interval'")
 	flag.BoolVar(&recOpts.DisableServerSideApply, "disable-ssa", false, "Use non-strategic three-way merge patches instead of server-side apply")
 	flag.StringVar(&compositionSelector, "composition-label-selector", labels.Everything().String(), "Optional label selector for compositions to be reconciled")
 	flag.StringVar(&compositionNamespace, "composition-namespace", metav1.NamespaceAll, "Optional namespace to limit compositions that will be reconciled")

--- a/cmd/eno-reconciler/main.go
+++ b/cmd/eno-reconciler/main.go
@@ -57,6 +57,7 @@ func run() error {
 	flag.DurationVar(&recOpts.Timeout, "timeout", time.Minute, "Per-resource reconciliation timeout. Avoids cases where client retries/timeouts are configured poorly and the loop gets blocked")
 	flag.DurationVar(&recOpts.ReadinessPollInterval, "readiness-poll-interval", time.Second*5, "Interval at which non-ready resources will be checked for readiness")
 	flag.DurationVar(&recOpts.MinReconcileInterval, "min-reconcile-interval", time.Second, "Minimum value of eno.azure.com/reconcile-interval that will be honored by the controller")
+	flag.DurationVar(&recOpts.DefaultReconcileInterval, "default-reconcile-interval", time.Second*15, "Reconcile interval used for resources that set 'eno.azure.io/use-default-reconcile-interval: true' but don't specify an explicit 'eno.azure.io/reconcile-interval'")
 	flag.BoolVar(&recOpts.DisableServerSideApply, "disable-ssa", false, "Use non-strategic three-way merge patches instead of server-side apply")
 	flag.StringVar(&compositionSelector, "composition-label-selector", labels.Everything().String(), "Optional label selector for compositions to be reconciled")
 	flag.StringVar(&compositionNamespace, "composition-namespace", metav1.NamespaceAll, "Optional namespace to limit compositions that will be reconciled")
@@ -157,6 +158,7 @@ func run() error {
 		"timeout", recOpts.Timeout,
 		"readinessPollInterval", recOpts.ReadinessPollInterval,
 		"minReconcileInterval", recOpts.MinReconcileInterval,
+		"defaultReconcileInterval", recOpts.DefaultReconcileInterval,
 		"disableServerSideApply", recOpts.DisableServerSideApply,
 		"compositionLabelSelector", compositionSelector,
 		"compositionNamespace", compositionNamespace,

--- a/dev/deploy.yaml
+++ b/dev/deploy.yaml
@@ -91,6 +91,7 @@ spec:
         - --leader-election
         - --leader-election-id=reconciler
         - --disable-ssa=$DISABLE_SSA
+        - --default-reconcile-interval=10s
         env:
           - name: POD_NAMESPACE
             valueFrom:

--- a/e2e/default_reconcile_interval_test.go
+++ b/e2e/default_reconcile_interval_test.go
@@ -1,0 +1,234 @@
+package e2e
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	flow "github.com/Azure/go-workflow"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	apiv1 "github.com/Azure/eno/api/v1"
+	fw "github.com/Azure/eno/e2e/framework"
+)
+
+// TestDefaultReconcileIntervalRecreatesDeletedResources validates the
+// eno.azure.io/use-default-reconcile-interval annotation.
+//
+// A synthesizer emits a ServiceAccount, ClusterRole, RoleBinding and Deployment.
+// All four carry eno.azure.io/use-default-reconcile-interval: "true". Only the
+// Deployment additionally sets an explicit eno.azure.io/reconcile-interval; the
+// other three rely purely on the default interval opt-in.
+//
+// After the composition is Ready, the four live resources are deleted out-of-band
+// (simulating a customer deleting a resource they can see). Without a reconcile
+// interval Eno would not requeue these resources until the next synthesis, so they
+// would stay deleted. The test verifies that eno-reconciler recreates each resource
+// (observed via a change in UID) purely because of the periodic requeue driven by
+// the default reconcile interval (and, for the Deployment, its explicit interval).
+//
+// NOTE: This requires the eno-reconciler deployed in the cluster to be built from a
+// revision that supports eno.azure.io/use-default-reconcile-interval.
+func TestDefaultReconcileIntervalRecreatesDeletedResources(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	cli := fw.NewClient(t)
+
+	synthName := fw.UniqueName("default-interval-synth")
+	compName := fw.UniqueName("default-interval-comp")
+	saName := fw.UniqueName("default-interval-sa")
+	clusterRoleName := fw.UniqueName("default-interval-cr")
+	roleBindingName := fw.UniqueName("default-interval-rb")
+	deployName := fw.UniqueName("default-interval-deploy")
+
+	const useDefault = "eno.azure.io/use-default-reconcile-interval"
+
+	// ServiceAccount - opts into the default reconcile interval, no explicit interval.
+	sa := &corev1.ServiceAccount{
+		TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "ServiceAccount"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        saName,
+			Namespace:   "default",
+			Annotations: map[string]string{useDefault: "true"},
+		},
+	}
+
+	// ClusterRole (cluster-scoped) - opts into the default reconcile interval.
+	clusterRole := &rbacv1.ClusterRole{
+		TypeMeta: metav1.TypeMeta{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "ClusterRole"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        clusterRoleName,
+			Annotations: map[string]string{useDefault: "true"},
+		},
+		Rules: []rbacv1.PolicyRule{{
+			APIGroups: []string{""},
+			Resources: []string{"configmaps"},
+			Verbs:     []string{"get", "list", "watch"},
+		}},
+	}
+
+	// RoleBinding - opts into the default reconcile interval, binds the ClusterRole to the ServiceAccount.
+	roleBinding := &rbacv1.RoleBinding{
+		TypeMeta: metav1.TypeMeta{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "RoleBinding"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        roleBindingName,
+			Namespace:   "default",
+			Annotations: map[string]string{useDefault: "true"},
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: "rbac.authorization.k8s.io",
+			Kind:     "ClusterRole",
+			Name:     clusterRoleName,
+		},
+		Subjects: []rbacv1.Subject{{
+			Kind:      "ServiceAccount",
+			Name:      saName,
+			Namespace: "default",
+		}},
+	}
+
+	// Deployment - opts into the default reconcile interval AND sets an explicit interval.
+	replicas := int32(1)
+	deploy := &appsv1.Deployment{
+		TypeMeta: metav1.TypeMeta{APIVersion: "apps/v1", Kind: "Deployment"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      deployName,
+			Namespace: "default",
+			Annotations: map[string]string{
+				useDefault:                        "true",
+				"eno.azure.io/reconcile-interval": "10s",
+			},
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &replicas,
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"app": deployName},
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"app": deployName},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name:    "test",
+						Image:   "docker.io/busybox:1.36.1",
+						Command: []string{"sh", "-c", "sleep 3600"},
+					}},
+				},
+			},
+		},
+	}
+
+	synth := fw.NewMinimalSynthesizer(synthName,
+		fw.WithCommand(fw.ToCommand(sa, clusterRole, roleBinding, deploy)))
+	comp := fw.NewComposition(compName, "default",
+		fw.WithSynthesizerRefs(apiv1.SynthesizerRef{Name: synthName}))
+	compKey := types.NamespacedName{Name: compName, Namespace: "default"}
+
+	// managed captures the resources Eno should manage together with a live handle
+	// that we use to read/delete them and track their UIDs for the recreation check.
+	type managed struct {
+		name string
+		obj  client.Object
+	}
+	resources := []managed{
+		{name: saName, obj: &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: saName, Namespace: "default"}}},
+		{name: clusterRoleName, obj: &rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: clusterRoleName}}},
+		{name: roleBindingName, obj: &rbacv1.RoleBinding{ObjectMeta: metav1.ObjectMeta{Name: roleBindingName, Namespace: "default"}}},
+		{name: deployName, obj: &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: deployName, Namespace: "default"}}},
+	}
+
+	// originalUIDs records the UID observed for each resource before the out-of-band
+	// deletion so the recreation check can confirm a genuinely new object.
+	originalUIDs := make(map[string]types.UID, len(resources))
+
+	// --- Workflow steps ---
+
+	createSynthesizer := fw.CreateStep(t, "createSynthesizer", cli, synth)
+
+	createComposition := fw.CreateStep(t, "createComposition", cli, comp)
+
+	waitCompositionReady := flow.Func("waitCompositionReady", func(ctx context.Context) error {
+		fw.WaitForCompositionReady(t, ctx, cli, compKey, 4*time.Minute)
+		t.Log("composition is Ready")
+		return nil
+	})
+
+	verifyCreated := flow.Func("verifyCreated", func(ctx context.Context) error {
+		for _, r := range resources {
+			fw.WaitForResourceExists(t, ctx, cli, r.obj, 60*time.Second)
+			uid := r.obj.GetUID()
+			require.NotEmpty(t, uid, "resource %s should have a UID once created", r.name)
+			originalUIDs[r.name] = uid
+			t.Logf("resource %s created with UID %s", r.name, uid)
+		}
+		return nil
+	})
+
+	deleteResourcesOutOfBand := flow.Func("deleteResourcesOutOfBand", func(ctx context.Context) error {
+		for _, r := range resources {
+			t.Logf("deleting resource %s out-of-band", r.name)
+			require.NoError(t, cli.Delete(ctx, r.obj), "failed to delete %s out-of-band", r.name)
+		}
+		return nil
+	})
+
+	verifyRecreated := flow.Func("verifyRecreated", func(ctx context.Context) error {
+		for _, r := range resources {
+			key := client.ObjectKeyFromObject(r.obj)
+			err := wait.PollUntilContextTimeout(ctx, 2*time.Second, 60*time.Second, true,
+				func(ctx context.Context) (bool, error) {
+					if err := cli.Get(ctx, key, r.obj); err != nil {
+						return false, nil
+					}
+					// Ensure this is a freshly recreated object (new UID) and not the
+					// terminating original still lingering.
+					if r.obj.GetDeletionTimestamp() != nil {
+						return false, nil
+					}
+					return r.obj.GetUID() != "" && r.obj.GetUID() != originalUIDs[r.name], nil
+				})
+			require.NoError(t, err,
+				"timed out waiting for eno-reconciler to recreate %s (original UID %s)", r.name, originalUIDs[r.name])
+			t.Logf("resource %s recreated with new UID %s", r.name, r.obj.GetUID())
+		}
+		return nil
+	})
+
+	deleteComposition := fw.DeleteStep(t, "deleteComposition", cli, comp)
+
+	verifyResourcesDeleted := flow.Func("verifyResourcesDeleted", func(ctx context.Context) error {
+		for _, r := range resources {
+			fw.WaitForResourceDeleted(t, ctx, cli, r.obj, 90*time.Second)
+		}
+		t.Log("all managed resources deleted after composition deletion")
+		return nil
+	})
+
+	cleanupSynthesizer := fw.CleanupStep(t, "cleanupSynthesizer", cli, synth)
+
+	// --- Wire the workflow DAG ---
+
+	w := new(flow.Workflow)
+	w.Add(
+		flow.Step(createComposition).DependsOn(createSynthesizer),
+		flow.Step(waitCompositionReady).DependsOn(createComposition),
+		flow.Step(verifyCreated).DependsOn(waitCompositionReady),
+		flow.Step(deleteResourcesOutOfBand).DependsOn(verifyCreated),
+		flow.Step(verifyRecreated).DependsOn(deleteResourcesOutOfBand),
+		flow.Step(deleteComposition).DependsOn(verifyRecreated),
+		flow.Step(verifyResourcesDeleted).DependsOn(deleteComposition),
+		flow.Step(cleanupSynthesizer).DependsOn(verifyResourcesDeleted),
+	)
+
+	require.NoError(t, w.Do(ctx))
+}

--- a/e2e/default_reconcile_interval_test.go
+++ b/e2e/default_reconcile_interval_test.go
@@ -20,12 +20,14 @@ import (
 )
 
 // TestDefaultReconcileIntervalRecreatesDeletedResources validates the
-// eno.azure.io/use-default-reconcile-interval annotation.
+// eno.azure.io/use-default-reconcile-interval annotation applied at the Composition level.
 //
 // A synthesizer emits a ServiceAccount, ClusterRole, RoleBinding and Deployment.
-// All four carry eno.azure.io/use-default-reconcile-interval: "true". Only the
-// Deployment additionally sets an explicit eno.azure.io/reconcile-interval; the
-// other three rely purely on the default interval opt-in.
+// The eno.azure.io/use-default-reconcile-interval: "true" annotation is set once on
+// the Composition (not on the individual resources) so it cascades to every resource
+// it manages - this matches the integration case where we can't ask partner teams to
+// annotate their own manifests. Only the Deployment additionally sets an explicit
+// eno.azure.io/reconcile-interval; the other three rely purely on the cascaded default.
 //
 // After the composition is Ready, the four live resources are deleted out-of-band
 // (simulating a customer deleting a resource they can see). Without a reconcile
@@ -52,22 +54,20 @@ func TestDefaultReconcileIntervalRecreatesDeletedResources(t *testing.T) {
 
 	const useDefault = "eno.azure.io/use-default-reconcile-interval"
 
-	// ServiceAccount - opts into the default reconcile interval, no explicit interval.
+	// ServiceAccount - inherits the default reconcile interval from the Composition, no explicit interval.
 	sa := &corev1.ServiceAccount{
 		TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "ServiceAccount"},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        saName,
-			Namespace:   "default",
-			Annotations: map[string]string{useDefault: "true"},
+			Name:      saName,
+			Namespace: "default",
 		},
 	}
 
-	// ClusterRole (cluster-scoped) - opts into the default reconcile interval.
+	// ClusterRole (cluster-scoped) - inherits the default reconcile interval from the Composition.
 	clusterRole := &rbacv1.ClusterRole{
 		TypeMeta: metav1.TypeMeta{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "ClusterRole"},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        clusterRoleName,
-			Annotations: map[string]string{useDefault: "true"},
+			Name: clusterRoleName,
 		},
 		Rules: []rbacv1.PolicyRule{{
 			APIGroups: []string{""},
@@ -76,13 +76,12 @@ func TestDefaultReconcileIntervalRecreatesDeletedResources(t *testing.T) {
 		}},
 	}
 
-	// RoleBinding - opts into the default reconcile interval, binds the ClusterRole to the ServiceAccount.
+	// RoleBinding - inherits the default reconcile interval from the Composition, binds the ClusterRole to the ServiceAccount.
 	roleBinding := &rbacv1.RoleBinding{
 		TypeMeta: metav1.TypeMeta{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "RoleBinding"},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        roleBindingName,
-			Namespace:   "default",
-			Annotations: map[string]string{useDefault: "true"},
+			Name:      roleBindingName,
+			Namespace: "default",
 		},
 		RoleRef: rbacv1.RoleRef{
 			APIGroup: "rbac.authorization.k8s.io",
@@ -96,7 +95,7 @@ func TestDefaultReconcileIntervalRecreatesDeletedResources(t *testing.T) {
 		}},
 	}
 
-	// Deployment - opts into the default reconcile interval AND sets an explicit interval.
+	// Deployment - inherits the default reconcile interval from the Composition AND sets an explicit interval.
 	replicas := int32(1)
 	deploy := &appsv1.Deployment{
 		TypeMeta: metav1.TypeMeta{APIVersion: "apps/v1", Kind: "Deployment"},
@@ -104,7 +103,6 @@ func TestDefaultReconcileIntervalRecreatesDeletedResources(t *testing.T) {
 			Name:      deployName,
 			Namespace: "default",
 			Annotations: map[string]string{
-				useDefault:                        "true",
 				"eno.azure.io/reconcile-interval": "10s",
 			},
 		},
@@ -132,6 +130,9 @@ func TestDefaultReconcileIntervalRecreatesDeletedResources(t *testing.T) {
 		fw.WithCommand(fw.ToCommand(sa, clusterRole, roleBinding, deploy)))
 	comp := fw.NewComposition(compName, "default",
 		fw.WithSynthesizerRefs(apiv1.SynthesizerRef{Name: synthName}))
+	// Opt every managed resource into the default reconcile interval by annotating the
+	// Composition once; the annotation cascades to all resources that don't set it themselves.
+	comp.Annotations = map[string]string{useDefault: "true"}
 	compKey := types.NamespacedName{Name: compName, Namespace: "default"}
 
 	// managed captures the resources Eno should manage together with a live handle

--- a/internal/controllers/reconciliation/controller.go
+++ b/internal/controllers/reconciliation/controller.go
@@ -41,27 +41,29 @@ type Options struct {
 	MigratingFieldManagers []string
 	MigratingFields        []string
 
-	Timeout               time.Duration
-	ReadinessPollInterval time.Duration
-	MinReconcileInterval  time.Duration
+	Timeout                  time.Duration
+	ReadinessPollInterval    time.Duration
+	MinReconcileInterval     time.Duration
+	DefaultReconcileInterval time.Duration
 
 	MaxConcurrentReconciles int
 }
 
 type Controller struct {
-	client                  client.Client
-	writeBuffer             *flowcontrol.ResourceSliceWriteBuffer
-	resourceClient          *resource.Cache
-	resourceFilter          cel.Program
-	timeout                 time.Duration
-	readinessPollInterval   time.Duration
-	upstreamClient          client.Client
-	minReconcileInterval    time.Duration
-	disableSSA              bool
-	failOpen                bool
-	migratingFieldManagers  []string
-	migratingFields         []string
-	maxConcurrentReconciles int
+	client                   client.Client
+	writeBuffer              *flowcontrol.ResourceSliceWriteBuffer
+	resourceClient           *resource.Cache
+	resourceFilter           cel.Program
+	timeout                  time.Duration
+	readinessPollInterval    time.Duration
+	upstreamClient           client.Client
+	minReconcileInterval     time.Duration
+	defaultReconcileInterval time.Duration
+	disableSSA               bool
+	failOpen                 bool
+	migratingFieldManagers   []string
+	migratingFields          []string
+	maxConcurrentReconciles  int
 }
 
 func New(mgr ctrl.Manager, opts Options) error {
@@ -78,19 +80,20 @@ func New(mgr ctrl.Manager, opts Options) error {
 	}
 
 	c := &Controller{
-		client:                  opts.Manager.GetClient(),
-		writeBuffer:             opts.WriteBuffer,
-		resourceClient:          cache,
-		resourceFilter:          opts.ResourceFilter,
-		timeout:                 opts.Timeout,
-		readinessPollInterval:   opts.ReadinessPollInterval,
-		upstreamClient:          upstreamClient,
-		minReconcileInterval:    opts.MinReconcileInterval,
-		disableSSA:              opts.DisableServerSideApply,
-		failOpen:                opts.FailOpen,
-		migratingFieldManagers:  opts.MigratingFieldManagers,
-		migratingFields:         opts.MigratingFields,
-		maxConcurrentReconciles: opts.MaxConcurrentReconciles,
+		client:                   opts.Manager.GetClient(),
+		writeBuffer:              opts.WriteBuffer,
+		resourceClient:           cache,
+		resourceFilter:           opts.ResourceFilter,
+		timeout:                  opts.Timeout,
+		readinessPollInterval:    opts.ReadinessPollInterval,
+		upstreamClient:           upstreamClient,
+		minReconcileInterval:     opts.MinReconcileInterval,
+		defaultReconcileInterval: opts.DefaultReconcileInterval,
+		disableSSA:               opts.DisableServerSideApply,
+		failOpen:                 opts.FailOpen,
+		migratingFieldManagers:   opts.MigratingFieldManagers,
+		migratingFields:          opts.MigratingFields,
+		maxConcurrentReconciles:  opts.MaxConcurrentReconciles,
 	}
 
 	reconciliationMaxConcurrent.Set(float64(opts.MaxConcurrentReconciles))
@@ -533,11 +536,24 @@ func (c *Controller) requeue(logger logr.Logger, resource *resource.Snapshot, re
 		return ctrl.Result{RequeueAfter: wait.Jitter(c.readinessPollInterval, 0.1)}, nil
 	}
 
-	if resource == nil || (resource.Deleted() && !resource.Disable) || resource.ReconcileInterval == nil {
+	if resource == nil || (resource.Deleted() && !resource.Disable) {
 		return ctrl.Result{}, nil
 	}
 
-	interval := resource.ReconcileInterval.Duration
+	// Determine the reconcile interval. An explicit eno.azure.io/reconcile-interval always
+	// wins. When it's absent but the resource opts in via eno.azure.io/use-default-reconcile-interval,
+	// fall back to the controller's default interval so drift (e.g. an accidental deletion of a
+	// customer-visible resource) is corrected without waiting for the next synthesis.
+	var interval time.Duration
+	switch {
+	case resource.ReconcileInterval != nil:
+		interval = resource.ReconcileInterval.Duration
+	case resource.UseDefaultReconcileInterval:
+		interval = c.defaultReconcileInterval
+	default:
+		return ctrl.Result{}, nil
+	}
+
 	if interval < c.minReconcileInterval {
 		logger.V(1).Info("reconcile interval is too small - using default", "latency", interval, "default", c.minReconcileInterval)
 		interval = c.minReconcileInterval

--- a/internal/controllers/reconciliation/controller_test.go
+++ b/internal/controllers/reconciliation/controller_test.go
@@ -23,11 +23,12 @@ import (
 
 func TestRequeue(t *testing.T) {
 	tests := []struct {
-		name           string
-		resource       *resource.Snapshot
-		ready          *metav1.Time
-		minReconcile   time.Duration
-		expectedResult time.Duration
+		name             string
+		resource         *resource.Snapshot
+		ready            *metav1.Time
+		minReconcile     time.Duration
+		defaultReconcile time.Duration
+		expectedResult   time.Duration
 	}{
 		{
 			name: "resource is not ready, requeue after readiness poll interval",
@@ -65,14 +66,59 @@ func TestRequeue(t *testing.T) {
 			minReconcile:   10 * time.Second,
 			expectedResult: 15 * time.Second,
 		},
+		{
+			name: "opts into default reconcile interval without an explicit interval",
+			resource: &resource.Snapshot{
+				ReconcileInterval:           nil,
+				UseDefaultReconcileInterval: true,
+			},
+			ready:            &metav1.Time{},
+			minReconcile:     1 * time.Second,
+			defaultReconcile: 15 * time.Second,
+			expectedResult:   15 * time.Second,
+		},
+		{
+			name: "explicit reconcile interval wins over the default opt-in",
+			resource: &resource.Snapshot{
+				ReconcileInterval:           &metav1.Duration{Duration: 15 * time.Second},
+				UseDefaultReconcileInterval: true,
+			},
+			ready:            &metav1.Time{},
+			minReconcile:     1 * time.Second,
+			defaultReconcile: 5 * time.Second,
+			expectedResult:   15 * time.Second,
+		},
+		{
+			name: "default reconcile interval below minReconcileInterval is floored",
+			resource: &resource.Snapshot{
+				ReconcileInterval:           nil,
+				UseDefaultReconcileInterval: true,
+			},
+			ready:            &metav1.Time{},
+			minReconcile:     10 * time.Second,
+			defaultReconcile: 5 * time.Second,
+			expectedResult:   10 * time.Second,
+		},
+		{
+			name: "no opt-in and no explicit interval does not requeue",
+			resource: &resource.Snapshot{
+				ReconcileInterval:           nil,
+				UseDefaultReconcileInterval: false,
+			},
+			ready:            &metav1.Time{},
+			minReconcile:     10 * time.Second,
+			defaultReconcile: 15 * time.Second,
+			expectedResult:   0,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			logger := logr.Discard()
 			c := &Controller{
-				readinessPollInterval: 10 * time.Second,
-				minReconcileInterval:  tt.minReconcile,
+				readinessPollInterval:    10 * time.Second,
+				minReconcileInterval:     tt.minReconcile,
+				defaultReconcileInterval: tt.defaultReconcile,
 			}
 			if tt.resource.Resource == nil {
 				tt.resource.Resource = &resource.Resource{}

--- a/internal/controllers/reconciliation/crud_test.go
+++ b/internal/controllers/reconciliation/crud_test.go
@@ -427,6 +427,71 @@ func TestReconcileInterval(t *testing.T) {
 	})
 }
 
+// TestUseDefaultReconcileInterval proves that resources which opt into the default reconcile
+// interval (without specifying an explicit one) are periodically reconciled and converge when
+// modified from outside of Eno.
+func TestUseDefaultReconcileInterval(t *testing.T) {
+	scheme := runtime.NewScheme()
+	corev1.SchemeBuilder.AddToScheme(scheme)
+	testv1.SchemeBuilder.AddToScheme(scheme)
+
+	ctx := testutil.NewContext(t)
+	mgr := testutil.NewManager(t)
+	upstream := mgr.GetClient()
+	downstream := mgr.DownstreamClient
+
+	registerControllers(t, mgr)
+	testutil.WithFakeExecutor(t, mgr, func(ctx context.Context, s *apiv1.Synthesizer, input *krmv1.ResourceList) (*krmv1.ResourceList, error) {
+		output := &krmv1.ResourceList{}
+		output.Items = []*unstructured.Unstructured{{
+			Object: map[string]any{
+				"apiVersion": "v1",
+				"kind":       "ConfigMap",
+				"metadata": map[string]any{
+					"name":      "test-obj",
+					"namespace": "default",
+					"annotations": map[string]string{
+						"eno.azure.io/use-default-reconcile-interval": "true",
+					},
+				},
+				"data": map[string]string{"foo": "bar"},
+			},
+		}}
+		return output, nil
+	})
+
+	// Test subject with a short default reconcile interval so the test converges quickly.
+	setupTestSubjectForOptions(t, mgr, Options{
+		Manager:                  mgr.Manager,
+		Timeout:                  time.Minute,
+		ReadinessPollInterval:    time.Hour,
+		DefaultReconcileInterval: 100 * time.Millisecond,
+		DisableServerSideApply:   mgr.NoSsaSupport,
+	})
+	mgr.Start(t)
+	writeGenericComposition(t, upstream)
+
+	// Wait for resource to be created
+	obj := &corev1.ConfigMap{}
+	testutil.Eventually(t, func() bool {
+		obj.SetName("test-obj")
+		obj.SetNamespace("default")
+		err := downstream.Get(ctx, client.ObjectKeyFromObject(obj), obj)
+		return err == nil
+	})
+
+	// Update the object from outside of Eno
+	obj.Data["foo"] = "baz"
+	require.NoError(t, downstream.Update(ctx, obj))
+
+	// The object should eventually converge with the desired state because the default
+	// reconcile interval keeps requeueing it even though no explicit interval was set.
+	testutil.Eventually(t, func() bool {
+		err := downstream.Get(ctx, client.ObjectKeyFromObject(obj), obj)
+		return err == nil && obj.Data["foo"] == "bar"
+	})
+}
+
 // TestReconcileCacheRace covers a race condition in which a work item remains in the queue after the
 // corresponding (version of the) manifest has been removed from cache.
 func TestReconcileCacheRace(t *testing.T) {

--- a/internal/resource/resource.go
+++ b/internal/resource/resource.go
@@ -371,6 +371,9 @@ func (r *Resource) SnapshotWithOverrides(ctx context.Context, comp *apiv1.Compos
 		snap.ReconcileInterval = &metav1.Duration{Duration: reconcileInterval}
 	}
 
+	const useDefaultReconcileIntervalKey = "eno.azure.io/use-default-reconcile-interval"
+	snap.UseDefaultReconcileInterval = cascadeAnnotation(comp, copy, useDefaultReconcileIntervalKey) == "true"
+
 	// Remove any eno.azure.io annotations and labels
 	copy.SetAnnotations(pruneMetadata(copy.GetAnnotations()))
 	copy.SetLabels(pruneMetadata(copy.GetLabels()))
@@ -383,12 +386,13 @@ func (r *Resource) SnapshotWithOverrides(ctx context.Context, comp *apiv1.Compos
 type Snapshot struct {
 	*Resource
 
-	ReconcileInterval  *metav1.Duration
-	Disable            bool
-	DisableUpdates     bool
-	Replace            bool
-	Orphan             bool
-	ForegroundDeletion bool
+	ReconcileInterval           *metav1.Duration
+	UseDefaultReconcileInterval bool
+	Disable                     bool
+	DisableUpdates              bool
+	Replace                     bool
+	Orphan                      bool
+	ForegroundDeletion          bool
 
 	parsed         *unstructured.Unstructured
 	overrideStatus string

--- a/internal/resource/resource_test.go
+++ b/internal/resource/resource_test.go
@@ -108,6 +108,40 @@ var newResourceTests = []struct {
 		},
 	},
 	{
+		Name: "use default reconcile interval opt-in",
+		Manifest: `{
+			"apiVersion": "v1",
+			"kind": "ConfigMap",
+			"metadata": {
+				"name": "foo",
+				"annotations": {
+					"eno.azure.io/use-default-reconcile-interval": "true"
+				}
+			}
+		}`,
+		Assert: func(t *testing.T, r *Snapshot) {
+			assert.True(t, r.UseDefaultReconcileInterval)
+			assert.Nil(t, r.ReconcileInterval)
+		},
+	},
+	{
+		Name: "explicit reconcile interval leaves default opt-in off",
+		Manifest: `{
+			"apiVersion": "v1",
+			"kind": "ConfigMap",
+			"metadata": {
+				"name": "foo",
+				"annotations": {
+					"eno.azure.io/reconcile-interval": "10s"
+				}
+			}
+		}`,
+		Assert: func(t *testing.T, r *Snapshot) {
+			assert.False(t, r.UseDefaultReconcileInterval)
+			assert.Equal(t, time.Second*10, r.ReconcileInterval.Duration)
+		},
+	},
+	{
 		Name: "zero-readiness-group",
 		Manifest: `{
 			"apiVersion": "v1",


### PR DESCRIPTION
## Summary

Adds an opt-in **default reconcile interval** for resources managed by Eno.

When a Composition (or an individual resource) is annotated with
`eno.azure.io/use-default-reconcile-interval: "true"`, every managed resource
that does **not** set an explicit `eno.azure.io/reconcile-interval` will be
periodically requeued using the reconciler's default interval (**15s**,
configurable via `--default-reconcile-interval`).

This lets us enable periodic drift correction for an entire Composition with a
single annotation, without asking partner teams to annotate each of their own
manifests.

## Motivation

Without a reconcile interval, Eno only re-applies a resource on the next
synthesis. If a customer-visible resource is deleted or modified out-of-band, it
can stay drifted until then. Opting into the default interval ensures such drift
(e.g. an accidental deletion) is corrected promptly.

## Behavior

Interval precedence when deciding whether/when to requeue:

1. Explicit `eno.azure.io/reconcile-interval` — always wins.
2. Else, if `eno.azure.io/use-default-reconcile-interval: "true"` — use the
   default interval.
3. Else — no periodic requeue (unchanged behavior).

The resolved interval is still floored by `--min-reconcile-interval`. The
`use-default` annotation cascades from the Composition to its resources, matching
existing annotations like `disable-reconciliation`.

## Changes

- New `--default-reconcile-interval` flag (default `15s`) on `eno-reconciler`.
- `use-default-reconcile-interval` opt-in plumbed through the resource snapshot
  and honored in the reconciler's requeue logic.
- Backward compatible: resources with neither annotation are unaffected.

## Testing

- Unit: requeue interval-resolution matrix (explicit wins, default opt-in,
  min-interval flooring, no-op when not opted in).
- Resource: annotation parsing for the new opt-in.
- Integration: out-of-Eno modification converges via the default interval.
- E2E: out-of-band deletion of ServiceAccount/ClusterRole/RoleBinding/Deployment
  is recreated purely from the periodic requeue (verified via new UIDs).
