### PR TITLE
[eno] Fix readiness handling for deleted tombstone resource

### DIFF
--- a/e2e/tombstone_readiness_test.go
+++ b/e2e/tombstone_readiness_test.go
@@ -1,0 +1,184 @@
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	flow "github.com/Azure/go-workflow"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	apiv1 "github.com/Azure/eno/api/v1"
+	fw "github.com/Azure/eno/e2e/framework"
+)
+
+func TestReadinessEnabledServiceTombstoneCompletes(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	const readinessExpression = "self.spec.type == 'ExternalName' || (self.spec.clusterIP != '' && (self.spec.type != 'LoadBalancer' || size(self.spec.externalIPs) > 0 || size(self.status.loadBalancer.ingress) > 0))"
+
+	cli := fw.NewClient(t)
+	synthName := fw.UniqueName("tombstone-readiness-synth")
+	compName := fw.UniqueName("tombstone-readiness-comp")
+	serviceName := fw.UniqueName("tombstone-readiness-service")
+	compKey := types.NamespacedName{Name: compName, Namespace: "default"}
+
+	service := &corev1.Service{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "Service",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      serviceName,
+			Namespace: "default",
+			Annotations: map[string]string{
+				"eno.azure.io/readiness": readinessExpression,
+			},
+		},
+		Spec: corev1.ServiceSpec{
+			Type:         corev1.ServiceTypeExternalName,
+			ExternalName: "example.com",
+		},
+	}
+	synth := fw.NewMinimalSynthesizer(synthName, fw.WithCommand(fw.ToCommand(service)))
+	comp := fw.NewComposition(compName, "default", fw.WithSynthesizerRefs(apiv1.SynthesizerRef{Name: synthName}))
+
+	var initialSynthesisUUID string
+	var initialSynthesizerGeneration int64
+
+	createSynthesizer := fw.CreateStep(t, "createSynthesizer", cli, synth)
+	createComposition := fw.CreateStep(t, "createComposition", cli, comp)
+
+	waitInitialReady := flow.Func("waitInitialReady", func(ctx context.Context) error {
+		fw.WaitForCompositionReady(t, ctx, cli, compKey, 3*time.Minute)
+		require.NoError(t, cli.Get(ctx, compKey, comp))
+		require.NotNil(t, comp.Status.CurrentSynthesis)
+		initialSynthesisUUID = comp.Status.CurrentSynthesis.UUID
+		initialSynthesizerGeneration = comp.Status.CurrentSynthesis.ObservedSynthesizerGeneration
+		return nil
+	})
+
+	verifyInitialService := flow.Func("verifyInitialService", func(ctx context.Context) error {
+		actual := &corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{Name: serviceName, Namespace: "default"},
+		}
+		fw.WaitForResourceExists(t, ctx, cli, actual, 30*time.Second)
+
+		manifest, state, err := findServiceInSynthesis(ctx, cli, comp, comp.Status.CurrentSynthesis, serviceName)
+		require.NoError(t, err)
+		require.False(t, manifest.Deleted)
+		annotations := serviceAnnotations(t, manifest)
+		require.Equal(t, readinessExpression, annotations["eno.azure.io/readiness"])
+		require.NotContains(t, annotations, "eno.azure.io/readiness-group")
+		require.NotNil(t, state)
+		require.True(t, state.Reconciled)
+		require.False(t, state.Deleted)
+		require.NotNil(t, state.Ready)
+		return nil
+	})
+
+	removeServiceFromOutput := flow.Func("removeServiceFromOutput", func(ctx context.Context) error {
+		require.NoError(t, cli.Get(ctx, types.NamespacedName{Name: synthName}, synth))
+		synth.Spec.Command = fw.ToCommand()
+		return cli.Update(ctx, synth)
+	})
+
+	waitForTombstoneSynthesis := flow.Func("waitForTombstoneSynthesis", func(ctx context.Context) error {
+		fw.WaitForCompositionResynthesized(t, ctx, cli, compKey, initialSynthesizerGeneration, 3*time.Minute)
+		require.NoError(t, cli.Get(ctx, compKey, comp))
+		require.NotNil(t, comp.Status.PreviousSynthesis)
+		require.NotNil(t, comp.Status.CurrentSynthesis)
+		require.Equal(t, initialSynthesisUUID, comp.Status.PreviousSynthesis.UUID)
+		require.NotEqual(t, initialSynthesisUUID, comp.Status.CurrentSynthesis.UUID)
+		return nil
+	})
+
+	verifyServiceDeleted := flow.Func("verifyServiceDeleted", func(ctx context.Context) error {
+		actual := &corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{Name: serviceName, Namespace: "default"},
+		}
+		fw.WaitForResourceDeleted(t, ctx, cli, actual, 60*time.Second)
+		return nil
+	})
+
+	verifyTombstoneStatus := flow.Func("verifyTombstoneStatus", func(ctx context.Context) error {
+		require.NoError(t, cli.Get(ctx, compKey, comp))
+		require.NotNil(t, comp.Status.CurrentSynthesis)
+
+		manifest, state, err := findServiceInSynthesis(ctx, cli, comp, comp.Status.CurrentSynthesis, serviceName)
+		require.NoError(t, err)
+		require.True(t, manifest.Deleted)
+		annotations := serviceAnnotations(t, manifest)
+		require.Equal(t, readinessExpression, annotations["eno.azure.io/readiness"])
+		require.NotContains(t, annotations, "eno.azure.io/readiness-group")
+		require.NotNil(t, state)
+		require.True(t, state.Reconciled)
+		require.True(t, state.Deleted)
+		require.NotNil(t, state.Ready)
+		return nil
+	})
+
+	cleanup := fw.CleanupStep(t, "cleanup", cli, comp, synth)
+
+	w := new(flow.Workflow)
+	w.Add(
+		flow.Step(createComposition).DependsOn(createSynthesizer),
+		flow.Step(waitInitialReady).DependsOn(createComposition),
+		flow.Step(verifyInitialService).DependsOn(waitInitialReady),
+		flow.Step(removeServiceFromOutput).DependsOn(verifyInitialService),
+		flow.Step(waitForTombstoneSynthesis).DependsOn(removeServiceFromOutput),
+		flow.Step(verifyServiceDeleted).DependsOn(waitForTombstoneSynthesis),
+		flow.Step(verifyTombstoneStatus).DependsOn(waitForTombstoneSynthesis),
+		flow.Step(cleanup).DependsOn(verifyServiceDeleted, verifyTombstoneStatus),
+	)
+
+	require.NoError(t, w.Do(ctx))
+}
+
+func findServiceInSynthesis(
+	ctx context.Context,
+	cli client.Client,
+	comp *apiv1.Composition,
+	synthesis *apiv1.Synthesis,
+	serviceName string,
+) (*apiv1.Manifest, *apiv1.ResourceState, error) {
+	for _, ref := range synthesis.ResourceSlices {
+		slice := &apiv1.ResourceSlice{}
+		if err := cli.Get(ctx, types.NamespacedName{Name: ref.Name, Namespace: comp.Namespace}, slice); err != nil {
+			return nil, nil, fmt.Errorf("getting resource slice %q: %w", ref.Name, err)
+		}
+
+		for i := range slice.Spec.Resources {
+			manifest := &slice.Spec.Resources[i]
+			obj := &unstructured.Unstructured{}
+			if err := obj.UnmarshalJSON([]byte(manifest.Manifest)); err != nil {
+				return nil, nil, fmt.Errorf("decoding manifest %d in resource slice %q: %w", i, slice.Name, err)
+			}
+			if obj.GetKind() != "Service" || obj.GetName() != serviceName {
+				continue
+			}
+
+			if len(slice.Status.Resources) <= i {
+				return manifest, nil, nil
+			}
+			return manifest, &slice.Status.Resources[i], nil
+		}
+	}
+
+	return nil, nil, fmt.Errorf("service %q was not found in synthesis %q", serviceName, synthesis.UUID)
+}
+
+func serviceAnnotations(t *testing.T, manifest *apiv1.Manifest) map[string]string {
+	t.Helper()
+	obj := &unstructured.Unstructured{}
+	require.NoError(t, obj.UnmarshalJSON([]byte(manifest.Manifest)))
+	return obj.GetAnnotations()
+}

