### PR TITLE
fix(controller): gracefully handle namespaces in a terminating state

### DIFF
--- a/internal/controllers/synthesis/gc.go
+++ b/internal/controllers/synthesis/gc.go
@@ -23,14 +23,15 @@ type podGarbageCollector struct {
 type terminalReason string
 
 const (
-	reasonSuccess            terminalReason = "success"
-	reasonTimeout            terminalReason = "timeout"
-	reasonSuperseded         terminalReason = "superseded"
-	reasonOrphaned           terminalReason = "orphaned"
-	reasonImageChanged       terminalReason = "image_changed"
-	reasonCompositionDeleted terminalReason = "composition_deleted"
-	reasonSynthesizerDeleted terminalReason = "synthesizer_deleted"
-	reasonKubeletTimeout     terminalReason = "kubelet_timeout"
+	reasonSuccess              terminalReason = "success"
+	reasonTimeout              terminalReason = "timeout"
+	reasonSuperseded           terminalReason = "superseded"
+	reasonOrphaned             terminalReason = "orphaned"
+	reasonImageChanged         terminalReason = "image_changed"
+	reasonCompositionDeleted   terminalReason = "composition_deleted"
+	reasonNamespaceTerminating terminalReason = "namespace_terminating"
+	reasonSynthesizerDeleted   terminalReason = "synthesizer_deleted"
+	reasonKubeletTimeout       terminalReason = "kubelet_timeout"
 )
 
 func NewPodGC(mgr ctrl.Manager, creationTimeout time.Duration) error {
@@ -90,6 +91,16 @@ func (p *podGarbageCollector) Reconcile(ctx context.Context, req ctrl.Request) (
 	if err != nil {
 		logger.Error(err, "failed to get composition resource")
 		return ctrl.Result{}, err
+	}
+
+	namespaceUnavailable, err := compositionNamespaceUnavailable(ctx, p.client, comp.Namespace)
+	if err != nil {
+		logger.Error(err, "failed to get composition namespace")
+		return ctrl.Result{}, err
+	}
+	if namespaceUnavailable {
+		logger = logger.WithValues("reason", "NamespaceTerminating")
+		return ctrl.Result{}, p.deletePod(ctx, pod, getSynthesizerName(pod), reasonNamespaceTerminating, logger)
 	}
 
 	// GC pods from missing synthesizers

--- a/internal/controllers/synthesis/gc_test.go
+++ b/internal/controllers/synthesis/gc_test.go
@@ -12,8 +12,34 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/util/retry"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
+
+func TestPodGCTerminatingCompositionNamespace(t *testing.T) {
+	ctx := testutil.NewContext(t)
+	now := metav1.Now()
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{
+		Name:              "terminating",
+		DeletionTimestamp: &now,
+		Finalizers:        []string{"test-finalizer"},
+	}}
+	synth := &apiv1.Synthesizer{ObjectMeta: metav1.ObjectMeta{Name: "test-synth"}}
+	comp := &apiv1.Composition{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-comp", Namespace: ns.Name},
+		Spec:       apiv1.CompositionSpec{Synthesizer: apiv1.SynthesizerRef{Name: synth.Name}},
+		Status:     apiv1.CompositionStatus{InFlightSynthesis: &apiv1.Synthesis{UUID: "test-synthesis"}},
+	}
+	pod := newPod(minimalTestConfig, comp, synth)
+	pod.GenerateName = ""
+	pod.Name = "test-pod"
+	cli := testutil.NewClient(t, ns, synth, comp, pod)
+	p := &podGarbageCollector{client: cli}
+
+	_, err := p.Reconcile(ctx, ctrl.Request{NamespacedName: client.ObjectKeyFromObject(pod)})
+	require.NoError(t, err)
+	assert.True(t, errors.IsNotFound(cli.Get(ctx, client.ObjectKeyFromObject(pod), pod)))
+}
 
 func TestPodGCMissingSynthesis(t *testing.T) {
 	ctx := testutil.NewContext(t)

--- a/internal/controllers/synthesis/lifecycle.go
+++ b/internal/controllers/synthesis/lifecycle.go
@@ -103,6 +103,16 @@ func (c *podLifecycleController) Reconcile(ctx context.Context, req ctrl.Request
 		return ctrl.Result{}, nil
 	}
 
+	namespaceUnavailable, err := compositionNamespaceUnavailable(ctx, c.client, comp.Namespace)
+	if err != nil {
+		logger.Error(err, "failed to get composition namespace", "compositionNamespace", comp.Namespace)
+		return ctrl.Result{}, err
+	}
+	if namespaceUnavailable {
+		logger.Info("refusing to create synthesizer pod because the composition namespace is terminating or missing", "compositionNamespace", comp.Namespace)
+		return ctrl.Result{}, nil
+	}
+
 	logger = logger.WithValues("compositionName", comp.Name, "compositionNamespace", comp.Namespace, "compositionGeneration", comp.Generation, "synthesisUUID", comp.Status.InFlightSynthesis.UUID,
 		"operationID", comp.GetAzureOperationID(), "operationOrigin", comp.GetAzureOperationOrigin())
 	ctx = logr.NewContext(ctx, logger)

--- a/internal/controllers/synthesis/lifecycle_test.go
+++ b/internal/controllers/synthesis/lifecycle_test.go
@@ -11,9 +11,12 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/util/retry"
 	"k8s.io/utils/ptr"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	apiv1 "github.com/Azure/eno/api/v1"
 	"github.com/Azure/eno/internal/controllers/composition"
@@ -22,6 +25,41 @@ import (
 	"github.com/Azure/eno/internal/testutil"
 	krmv1 "github.com/Azure/eno/pkg/krm/functions/api/v1"
 )
+
+func TestTerminatingCompositionNamespaceDoesNotCreatePod(t *testing.T) {
+	ctx := context.Background()
+	scheme := runtime.NewScheme()
+	require.NoError(t, apiv1.SchemeBuilder.AddToScheme(scheme))
+	require.NoError(t, corev1.SchemeBuilder.AddToScheme(scheme))
+
+	now := metav1.Now()
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{
+		Name:              "terminating",
+		DeletionTimestamp: &now,
+		Finalizers:        []string{"test-finalizer"},
+	}}
+	syn := &apiv1.Synthesizer{ObjectMeta: metav1.ObjectMeta{Name: "test-synth"}}
+	comp := &apiv1.Composition{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "test-comp",
+			Namespace:  ns.Name,
+			Finalizers: []string{"eno.azure.io/cleanup"},
+		},
+		Spec: apiv1.CompositionSpec{Synthesizer: apiv1.SynthesizerRef{Name: syn.Name}},
+		Status: apiv1.CompositionStatus{
+			InFlightSynthesis: &apiv1.Synthesis{UUID: "test-synthesis"},
+		},
+	}
+	cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(ns, syn, comp).Build()
+	c := &podLifecycleController{config: minimalTestConfig, client: cli, noCacheReader: cli}
+
+	_, err := c.Reconcile(ctx, ctrl.Request{NamespacedName: client.ObjectKeyFromObject(comp)})
+	require.NoError(t, err)
+
+	pods := &corev1.PodList{}
+	require.NoError(t, cli.List(ctx, pods, client.InNamespace(minimalTestConfig.PodNamespace)))
+	assert.Empty(t, pods.Items)
+}
 
 // TestCompositionDeletion proves that a composition's status is eventually updated to reflect its deletion.
 // This is necessary to unblock finalizer removal, since we don't synthesize deleted compositions.

--- a/internal/controllers/synthesis/namespace.go
+++ b/internal/controllers/synthesis/namespace.go
@@ -1,0 +1,21 @@
+package synthesis
+
+import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func compositionNamespaceUnavailable(ctx context.Context, reader client.Reader, name string) (bool, error) {
+	ns := &corev1.Namespace{}
+	err := reader.Get(ctx, client.ObjectKey{Name: name}, ns)
+	if errors.IsNotFound(err) {
+		return true, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	return ns.DeletionTimestamp != nil, nil
+}

--- a/internal/execution/executor.go
+++ b/internal/execution/executor.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Azure/eno/internal/resource"
 	krmv1 "github.com/Azure/eno/pkg/krm/functions/api/v1"
 	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -100,6 +101,10 @@ func (e *Executor) Synthesize(ctx context.Context, env *Env) error {
 	if err == nil {
 		logger.Info("writing resource slices")
 		sliceRefs, err = e.writeSlices(ctx, comp, output)
+		if errors.IsForbidden(err) && errors.HasStatusCause(err, corev1.NamespaceTerminatingCause) {
+			logger.Info("composition namespace is terminating - abandoning synthesis")
+			return nil
+		}
 		if err != nil {
 			logger.Error(err, "failed to write resource slices")
 			return err

--- a/internal/execution/executor_test.go
+++ b/internal/execution/executor_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -18,6 +19,7 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 )
 
 func TestBasics(t *testing.T) {
@@ -106,6 +108,70 @@ func TestBasics(t *testing.T) {
 	// No-op since the synthesis is already complete
 	err = e.Synthesize(ctx, env)
 	require.NoError(t, err)
+}
+
+func TestNamespaceTerminationWhileWritingSlicesIsAbandoned(t *testing.T) {
+	ctx := context.Background()
+	scheme := runtime.NewScheme()
+	require.NoError(t, apiv1.SchemeBuilder.AddToScheme(scheme))
+
+	syn := &apiv1.Synthesizer{ObjectMeta: metav1.ObjectMeta{Name: "test-synth"}}
+	comp := &apiv1.Composition{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-comp", Namespace: "terminating"},
+		Spec:       apiv1.CompositionSpec{Synthesizer: apiv1.SynthesizerRef{Name: syn.Name}},
+		Status:     apiv1.CompositionStatus{InFlightSynthesis: &apiv1.Synthesis{UUID: "test-uuid"}},
+	}
+	resourceSliceCreates := 0
+	cli := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(syn, comp).
+		WithStatusSubresource(&apiv1.ResourceSlice{}, &apiv1.Composition{}).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Create: func(ctx context.Context, writer client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
+				if _, ok := obj.(*apiv1.ResourceSlice); !ok {
+					return writer.Create(ctx, obj, opts...)
+				}
+				resourceSliceCreates++
+				return &errors.StatusError{ErrStatus: metav1.Status{
+					Status:  metav1.StatusFailure,
+					Reason:  metav1.StatusReasonForbidden,
+					Message: "unable to create new content because the namespace is being terminated",
+					Details: &metav1.StatusDetails{Causes: []metav1.StatusCause{{Type: corev1.NamespaceTerminatingCause}}},
+				}}
+			},
+		}).
+		Build()
+
+	e := &Executor{
+		Reader: cli,
+		Writer: cli,
+		Handler: func(context.Context, *apiv1.Synthesizer, *krmv1.ResourceList) (*krmv1.ResourceList, error) {
+			return &krmv1.ResourceList{
+				Items: []*unstructured.Unstructured{{Object: map[string]any{
+					"apiVersion": "v1",
+					"kind":       "ConfigMap",
+					"metadata": map[string]any{
+						"name":      "test-output",
+						"namespace": "default",
+					},
+				}}},
+			}, nil
+		},
+	}
+	err := e.Synthesize(ctx, &Env{
+		CompositionName:      comp.Name,
+		CompositionNamespace: comp.Namespace,
+		SynthesisUUID:        comp.Status.InFlightSynthesis.UUID,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 1, resourceSliceCreates)
+
+	require.NoError(t, cli.Get(ctx, client.ObjectKeyFromObject(comp), comp))
+	assert.NotNil(t, comp.Status.InFlightSynthesis)
+	assert.Nil(t, comp.Status.CurrentSynthesis)
+	slices := &apiv1.ResourceSliceList{}
+	require.NoError(t, cli.List(ctx, slices, client.InNamespace(comp.Namespace)))
+	assert.Empty(t, slices.Items)
 }
 
 func TestWithInputs(t *testing.T) {


### PR DESCRIPTION
Prevents synthesis pods from repeatedly crash-looping when their composition namespace is terminating.

- Skip creating new synthesis pods for terminating or missing namespaces.
- Garbage-collect synthesis pods already running in those namespaces.
- Treat `NamespaceTerminating` errors while writing resource slices as a clean exit.
- Preserve existing retry behavior for transient and unrelated failures.

This reduces unnecessary pod churn and Kubernetes control-plane pressure during namespace deletion.