### PR TITLE
[eno] Cleanup AKS specific labels

### DIFF
--- a/internal/controllers/composition/controller.go
+++ b/internal/controllers/composition/controller.go
@@ -32,8 +32,6 @@ import (
 
 const (
 	enoCompositionForceDeleteAnnotation = "eno.azure.io/forceDeleteWhenSymphonyGone"
-	AKSComponentLabel                   = "aks.azure.com/component-type" // TODO(ruinanliu): Temp workaround remove after 14802391 is released
-	addOnLabelValue                     = "addon"                        // TODO(ruinanliu):  Temp workaround remove after 14802391 is released
 	EnoCleanupFinalizer                 = "eno.azure.io/cleanup"
 	MissingInputStatus                  = "MissingInputs"
 	MismatchedInputsStatus              = "MismatchedInputs"
@@ -417,8 +415,7 @@ func (c *compositionController) logNotReadyResources(ctx context.Context, comp *
 func (c *compositionController) shouldForceRemoveFinalizer(ctx context.Context, comp *apiv1.Composition) bool {
 	logger := logr.FromContextOrDiscard(ctx)
 
-	// TODO(ruinanliu): Temp workaround remove isAddonComposition method after PR 14802391 is released
-	if !isCompositionMarkedForcedDelete(comp) && !isAddonComposition(comp) {
+	if !isCompositionMarkedForcedDelete(comp) {
 		return false
 	}
 
@@ -471,16 +468,6 @@ func isCompositionMarkedForcedDelete(comp *apiv1.Composition) bool {
 		return false
 	}
 	return annotations[enoCompositionForceDeleteAnnotation] == "true"
-}
-
-// isAddonComposition checks if the composition's label contains addon label.
-// TODO(ruinanliu): Temp workaround remove after PR 14802391 is released
-func isAddonComposition(comp *apiv1.Composition) bool {
-	labels := comp.GetLabels()
-	if labels == nil {
-		return false
-	}
-	return labels[AKSComponentLabel] == addOnLabelValue
 }
 
 func buildSimplifiedStatus(synth *apiv1.Synthesizer, comp *apiv1.Composition) *apiv1.SimplifiedStatus {

--- a/internal/controllers/composition/controller_test.go
+++ b/internal/controllers/composition/controller_test.go
@@ -280,60 +280,15 @@ type simplifiedStatusState struct {
 	Comp  *apiv1.Composition
 }
 
-func TestIsAddonComposition(t *testing.T) {
-	tests := []struct {
-		name     string
-		labels   map[string]string
-		expected bool
-	}{
-		{
-			name:     "nil labels",
-			labels:   nil,
-			expected: false,
-		},
-		{
-			name:     "empty labels",
-			labels:   map[string]string{},
-			expected: false,
-		},
-		{
-			name:     "unrelated labels",
-			labels:   map[string]string{"foo": "bar"},
-			expected: false,
-		},
-		{
-			name:     "AKS component label with wrong value",
-			labels:   map[string]string{AKSComponentLabel: "not-addon"},
-			expected: false,
-		},
-		{
-			name:     "AKS component label with addon value",
-			labels:   map[string]string{AKSComponentLabel: addOnLabelValue},
-			expected: true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			comp := &apiv1.Composition{}
-			comp.Labels = tt.labels
-			assert.Equal(t, tt.expected, isAddonComposition(comp))
-		})
-	}
-}
-
 func TestShouldForceRemoveFinalizer(t *testing.T) {
 	const symphonyName = "my-symphony"
 	const namespace = "default"
 
-	addonLabels := map[string]string{AKSComponentLabel: addOnLabelValue}
-
-	newComp := func(annotations map[string]string, labels map[string]string, withOwnerRef bool) *apiv1.Composition {
+	newComp := func(annotations map[string]string, withOwnerRef bool) *apiv1.Composition {
 		comp := &apiv1.Composition{}
 		comp.Name = "comp-1"
 		comp.Namespace = namespace
 		comp.Annotations = annotations
-		comp.Labels = labels
 		comp.Finalizers = []string{"eno.azure.io/cleanup"}
 		if withOwnerRef {
 			comp.OwnerReferences = []metav1.OwnerReference{{
@@ -349,80 +304,38 @@ func TestShouldForceRemoveFinalizer(t *testing.T) {
 	tests := []struct {
 		name           string
 		annotations    map[string]string
-		labels         map[string]string
 		withOwnerRef   bool
 		symphonyExists bool
 		expected       bool
 	}{
 		{
-			name:         "no annotations and no addon label",
+			name:         "no annotations",
 			annotations:  nil,
-			labels:       nil,
 			withOwnerRef: true,
 			expected:     false,
 		},
 		{
-			name:         "no annotations and wrong addon label value",
-			annotations:  nil,
-			labels:       map[string]string{AKSComponentLabel: "not-addon"},
-			withOwnerRef: true,
-			expected:     false,
-		},
-		{
-			name:         "annotation set to false and no addon label",
+			name:         "annotation set to false",
 			annotations:  map[string]string{enoCompositionForceDeleteAnnotation: "false"},
-			labels:       nil,
 			withOwnerRef: true,
 			expected:     false,
 		},
 		{
-			name:         "no annotation - addon label only - symphony gone",
-			annotations:  nil,
-			labels:       addonLabels,
-			withOwnerRef: true,
-			expected:     true,
-		},
-		{
-			name:           "no annotation - addon label only - symphony exists",
-			annotations:    nil,
-			labels:         addonLabels,
-			withOwnerRef:   true,
-			symphonyExists: true,
-			expected:       false,
-		},
-		{
-			name:         "annotation set to true - no addon label - symphony gone",
+			name:         "annotation set to true - symphony gone",
 			annotations:  map[string]string{enoCompositionForceDeleteAnnotation: "true"},
-			labels:       nil,
 			withOwnerRef: true,
 			expected:     true,
 		},
 		{
-			name:         "annotation set to true - addon label - symphony gone",
-			annotations:  map[string]string{enoCompositionForceDeleteAnnotation: "true"},
-			labels:       addonLabels,
-			withOwnerRef: true,
-			expected:     true,
-		},
-		{
-			name:           "annotation set to true - addon label - symphony exists",
+			name:           "annotation set to true - symphony exists",
 			annotations:    map[string]string{enoCompositionForceDeleteAnnotation: "true"},
-			labels:         addonLabels,
 			withOwnerRef:   true,
 			symphonyExists: true,
 			expected:       false,
 		},
 		{
-			name:         "annotation set to true - addon label - no owner ref",
+			name:         "annotation set to true - no owner ref",
 			annotations:  map[string]string{enoCompositionForceDeleteAnnotation: "true"},
-			labels:       addonLabels,
-			withOwnerRef: false,
-			expected:     false,
-		},
-		{
-			name:         "addon label only - no owner ref",
-			annotations:  nil,
-			labels:       addonLabels,
 			withOwnerRef: false,
 			expected:     false,
 		},
@@ -430,7 +343,7 @@ func TestShouldForceRemoveFinalizer(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			comp := newComp(tt.annotations, tt.labels, tt.withOwnerRef)
+			comp := newComp(tt.annotations, tt.withOwnerRef)
 			objs := []client.Object{comp}
 			if tt.symphonyExists {
 				symph := &apiv1.Symphony{}


### PR DESCRIPTION
## Summary
Removes the temporary AKS-specific addon-label workaround from the composition controller now that PR 14802391 has merged and released.

`shouldForceRemoveFinalizer` previously force-removed the cleanup finalizer for compositions labeled `aks.azure.com/component-type: addon`, as a stopgap until addon compositions set the `eno.azure.io/forceDeleteWhenSymphonyGone` annotation directly. Now that 14802391 stamps that annotation, the label-based fallback is no longer needed.

## Changes
- Remove `AKSComponentLabel` / `addOnLabelValue` constants and the
  `isAddonComposition` helper.
- Gate `shouldForceRemoveFinalizer` solely on the `forceDeleteWhenSymphonyGone`
  annotation.
- Drop the obsolete `TestIsAddonComposition` and addon-label test cases.

## Notes
No behavior change for compositions using the annotation. Depends on 14802391 being rolled out so all addon compositions carry the annotation.