--- a/go.work.sum
+++ b/go.work.sum
@@ -83,6 +83,7 @@ cloud.google.com/go/assuredworkloads v1.11.5 h1:gCrN3IyvqY3cP0wh2h43d99CgH3G+WYs
 cloud.google.com/go/assuredworkloads v1.11.5/go.mod h1:FKJ3g3ZvkL2D7qtqIGnDufFkHxwIpNM9vtmhvt+6wqk=
 cloud.google.com/go/assuredworkloads v1.12.0/go.mod h1:jX84R+0iANggmSbzvVgrGWaqdhRsQihAv4fF7IQ4r7Q=
 cloud.google.com/go/auth v0.9.3/go.mod h1:7z6VY+7h3KUdRov5F1i8NDP5ZzWKYmEPO842BgCsmTk=
+cloud.google.com/go/auth v0.18.2/go.mod h1:xD+oY7gcahcu7G2SG2DsBerfFxgPAJz17zz2joOFF3M=
 cloud.google.com/go/auth/oauth2adapt v0.2.4/go.mod h1:jC/jOpwFP6JBxhB3P5Rr0a9HLMC/Pe3eaL4NmdvqPtc=
 cloud.google.com/go/automl v1.13.4/go.mod h1:ULqwX/OLZ4hBVfKQaMtxMSTlPx0GqGbWN8uA/1EqCP8=
 cloud.google.com/go/automl v1.13.5 h1:ijiJy9sYWh75WrqImXsfWc1e3HR3iO+ef9fvW03Ig/4=
