### PR TITLE
security: bump Go toolchain to 1.25.13

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/Azure/eno
 
 go 1.25.0
 
-toolchain go1.25.12
+toolchain go1.25.13
 
 require (
 	github.com/Azure/go-workflow v0.1.13


### PR DESCRIPTION
## Summary

Bump the root module toolchain from Go 1.25.12 to 1.25.13. Both controller and reconciler Dockerfiles use `GOTOOLCHAIN=auto` with workspace mode disabled, so this updates both published binaries without changing application dependencies or behavior.

This addresses the current Go stdlib CVEs affecting `eno-controller:v0.2.16` and `eno-reconciler:v0.2.16`.

## Verification

- complete `make test` suite passed with envtest and Helm prerequisites
- controller and reconciler linux/amd64 images built successfully
- both shipped binaries report Go 1.25.13
- Trivy v0.72.0-5 isolated-binary scans report zero fixable findings for both images
- old/new command-line help surfaces are identical
- `git diff --check` passed

After merge, publish a new release tag through the existing `Building and Pushing to MCR` workflow, scan both MCR images, then update the aks-rp ENO pin.