@@ -586,6 +587,7 @@ github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.26.0
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.26.0/go.mod h1:2bIszWvQRlJVmJLiuLhukLImRjKPcYdzzsx6darK02A=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.30.0/go.mod h1:P4WPRUkOhJC13W//jWpyfJNDAIpvRbAUIYLX/4jtlE0=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.32.0/go.mod h1:RD2SsorTmYhF6HkTmDw7KmPYQk8OBYwTkuasChwv7R4=
+github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.33.0/go.mod h1:pJTkW8hEUIIi3Pf65lPZOnn4Y81yCllX6IWk2jNXdkM=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.48.1/go.mod h1:jyqM3eLpJ3IbIFDTKVz2rF9T/xWGW0rIriGwnz8l9Tk=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.48.1/go.mod h1:viRWSEhtMZqz1rhwmOVKkWl6SwmVowfL9O2YR5gI2PE=
 github.com/Masterminds/semver/v3 v3.1.1/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=
@@ -1356,6 +1358,7 @@ github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm4
 github.com/google/s2a-go v0.1.7 h1:60BLSyTrOV4/haCDW4zb1guZItoSq8foHCXrAnjBo/o=
 github.com/google/s2a-go v0.1.7/go.mod h1:50CgR4k1jNlWBu4UfS4AcfhVe1r6pdZPygJ3R8F0Qdw=
 github.com/google/s2a-go v0.1.8/go.mod h1:6iNWHTpQ+nfNRN5E00MSdfDwVesa8hhS32PhPO8deJA=
+github.com/google/s2a-go v0.1.9/go.mod h1:YA0Ei2ZQL3acow2O62kdp9UlnvMmU7kA6Eutn0dXayM=
 github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.2.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
@@ -1366,12 +1369,14 @@ github.com/googleapis/enterprise-certificate-proxy v0.3.2 h1:Vie5ybvEvT75RniqhfF
 github.com/googleapis/enterprise-certificate-proxy v0.3.2/go.mod h1:VLSiSSBs/ksPL8kq3OBOQ6WRI2QnaFynd1DCjZ62+V0=
 github.com/googleapis/enterprise-certificate-proxy v0.3.3/go.mod h1:YKe7cfqYXjKGpGvmSg28/fFvhNzinZQm8DGnaburhGA=
 github.com/googleapis/enterprise-certificate-proxy v0.3.4/go.mod h1:YKe7cfqYXjKGpGvmSg28/fFvhNzinZQm8DGnaburhGA=
+github.com/googleapis/enterprise-certificate-proxy v0.3.11/go.mod h1:RFV7MUdlb7AgEq2v7FmMCfeSMCllAzWxFgRdusoGks8=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
 github.com/googleapis/gax-go/v2 v2.12.1/go.mod h1:61M8vcyyXR2kqKFxKrfA22jaA8JGF7Dc8App1U3H6jc=
 github.com/googleapis/gax-go/v2 v2.12.2 h1:mhN09QQW1jEWeMF74zGR81R30z4VJzjZsfkUhuHF+DA=
 github.com/googleapis/gax-go/v2 v2.12.2/go.mod h1:61M8vcyyXR2kqKFxKrfA22jaA8JGF7Dc8App1U3H6jc=
 github.com/googleapis/gax-go/v2 v2.13.0/go.mod h1:Z/fvTZXF8/uw7Xu5GuslPw+bplx6SS338j1Is2S+B7A=
+github.com/googleapis/gax-go/v2 v2.17.0/go.mod h1:mzaqghpQp4JDh3HvADwrat+6M3MOIDp5YKHhb9PAgDY=
 github.com/googleapis/gnostic v0.4.1/go.mod h1:LRhVm6pbyptWbWbuZ38d1eyptfvIytN3ir6b65WBswg=
 github.com/googleapis/gnostic v0.5.1/go.mod h1:6U4PtQXGIEt/Z3h5MAT7FNofLnw9vXk2cUuW7uA/OeU=
 github.com/googleapis/gnostic v0.5.5 h1:9fHAtK0uDfpveeqqo1hkEZJcFvYXAiCN3UutL8F9xHw=
@@ -1928,6 +1933,7 @@ github.com/spf13/viper v1.7.0/go.mod h1:8WkrPz2fc9jxqZNCJI/76HCieCp4Q8HaLFoCha5q
 github.com/spiffe/go-spiffe/v2 v2.5.0 h1:N2I01KCUkv1FAjZXJMwh95KK1ZIQLYbPfhaxw8WS0hE=
 github.com/spiffe/go-spiffe/v2 v2.5.0/go.mod h1:P+NxobPc6wXhVtINNtFjNWGBTreew1GBUCwT2wPmb7g=
 github.com/spiffe/go-spiffe/v2 v2.6.0/go.mod h1:gm2SeUoMZEtpnzPNs2Csc0D/gX33k1xIx7lEzqblHEs=
+github.com/spiffe/go-spiffe/v2 v2.7.0/go.mod h1:47Q0Q9/AqGha8QLHp+kxpH4Wca7X7EnOtlIJy3mxZ3U=
 github.com/stefanberger/go-pkcs11uri v0.0.0-20201008174630-78d3cae3a980/go.mod h1:AO3tvPzVZ/ayst6UlUKUv6rcPQInYe3IknH3jYhAKu8=
 github.com/stefanberger/go-pkcs11uri v0.0.0-20230803200340-78284954bff6 h1:pnnLyeX7o/5aX8qUQ69P/mLojDqwda8hFOCBTmP/6hw=
 github.com/stefanberger/go-pkcs11uri v0.0.0-20230803200340-78284954bff6/go.mod h1:39R/xuhNgVhi+K0/zst4TLrJrVmbm6LVgl4A0+ZFS5M=
@@ -2117,6 +2123,7 @@ go.opentelemetry.io/contrib/detectors/gcp v1.34.0 h1:JRxssobiPg23otYU5SbWtQC//sn
 go.opentelemetry.io/contrib/detectors/gcp v1.34.0/go.mod h1:cV4BMFcscUR/ckqLkbfQmF0PRsq8w/lMGzdbCSveBHo=
 go.opentelemetry.io/contrib/detectors/gcp v1.39.0/go.mod h1:t/OGqzHBa5v6RHZwrDBJ2OirWc+4q/w2fTbLZwAKjTk=
 go.opentelemetry.io/contrib/detectors/gcp v1.43.0/go.mod h1:RyaZMFY7yi1kAs45S6mbFGz8O8rqB0dTY14uzvG4LCs=
+go.opentelemetry.io/contrib/detectors/gcp v1.44.0/go.mod h1:tNAsgd8avTGke1+MndXlU5Cru4PQ9Ai/cCNWQv/ZJ/s=
 go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.20.0/go.mod h1:oVGt1LRbBOBq1A5BQLlUg9UaU/54aiHw8cgjV3aWZ/E=
 go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.28.0/go.mod h1:vEhqr0m4eTc+DWxfsXoXue2GBgV2uUwVznkGIHW/e5w=
 go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.45.0/go.mod h1:vsh3ySueQCiKPxFLvjWC4Z135gIa34TQ/NSqkDTZYUM=

--- a/internal/controllers/reconciliation/controller.go
+++ b/internal/controllers/reconciliation/controller.go
@@ -192,7 +192,7 @@ func (c *Controller) Reconcile(ctx context.Context, req resource.Request) (ctrl.
 	deleted := markResourceAsDeleted(current, snap, failingOpen)
 
 	// For tombstones, confirmed deletion is the terminal readiness state. Explicit readiness checks cannot be evaluated after the target object has disappeared
-	if snap.Deleted() && deleted && ready == nil {
+	if snap != nil && snap.Deleted() && deleted && ready == nil {
 		now := metav1.Now()
 		ready = &now
 		logger.Info("resource deletion is complete", "ready", ready)

--- a/internal/controllers/reconciliation/controller.go
+++ b/internal/controllers/reconciliation/controller.go
@@ -191,6 +191,13 @@ func (c *Controller) Reconcile(ctx context.Context, req resource.Request) (ctrl.
 
 	deleted := markResourceAsDeleted(current, snap, failingOpen)
 
+	// For tombstones, confirmed deletion is the terminal readiness state. Explicit readiness checks cannot be evaluated after the target object has disappeared
+	if snap.Deleted() && deleted && ready == nil {
+		now := metav1.Now()
+		ready = &now
+		logger.Info("resource deletion is complete", "ready", ready)
+	}
+
 	c.writeBuffer.PatchStatusAsync(ctx, &resource.ManifestRef, patchResourceState(deleted, ready))
 	return c.requeue(logger, snap, ready)
 }
@@ -213,31 +220,39 @@ func (c *Controller) reconcileResource(ctx context.Context, comp *apiv1.Composit
 		return nil, nil, nil, false, err
 	}
 
-	// Evaluate resource readiness
-	// - Readiness checks are skipped when this version of the resource's desired state has already become ready
-	// - Readiness checks are skipped when the resource hasn't changed since the last check
-	// - Readiness defaults to true if no checks are given
-	logger.Info("evaluating resource readiness")
-	status := resource.State()
-	if status == nil || status.Ready == nil {
-		readiness, ok := resource.ReadinessChecks.EvalOptionally(ctx, &apiv1.Composition{}, current)
-		if ok {
-			ready = &readiness.ReadyTime
-			resource.ResetNotReadyReason()
-			logger.Info("resource is ready", "readyTime", ready)
-		} else {
-			logResourceNotReady(ctx, logger, resource, current)
-		}
-	} else {
-		ready = status.Ready
-	}
-
 	logger.Info("creating resource snapshot")
 	snap, err = resource.Snapshot(ctx, comp, current)
 	if err != nil {
 		logger.Error(err, "failed to create resource snapshot")
 		return nil, nil, nil, false, fmt.Errorf("failed to create resource snapshot: %w", err)
 	}
+
+	status := resource.State()
+	if snap.Deleted() {
+		// The desired state is deletion. Normal object readiness expressions should no longer apply
+		if status != nil {
+			ready = status.Ready
+		}
+	} else {
+		// Evaluate resource readiness
+		// - Readiness checks are skipped when this version of the resource's desired state has already become ready
+		// - Readiness checks are skipped when the resource hasn't changed since the last check
+		// - Readiness defaults to true if no checks are given
+		logger.Info("evaluating resource readiness")
+		if status == nil || status.Ready == nil {
+			readiness, ok := resource.ReadinessChecks.EvalOptionally(ctx, &apiv1.Composition{}, current)
+			if ok {
+				ready = &readiness.ReadyTime
+				resource.ResetNotReadyReason()
+				logger.Info("resource is ready", "readyTime", ready)
+			} else {
+				logResourceNotReady(ctx, logger, resource, current)
+			}
+		} else {
+			ready = status.Ready
+		}
+	}
+
 	if status := snap.OverrideStatus(); len(status) > 0 {
 		logger = logger.WithValues("overrideStatus", status)
 		ctx = logr.NewContext(ctx, logger)
@@ -530,7 +545,7 @@ func (c *Controller) getCurrent(ctx context.Context, resource *resource.Resource
 }
 
 func (c *Controller) requeue(logger logr.Logger, resource *resource.Snapshot, ready *metav1.Time) (ctrl.Result, error) {
-	pendingForegroundDeletion := (resource != nil && resource.Deleted() && !resource.Disable && resource.ForegroundDeletion)
+	pendingForegroundDeletion := resource != nil && resource.Deleted() && !resource.Disable && resource.ForegroundDeletion
 
 	if ready == nil || pendingForegroundDeletion {
 		return ctrl.Result{RequeueAfter: wait.Jitter(c.readinessPollInterval, 0.1)}, nil

--- a/internal/controllers/reconciliation/controller_test.go
+++ b/internal/controllers/reconciliation/controller_test.go
@@ -1,6 +1,7 @@
 package reconciliation
 
 import (
+	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -22,6 +23,10 @@ import (
 )
 
 func TestRequeue(t *testing.T) {
+	tombstone := newTombstoneSnapshot(t, false)
+	foregroundTombstone := newTombstoneSnapshot(t, true)
+	now := metav1.Now()
+
 	tests := []struct {
 		name             string
 		resource         *resource.Snapshot
@@ -40,13 +45,25 @@ func TestRequeue(t *testing.T) {
 			expectedResult: 10 * time.Second,
 		},
 		{
-			name: "resource is deleted, no requeue",
-			resource: &resource.Snapshot{
-				ReconcileInterval: nil,
-			},
-			ready:          &metav1.Time{},
+			name:           "completed tombstone does not requeue",
+			resource:       tombstone,
+			ready:          &now,
 			minReconcile:   10 * time.Second,
 			expectedResult: 0,
+		},
+		{
+			name:           "incomplete tombstone requeues",
+			resource:       tombstone,
+			ready:          nil,
+			minReconcile:   10 * time.Second,
+			expectedResult: 10 * time.Second,
+		},
+		{
+			name:           "foreground tombstone requeues while deletion is pending",
+			resource:       foregroundTombstone,
+			ready:          &now,
+			minReconcile:   10 * time.Second,
+			expectedResult: 10 * time.Second,
 		},
 		{
 			name: "resource has reconcile interval less than minReconcileInterval",
@@ -129,6 +146,31 @@ func TestRequeue(t *testing.T) {
 			assert.InDelta(t, tt.expectedResult, result.RequeueAfter, float64(2*time.Second))
 		})
 	}
+}
+
+func newTombstoneSnapshot(t *testing.T, foreground bool) *resource.Snapshot {
+	t.Helper()
+
+	deletionStrategy := ""
+	if foreground {
+		deletionStrategy = `"annotations":{"eno.azure.io/deletion-strategy":"foreground"},`
+	}
+	slice := &apiv1.ResourceSlice{
+		Spec: apiv1.ResourceSliceSpec{
+			Resources: []apiv1.Manifest{{
+				Deleted: true,
+				Manifest: fmt.Sprintf(
+					`{"apiVersion":"v1","kind":"ConfigMap","metadata":{%s"name":"test","namespace":"default"}}`,
+					deletionStrategy,
+				),
+			}},
+		},
+	}
+	res, err := resource.FromSlice(context.Background(), &apiv1.Composition{}, slice, 0)
+	require.NoError(t, err)
+	snapshot, err := res.Snapshot(context.Background(), &apiv1.Composition{}, nil)
+	require.NoError(t, err)
+	return snapshot
 }
 
 func TestBuildNonStrategicPatch_NilPrevious(t *testing.T) {

--- a/internal/controllers/reconciliation/ordering_test.go
+++ b/internal/controllers/reconciliation/ordering_test.go
@@ -59,8 +59,8 @@ func TestReadinessGroups(t *testing.T) {
 						"name":      "test-obj-1",
 						"namespace": "default",
 						// Explicit readiness-group: ConfigMap now defaults into the reserved
-					// [-100,-81] range; this test wants the legacy group-0 behavior.
-					"annotations": map[string]string{
+						// [-100,-81] range; this test wants the legacy group-0 behavior.
+						"annotations": map[string]string{
 							"eno.azure.io/readiness-group": "0",
 						},
 					},
@@ -161,6 +161,127 @@ func TestReadinessGroups(t *testing.T) {
 		err := upstream.Get(ctx, client.ObjectKeyFromObject(comp), comp)
 		return errors.IsNotFound(err)
 	})
+}
+
+func TestTombstoneBlocksLaterReadinessGroupUntilDeletionCompletes(t *testing.T) {
+	const readinessExpression = "self.spec.type == 'ExternalName'"
+
+	ctx := testutil.NewContext(t)
+	mgr := testutil.NewManager(t)
+	upstream := mgr.GetClient()
+	downstream := mgr.DownstreamClient
+
+	registerControllers(t, mgr)
+	testutil.WithFakeExecutor(t, mgr, func(ctx context.Context, synth *apiv1.Synthesizer, input *krmv1.ResourceList) (*krmv1.ResourceList, error) {
+		output := &krmv1.ResourceList{}
+		if synth.Spec.Image == "delete" {
+			output.Items = []*unstructured.Unstructured{{
+				Object: map[string]any{
+					"apiVersion": "v1",
+					"kind":       "ConfigMap",
+					"metadata": map[string]any{
+						"name":      "after-service-deletion",
+						"namespace": "default",
+						"annotations": map[string]any{
+							"eno.azure.io/readiness-group": "0",
+						},
+					},
+				},
+			}}
+			return output, nil
+		}
+
+		output.Items = []*unstructured.Unstructured{{
+			Object: map[string]any{
+				"apiVersion": "v1",
+				"kind":       "Service",
+				"metadata": map[string]any{
+					"name":       "test-service",
+					"namespace":  "default",
+					"finalizers": []any{"eno.azure.io/test"},
+					"annotations": map[string]any{
+						"eno.azure.io/readiness":         readinessExpression,
+						"eno.azure.io/readiness-group":   "-1",
+						"eno.azure.io/deletion-strategy": "foreground",
+					},
+				},
+				"spec": map[string]any{
+					"type":         "ExternalName",
+					"externalName": "example.com",
+				},
+			},
+		}}
+		return output, nil
+	})
+
+	setupTestSubjectForOptions(t, mgr, Options{
+		Manager:                mgr.Manager,
+		Timeout:                time.Minute,
+		ReadinessPollInterval:  10 * time.Millisecond,
+		DisableServerSideApply: mgr.NoSsaSupport,
+	})
+	mgr.Start(t)
+	synth, comp := writeGenericComposition(t, upstream)
+	waitForReadiness(t, mgr, comp, synth, nil)
+	firstSynthesisUUID := comp.Status.CurrentSynthesis.UUID
+
+	setImage(t, upstream, synth, "delete")
+
+	service := &corev1.Service{}
+	service.Name = "test-service"
+	service.Namespace = "default"
+	testutil.Eventually(t, func() bool {
+		err := downstream.Get(ctx, client.ObjectKeyFromObject(service), service)
+		return err == nil && service.DeletionTimestamp != nil
+	})
+
+	testutil.Eventually(t, func() bool {
+		slices, err := mgr.GetCurrentResourceSlices(ctx)
+		if err != nil {
+			t.Log(err)
+			return false
+		}
+		for _, slice := range slices {
+			for i, manifest := range slice.Spec.Resources {
+				if !manifest.Deleted || len(slice.Status.Resources) <= i {
+					continue
+				}
+				obj := &unstructured.Unstructured{}
+				if err := obj.UnmarshalJSON([]byte(manifest.Manifest)); err != nil {
+					return false
+				}
+				if obj.GetKind() == "Service" && obj.GetName() == "test-service" {
+					state := slice.Status.Resources[i]
+					return state.Reconciled && !state.Deleted && state.Ready == nil
+				}
+			}
+		}
+		return false
+	})
+
+	blocked := &corev1.ConfigMap{}
+	blocked.Name = "after-service-deletion"
+	blocked.Namespace = "default"
+	require.True(t, errors.IsNotFound(downstream.Get(ctx, client.ObjectKeyFromObject(blocked), blocked)))
+
+	require.NoError(t, retry.RetryOnConflict(testutil.Backoff, func() error {
+		if err := downstream.Get(ctx, client.ObjectKeyFromObject(service), service); err != nil {
+			return err
+		}
+		service.Finalizers = nil
+		return downstream.Update(ctx, service)
+	}))
+
+	testutil.Eventually(t, func() bool {
+		service := &corev1.Service{}
+		service.Name = "test-service"
+		service.Namespace = "default"
+		return errors.IsNotFound(downstream.Get(ctx, client.ObjectKeyFromObject(service), service))
+	})
+	testutil.Eventually(t, func() bool {
+		return downstream.Get(ctx, client.ObjectKeyFromObject(blocked), blocked) == nil
+	})
+	waitForReadiness(t, mgr, comp, synth, &firstSynthesisUUID)
 }
 
 func TestCRDOrdering(t *testing.T) {

--- a/internal/controllers/reconciliation/status_test.go
+++ b/internal/controllers/reconciliation/status_test.go
@@ -3,6 +3,7 @@ package reconciliation
 import (
 	"context"
 	"testing"
+	"time"
 
 	apiv1 "github.com/Azure/eno/api/v1"
 	testv1 "github.com/Azure/eno/internal/controllers/reconciliation/fixtures/v1"
@@ -11,6 +12,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -105,6 +107,98 @@ func TestResourceReadiness(t *testing.T) {
 		err = upstream.Get(ctx, client.ObjectKeyFromObject(comp), comp)
 		return err == nil && comp.Status.CurrentSynthesis != nil && comp.Status.CurrentSynthesis.Ready == nil
 	})
+}
+
+func TestTombstonedServiceWithReadinessBecomesReadyAfterDeletion(t *testing.T) {
+	const readinessExpression = "self.spec.type == 'ExternalName' || (self.spec.clusterIP != '' && (self.spec.type != 'LoadBalancer' || size(self.spec.externalIPs) > 0 || size(self.status.loadBalancer.ingress) > 0))"
+
+	ctx := testutil.NewContext(t)
+	mgr := testutil.NewManager(t)
+	upstream := mgr.GetClient()
+	downstream := mgr.DownstreamClient
+
+	registerControllers(t, mgr)
+	testutil.WithFakeExecutor(t, mgr, func(ctx context.Context, synth *apiv1.Synthesizer, input *krmv1.ResourceList) (*krmv1.ResourceList, error) {
+		output := &krmv1.ResourceList{}
+		if synth.Spec.Image == "delete" {
+			return output, nil
+		}
+
+		output.Items = []*unstructured.Unstructured{{
+			Object: map[string]any{
+				"apiVersion": "v1",
+				"kind":       "Service",
+				"metadata": map[string]any{
+					"name":      "test-service",
+					"namespace": "default",
+					"annotations": map[string]any{
+						"eno.azure.io/readiness": readinessExpression,
+					},
+				},
+				"spec": map[string]any{
+					"type":         "ExternalName",
+					"externalName": "example.com",
+				},
+			},
+		}}
+		return output, nil
+	})
+
+	setupTestSubjectForOptions(t, mgr, Options{
+		Manager:                mgr.Manager,
+		Timeout:                time.Minute,
+		ReadinessPollInterval:  10 * time.Millisecond,
+		DisableServerSideApply: mgr.NoSsaSupport,
+	})
+	mgr.Start(t)
+	synth, comp := writeGenericComposition(t, upstream)
+	waitForReadiness(t, mgr, comp, synth, nil)
+	firstSynthesisUUID := comp.Status.CurrentSynthesis.UUID
+
+	service := &corev1.Service{}
+	service.Name = "test-service"
+	service.Namespace = "default"
+	require.NoError(t, downstream.Get(ctx, client.ObjectKeyFromObject(service), service))
+
+	setImage(t, upstream, synth, "delete")
+
+	testutil.Eventually(t, func() bool {
+		service := &corev1.Service{}
+		service.Name = "test-service"
+		service.Namespace = "default"
+		return apierrors.IsNotFound(downstream.Get(ctx, client.ObjectKeyFromObject(service), service))
+	})
+
+	testutil.Eventually(t, func() bool {
+		slices, err := mgr.GetCurrentResourceSlices(ctx)
+		if err != nil {
+			t.Log(err)
+			return false
+		}
+		for _, slice := range slices {
+			for i, manifest := range slice.Spec.Resources {
+				obj := &unstructured.Unstructured{}
+				if err := obj.UnmarshalJSON([]byte(manifest.Manifest)); err != nil {
+					t.Log(err)
+					return false
+				}
+				if obj.GetKind() != "Service" || obj.GetName() != "test-service" {
+					continue
+				}
+				if !manifest.Deleted || obj.GetAnnotations()["eno.azure.io/readiness"] != readinessExpression {
+					return false
+				}
+				if len(slice.Status.Resources) <= i {
+					return false
+				}
+				state := slice.Status.Resources[i]
+				return state.Reconciled && state.Deleted && state.Ready != nil
+			}
+		}
+		return false
+	})
+
+	waitForReadiness(t, mgr, comp, synth, &firstSynthesisUUID)
 }
 
 // TestReconcileStatus proves that reconciliation and deletion status are written to resource slices as expected.

--- a/internal/controllers/resourceslice/slice_test.go
+++ b/internal/controllers/resourceslice/slice_test.go
@@ -18,7 +18,7 @@ import (
 	apiv1 "github.com/Azure/eno/api/v1"
 )
 
-func testAggregation(t *testing.T, ready bool, reconciled bool) {
+func testAggregation(t *testing.T, ready bool, reconciled bool, deleted bool) {
 	ctx := testutil.NewContext(t)
 	cli := testutil.NewClient(t)
 
@@ -32,7 +32,7 @@ func testAggregation(t *testing.T, ready bool, reconciled bool) {
 	slice.Name = "test-slice-1"
 	slice.Namespace = "default"
 	slice.Spec.Resources = []apiv1.Manifest{{Manifest: "{}"}}
-	slice.Status.Resources = []apiv1.ResourceState{{Ready: readyTime, Reconciled: reconciled}}
+	slice.Status.Resources = []apiv1.ResourceState{{Ready: readyTime, Reconciled: reconciled, Deleted: deleted}}
 	require.NoError(t, cli.Create(ctx, slice))
 	require.NoError(t, cli.Status().Update(ctx, slice))
 
@@ -58,19 +58,27 @@ func testAggregation(t *testing.T, ready bool, reconciled bool) {
 }
 
 func TestAggregationHappyPath(t *testing.T) {
-	testAggregation(t, true, true)
+	testAggregation(t, true, true, false)
 }
 
 func TestAggregationNegative(t *testing.T) {
-	testAggregation(t, false, false)
+	testAggregation(t, false, false, false)
 }
 
 func TestAggregationReadyNotReconciled(t *testing.T) {
-	testAggregation(t, true, false)
+	testAggregation(t, true, false, false)
 }
 
 func TestAggregationReconciledNotReady(t *testing.T) {
-	testAggregation(t, false, true)
+	testAggregation(t, false, true, false)
+}
+
+func TestAggregationDeletedReady(t *testing.T) {
+	testAggregation(t, true, true, true)
+}
+
+func TestAggregationDeletedNotReady(t *testing.T) {
+	testAggregation(t, false, true, true)
 }
 
 func TestStaleStatus(t *testing.T) {


### PR DESCRIPTION
ENO continued evaluating normal readiness expressions after tombstoned resources had been successfully deleted. Because readiness expressions cannot pass when the target object no longer exists, the ResourceState remained `Deleted=true` and `Reconciled=true` but `Ready=nil`, leaving the Composition stuck in `NotReady`.

This change identifies deletion snapshots before evaluating normal object readiness. Once deletion is confirmed, ENO treats deletion completion as the tombstone's terminal readiness state. This preserves existing readiness and deletion ordering while allowing the Composition to become ready.

Added unit, integration, ordering, ResourceSlice aggregation, and live-cluster E2E coverage for removing a readiness-enabled Service in a subsequent synthesis